### PR TITLE
Add SPAN/mirror port mode for direction-aware RX/TX

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ chmod 0600 /opt/bandwidth-monitor/.env
 | `UNIFI_SITE` | `default` | UniFi site name |
 | `VPN_STATUS_FILES` | *(none)* | Comma-separated `iface=path` pairs for VPN routing detection (e.g. `wg0=/run/wg0-active`) |
 | `LOCAL_NETS` | *(auto-detect)* | Comma-separated CIDRs for RX/TX direction detection (e.g. `192.0.2.0/24,2001:db8::/48`). Auto-discovered from local interfaces if not set. |
+| `SPAN_DEVICE` | *(disabled)* | SPAN/mirror port interface for direction-aware RX/TX (requires `LOCAL_NETS`; e.g. `eth1`) |
 
 The DNS tab supports either **AdGuard Home** or **NextDNS** (mutually exclusive; AdGuard takes priority if both are configured). The WiFi tab is only shown when UniFi is configured.
 
@@ -114,6 +115,22 @@ For SPAN/mirror port setups or if auto-discovery doesn't cover all your addresse
 ```bash
 LOCAL_NETS=192.0.2.0/24,2001:db8::/48
 ```
+
+### SPAN / Mirror Port Mode
+
+On a SPAN or mirror port, the kernel sees all mirrored traffic as RX in `/proc/net/dev`, making the normal RX/TX split meaningless. Setting `SPAN_DEVICE` activates a pcap-based overlay that inspects IP headers and classifies direction using `LOCAL_NETS`:
+
+- **src in LOCAL_NETS → remote** = upload (TX)
+- **remote → dst in LOCAL_NETS** = download (RX)
+- **both local** = counted as both (intra-LAN)
+
+```bash
+# In your .env
+SPAN_DEVICE=eth1
+LOCAL_NETS=192.0.2.0/24,2001:db8::/48
+```
+
+All other interfaces keep their normal `/proc/net/dev` stats, VPN routing detection, interface grouping, etc. Only the SPAN device gets its RX/TX overridden. Requires root or `CAP_NET_RAW`.
 
 ### VPN Routing Detection (OpenWrt)
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -52,6 +52,10 @@ type Collector struct {
 	history        map[string][]HistoryPoint
 	ifaceTypeCache map[string]string
 	vpnStatusFiles map[string]string // iface name → sentinel file path
+	span           *spanOverlay      // nil when SPAN mode is disabled
+	spanPrevRx     uint64
+	spanPrevTx     uint64
+	spanHasPrev    bool
 	stopCh         chan struct{}
 }
 
@@ -81,7 +85,17 @@ func New(vpnStatusFiles map[string]string) *Collector {
 	}
 }
 
+// EnableSPAN activates pcap-based direction detection on a SPAN/mirror port.
+// When enabled, the RX/TX rates and cumulative bytes for the named device are
+// derived from packet inspection against localNets instead of /proc/net/dev.
+func (c *Collector) EnableSPAN(device string, promiscuous bool, localNets []*net.IPNet) {
+	c.span = newSpanOverlay(device, promiscuous, localNets)
+}
+
 func (c *Collector) Run() {
+	if c.span != nil {
+		go c.span.run()
+	}
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 	c.poll()
@@ -96,6 +110,9 @@ func (c *Collector) Run() {
 }
 
 func (c *Collector) Stop() {
+	if c.span != nil {
+		c.span.stop()
+	}
 	close(c.stopCh)
 }
 
@@ -217,6 +234,26 @@ func (c *Collector) poll() {
 				iface.RxRate = float64(cur.rxBytes-prev.rxBytes) / dt
 				iface.TxRate = float64(cur.txBytes-prev.txBytes) / dt
 			}
+		}
+
+		// SPAN overlay: override RX/TX with direction-aware pcap data
+		if c.span != nil && name == c.span.device {
+			rxB, txB, rxP, txP := c.span.snapshot()
+			iface.RxBytes = rxB
+			iface.TxBytes = txB
+			iface.RxPackets = rxP
+			iface.TxPackets = txP
+			iface.IfaceType = "span"
+			if c.spanHasPrev {
+				dt := now.Sub(prev.ts).Seconds()
+				if dt > 0 {
+					iface.RxRate = float64(rxB-c.spanPrevRx) / dt
+					iface.TxRate = float64(txB-c.spanPrevTx) / dt
+				}
+			}
+			c.spanPrevRx = rxB
+			c.spanPrevTx = txB
+			c.spanHasPrev = true
 		}
 
 		c.current[name] = iface

--- a/collector/span.go
+++ b/collector/span.go
@@ -1,0 +1,150 @@
+package collector
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcap"
+)
+
+const (
+	spanSnapshotLen = 128 // only need IP headers for direction + length
+	spanCapTimeout  = 100 * time.Millisecond
+)
+
+// spanOverlay captures packets on a SPAN/mirror port and classifies traffic
+// direction using LOCAL_NETS. It feeds direction-aware RX/TX counters back
+// to the main Collector, which uses them to override the /proc/net/dev
+// numbers for the SPAN device.
+type spanOverlay struct {
+	device    string
+	promisc   bool
+	localNets []*net.IPNet
+
+	accMu     sync.Mutex
+	rxBytes   uint64
+	txBytes   uint64
+	rxPackets uint64
+	txPackets uint64
+
+	stopCh chan struct{}
+}
+
+func newSpanOverlay(device string, promisc bool, localNets []*net.IPNet) *spanOverlay {
+	return &spanOverlay{
+		device:    device,
+		promisc:   promisc,
+		localNets: localNets,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// run opens the capture device and classifies packets until stopped.
+func (s *spanOverlay) run() {
+	handle, err := pcap.OpenLive(s.device, int32(spanSnapshotLen), s.promisc, spanCapTimeout)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "span: cannot open %s: %v\n", s.device, err)
+		fmt.Fprintln(os.Stderr, "span: pcap requires root or CAP_NET_RAW")
+		return
+	}
+	defer handle.Close()
+
+	if err := handle.SetBPFFilter("ip or ip6"); err != nil {
+		fmt.Fprintf(os.Stderr, "span: BPF filter error: %v\n", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "span: capturing on %s (promiscuous=%v, %d local nets)\n",
+		s.device, s.promisc, len(s.localNets))
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		default:
+		}
+		data, _, err := handle.ReadPacketData()
+		if err != nil {
+			if err == pcap.NextErrorTimeoutExpired {
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "span: read error on %s: %v\n", s.device, err)
+			return
+		}
+		pkt := gopacket.NewPacket(data, handle.LinkType(), gopacket.DecodeOptions{
+			Lazy:   true,
+			NoCopy: true,
+		})
+		s.processPacket(pkt)
+	}
+}
+
+func (s *spanOverlay) stop() {
+	close(s.stopCh)
+}
+
+// snapshot returns the current cumulative counters.
+func (s *spanOverlay) snapshot() (rxBytes, txBytes, rxPackets, txPackets uint64) {
+	s.accMu.Lock()
+	rxBytes = s.rxBytes
+	txBytes = s.txBytes
+	rxPackets = s.rxPackets
+	txPackets = s.txPackets
+	s.accMu.Unlock()
+	return
+}
+
+func (s *spanOverlay) processPacket(pkt gopacket.Packet) {
+	var srcIP, dstIP net.IP
+	var pktLen uint64
+
+	if ipLayer := pkt.Layer(layers.LayerTypeIPv4); ipLayer != nil {
+		ip := ipLayer.(*layers.IPv4)
+		srcIP = ip.SrcIP
+		dstIP = ip.DstIP
+		pktLen = uint64(ip.Length)
+	} else if ipLayer := pkt.Layer(layers.LayerTypeIPv6); ipLayer != nil {
+		ip := ipLayer.(*layers.IPv6)
+		srcIP = ip.SrcIP
+		dstIP = ip.DstIP
+		pktLen = uint64(ip.Length) + 40 // IPv6 payload length excludes the 40-byte header
+	} else {
+		return
+	}
+
+	srcLocal := s.isLocal(srcIP)
+	dstLocal := s.isLocal(dstIP)
+
+	s.accMu.Lock()
+	switch {
+	case srcLocal && !dstLocal:
+		// local → remote = upload (TX)
+		s.txBytes += pktLen
+		s.txPackets++
+	case !srcLocal && dstLocal:
+		// remote → local = download (RX)
+		s.rxBytes += pktLen
+		s.rxPackets++
+	case srcLocal && dstLocal:
+		// intra-LAN — count as both
+		s.rxBytes += pktLen
+		s.rxPackets++
+		s.txBytes += pktLen
+		s.txPackets++
+	}
+	// both-remote packets (shouldn't appear on a properly-filtered SPAN) are ignored
+	s.accMu.Unlock()
+}
+
+func (s *spanOverlay) isLocal(ip net.IP) bool {
+	for _, n := range s.localNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/env.example
+++ b/env.example
@@ -33,3 +33,7 @@ UNIFI_PASS=your_password
 # Local networks for RX/TX direction detection (auto-discovered if not set)
 # Override for SPAN ports or dynamic ISP prefixes
 # LOCAL_NETS=192.0.2.0/24,2001:db8::/48
+
+# SPAN/mirror port: override RX/TX direction on this interface using pcap.
+# Requires LOCAL_NETS to be set. Other interfaces keep normal /proc/net/dev stats.
+# SPAN_DEVICE=eth1

--- a/main.go
+++ b/main.go
@@ -129,6 +129,17 @@ func main() {
 	}
 
 	statsCollector := collector.New(vpnStatusFiles)
+
+	// SPAN/mirror port mode: override RX/TX direction on a specific interface
+	// using pcap-based packet inspection against LOCAL_NETS.
+	spanDevice := env("SPAN_DEVICE", "")
+	if spanDevice != "" && len(localNets) > 0 {
+		statsCollector.EnableSPAN(spanDevice, promiscuousBool, localNets)
+		log.Printf("SPAN mode enabled on %s (%d local nets)", spanDevice, len(localNets))
+	} else if spanDevice != "" && len(localNets) == 0 {
+		log.Printf("SPAN_DEVICE=%s set but LOCAL_NETS is empty — SPAN mode disabled", spanDevice)
+	}
+
 	go statsCollector.Run()
 
 	talkerTracker := talkers.New(captureDevice, promiscuousBool, localNets, geoDB)

--- a/packaging/openwrt-files/bandwidth-monitor.init
+++ b/packaging/openwrt-files/bandwidth-monitor.init
@@ -26,7 +26,8 @@ start_service() {
         UNIFI_USER="${UNIFI_USER:-}" \
         UNIFI_PASS="${UNIFI_PASS:-}" \
         UNIFI_SITE="${UNIFI_SITE:-default}" \
-        VPN_STATUS_FILES="${VPN_STATUS_FILES:-}"
+        VPN_STATUS_FILES="${VPN_STATUS_FILES:-}" \
+        SPAN_DEVICE="${SPAN_DEVICE:-}"
     procd_set_param respawn 3600 5 5
     procd_set_param stdout 1
     procd_set_param stderr 1


### PR DESCRIPTION
When SPAN_DEVICE is set alongside LOCAL_NETS, the collector opens a pcap capture on the specified interface and classifies each packet as download (RX) or upload (TX) by inspecting IP headers against the configured local networks. This overrides the /proc/net/dev counters for that single interface while leaving all other interfaces, VPN routing detection, and interface classification untouched.

Based on the approach proposed in PR #13 by @yeled, reworked as an additive overlay that preserves existing multi-interface and VPN functionality.