### PR TITLE
feat: smooth graphs, INTERFACES filter, reorder interface groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ chmod 0600 /opt/bandwidth-monitor/.env
 | `LISTEN` | `:8080` | HTTP listen address (e.g. `198.51.100.1:8080`) |
 | `DEVICE` | *(all)* | Network device for packet capture (e.g. `eth0`) |
 | `PROMISCUOUS` | `true` | Enable promiscuous mode for packet capture (`true`/`false`) |
+| `INTERFACES` | *(all)* | Comma-separated list of interfaces to display (e.g. `eth0,ppp0,wg0`). If not set, all interfaces are shown. |
 | `GEO_COUNTRY` | `GeoLite2-Country.mmdb` | Path to GeoLite2 Country MMDB |
 | `GEO_ASN` | `GeoLite2-ASN.mmdb` | Path to GeoLite2 ASN MMDB |
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -52,6 +52,7 @@ type Collector struct {
 	history        map[string][]HistoryPoint
 	ifaceTypeCache map[string]string
 	vpnStatusFiles map[string]string // iface name → sentinel file path
+	allowedIfaces  map[string]bool   // nil = all; non-nil = whitelist
 	nlHandle       *vnl.Handle       // persistent netlink handle
 	addrCache      map[int][]string  // cached addresses by link index
 	addrCacheTime  time.Time         // last address refresh
@@ -74,9 +75,16 @@ type rawStat struct {
 	ts        time.Time
 }
 
-func New(vpnStatusFiles map[string]string) *Collector {
+func New(vpnStatusFiles map[string]string, allowedIfaces []string) *Collector {
 	if vpnStatusFiles == nil {
 		vpnStatusFiles = make(map[string]string)
+	}
+	var allowed map[string]bool
+	if len(allowedIfaces) > 0 {
+		allowed = make(map[string]bool, len(allowedIfaces))
+		for _, name := range allowedIfaces {
+			allowed[name] = true
+		}
 	}
 	// Create a persistent netlink handle to avoid per-poll socket creation.
 	// Falls back to package-level functions if handle creation fails.
@@ -90,6 +98,7 @@ func New(vpnStatusFiles map[string]string) *Collector {
 		history:        make(map[string][]HistoryPoint),
 		ifaceTypeCache: make(map[string]string),
 		vpnStatusFiles: vpnStatusFiles,
+		allowedIfaces:  allowed,
 		nlHandle:       nlh,
 		addrCache:      make(map[int][]string),
 		stopCh:         make(chan struct{}),
@@ -135,6 +144,9 @@ func (c *Collector) GetAll() []InterfaceStat {
 	defer c.mu.RUnlock()
 	stats := make([]InterfaceStat, 0, len(c.current))
 	for _, s := range c.current {
+		if c.allowedIfaces != nil && !c.allowedIfaces[s.Name] {
+			continue
+		}
 		stats = append(stats, *s)
 	}
 	return stats
@@ -145,6 +157,9 @@ func (c *Collector) GetHistory() map[string][]HistoryPoint {
 	defer c.mu.RUnlock()
 	result := make(map[string][]HistoryPoint, len(c.history))
 	for k, v := range c.history {
+		if c.allowedIfaces != nil && !c.allowedIfaces[k] {
+			continue
+		}
 		cp := make([]HistoryPoint, len(v))
 		copy(cp, v)
 		result[k] = cp
@@ -167,6 +182,9 @@ func (c *Collector) GetSparklines(duration time.Duration, maxPoints int) map[str
 	result := make(map[string][]SparkPoint, len(c.history))
 
 	for name, hist := range c.history {
+		if c.allowedIfaces != nil && !c.allowedIfaces[name] {
+			continue
+		}
 		start := 0
 		for start < len(hist) && hist[start].Timestamp < cutoff {
 			start++

--- a/env.example
+++ b/env.example
@@ -6,6 +6,9 @@ LISTEN=:8080
 # DEVICE=eth0
 # PROMISCUOUS=true
 
+# Only show these interfaces (comma-separated). If not set, all are shown.
+# INTERFACES=eth0,ppp0,wg0,br-lan
+
 # GeoIP MMDB paths (relative to WorkingDirectory)
 # GEO_COUNTRY=GeoLite2-Country.mmdb
 # GEO_ASN=GeoLite2-ASN.mmdb

--- a/main.go
+++ b/main.go
@@ -137,7 +137,20 @@ func main() {
 		}
 	}
 
-	statsCollector := collector.New(vpnStatusFiles)
+	// Parse INTERFACES: comma-separated list of interface names to display.
+	// If not set, all interfaces are shown.
+	var allowedIfaces []string
+	if raw := os.Getenv("INTERFACES"); raw != "" {
+		for _, name := range strings.Split(raw, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				allowedIfaces = append(allowedIfaces, name)
+			}
+		}
+		log.Printf("INTERFACES: showing %d interface(s): %s", len(allowedIfaces), strings.Join(allowedIfaces, ", "))
+	}
+
+	statsCollector := collector.New(vpnStatusFiles, allowedIfaces)
 
 	// Shared reverse-DNS resolver — used by talkers, conntrack, and debug.
 	dnsResolver := resolver.New()

--- a/static/app.js
+++ b/static/app.js
@@ -231,8 +231,8 @@
         for (var n of list) {
             if (!chartData[n]) continue;
             var c = chartColors[ci % chartColors.length];
-            ds.push({ label: n + ' RX', data: chartData[n].rx, borderColor: c.rx, backgroundColor: c.rxBg, fill: 'origin', tension: 0, pointRadius: 0, borderWidth: 1.5 });
-            ds.push({ label: n + ' TX', data: chartData[n].tx, borderColor: c.tx, backgroundColor: c.txBg, fill: 'origin', tension: 0, pointRadius: 0, borderWidth: 1.5 });
+            ds.push({ label: n + ' RX', data: chartData[n].rx, borderColor: c.rx, backgroundColor: c.rxBg, fill: 'origin', tension: 0.3, pointRadius: 0, borderWidth: 1.5 });
+            ds.push({ label: n + ' TX', data: chartData[n].tx, borderColor: c.tx, backgroundColor: c.txBg, fill: 'origin', tension: 0.3, pointRadius: 0, borderWidth: 1.5 });
             ci++;
         }
         trafficChart.data.datasets = ds;
@@ -262,11 +262,11 @@
     }
 
     var groupMeta = {
-        physical: { label: 'Physical', order: 0 },
-        loopback: { label: 'Loopback', order: 1 },
+        wan:      { label: 'WAN', order: 0 },
+        vpn:      { label: 'VPN', order: 1 },
         vlan:     { label: 'VLAN', order: 2 },
-        wan:      { label: 'WAN', order: 3 },
-        vpn:      { label: 'VPN', order: 4 }
+        physical: { label: 'Physical', order: 3 },
+        loopback: { label: 'Loopback', order: 4 }
     };
 
     function renderStatsRow(ifaces) {


### PR DESCRIPTION
- Smooth spiky line charts by setting Chart.js tension to 0.3 (cubic bezier interpolation instead of jagged linear segments)
- Add INTERFACES env var: comma-separated whitelist of interface names to display. When set, only listed interfaces appear in the dashboard, API responses, history, and sparklines. Falls back to all interfaces when not set.
- Reorder interface group display: WAN > VPN > VLAN > Physical > Loopback (was Physical > Loopback > VLAN > WAN > VPN). Interfaces within each group are sorted alphabetically.
- Update env.example and README with the new INTERFACES variable.