### PR TITLE
feat(nat): enrich conntrack entries with reverse DNS, GeoIP, and ASN

### DIFF
--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -58,10 +58,16 @@ type Entry struct {
 	TTL      int    `json:"ttl"`
 
 	// Original direction
-	OrigSrc   string `json:"orig_src"`
-	OrigDst   string `json:"orig_dst"`
-	OrigSPort string `json:"orig_sport,omitempty"`
-	OrigDPort string `json:"orig_dport,omitempty"`
+	OrigSrc     string `json:"orig_src"`
+	OrigDst     string `json:"orig_dst"`
+	OrigSPort   string `json:"orig_sport,omitempty"`
+	OrigDPort   string `json:"orig_dport,omitempty"`
+	OrigSrcHost string `json:"orig_src_host,omitempty"`
+	OrigSrcGeo  string `json:"orig_src_geo,omitempty"`
+	OrigSrcASN  string `json:"orig_src_asn,omitempty"`
+	OrigDstHost string `json:"orig_dst_host,omitempty"`
+	OrigDstGeo  string `json:"orig_dst_geo,omitempty"`
+	OrigDstASN  string `json:"orig_dst_asn,omitempty"`
 
 	// Reply direction
 	ReplSrc   string `json:"repl_src"`
@@ -314,6 +320,12 @@ func (t *Tracker) poll() {
 	if len(ipv6Entries) > maxEntries {
 		ipv6Entries = ipv6Entries[:maxEntries]
 	}
+
+	// Enrich the capped entry lists with reverse DNS + GeoIP.
+	// Uses the shared async resolver (cache-first) and GeoIP cache.
+	t.enrichEntries(ipv4Entries)
+	t.enrichEntries(ipv6Entries)
+
 	s.IPv4Entries = ipv4Entries
 	s.IPv6Entries = ipv6Entries
 
@@ -434,6 +446,46 @@ func (t *Tracker) enrichHosts(hosts []HostStat) {
 				hosts[i].CountryName = geo.CountryName
 				hosts[i].ASN = geo.ASN
 				hosts[i].ASOrg = geo.ASOrg
+			}
+		}
+	}
+}
+
+// enrichEntries adds reverse DNS hostnames and GeoIP to orig_src and orig_dst.
+// Uses async resolver (returns cached or raw IP) and GeoIP cache.
+func (t *Tracker) enrichEntries(entries []Entry) {
+	for i := range entries {
+		e := &entries[i]
+
+		// Reverse DNS for original source and destination
+		if t.dns != nil {
+			e.OrigSrcHost = t.dns.LookupAddrAsync(e.OrigSrc)
+			if e.OrigSrcHost == e.OrigSrc {
+				e.OrigSrcHost = ""
+			}
+			e.OrigDstHost = t.dns.LookupAddrAsync(e.OrigDst)
+			if e.OrigDstHost == e.OrigDst {
+				e.OrigDstHost = ""
+			}
+		}
+
+		// GeoIP for original source and destination
+		if t.geoDB != nil && t.geoDB.Available() {
+			if geo := t.geoDB.Lookup(e.OrigSrc); geo != nil {
+				if geo.Country != "" {
+					e.OrigSrcGeo = geo.Country
+				}
+				if geo.ASOrg != "" {
+					e.OrigSrcASN = fmt.Sprintf("AS%d %s", geo.ASN, geo.ASOrg)
+				}
+			}
+			if geo := t.geoDB.Lookup(e.OrigDst); geo != nil {
+				if geo.Country != "" {
+					e.OrigDstGeo = geo.Country
+				}
+				if geo.ASOrg != "" {
+					e.OrigDstASN = fmt.Sprintf("AS%d %s", geo.ASN, geo.ASOrg)
+				}
 			}
 		}
 	}

--- a/static/app.js
+++ b/static/app.js
@@ -939,6 +939,10 @@
                        (e.orig_dst || '').indexOf(search) !== -1 ||
                        (e.repl_src || '').indexOf(search) !== -1 ||
                        (e.repl_dst || '').indexOf(search) !== -1 ||
+                       (e.orig_src_host || '').toLowerCase().indexOf(search) !== -1 ||
+                       (e.orig_dst_host || '').toLowerCase().indexOf(search) !== -1 ||
+                       (e.orig_dst_asn || '').toLowerCase().indexOf(search) !== -1 ||
+                       (e.orig_src_asn || '').toLowerCase().indexOf(search) !== -1 ||
                        (e.protocol || '').toLowerCase().indexOf(search) !== -1 ||
                        (e.state || '').toLowerCase().indexOf(search) !== -1 ||
                        (e.orig_sport || '').indexOf(search) !== -1 ||
@@ -970,11 +974,23 @@
             var replSrcHL = (e.repl_src !== e.orig_dst) ? ' style="color:var(--tx);font-weight:600"' : '';
             var replDstHL = (e.repl_dst !== e.orig_src) ? ' style="color:var(--rx);font-weight:600"' : '';
 
+            // Helper: render IP cell with optional enrichment below
+            function ipCell(addr, host, geo, asn, hlStyle) {
+                var s = '<td' + (hlStyle || '') + '><div style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap">' + addr + '</div>';
+                var info = [];
+                if (host) info.push(host);
+                if (geo) info.push(countryFlag(geo) + ' ' + geo);
+                if (asn) info.push(asn);
+                if (info.length) s += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px">' + info.join(' · ') + '</div>';
+                s += '</td>';
+                return s;
+            }
+
             h += '<tr>';
             h += '<td style="font-size:12px;font-weight:500">' + (e.protocol || '').toUpperCase() + '</td>';
             h += '<td>' + (e.state ? '<span class="nat-state-badge ' + stateClass + '">' + e.state + '</span>' : '<span style="color:var(--text-2)">—</span>') + '</td>';
-            h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap">' + origSrc + '</td>';
-            h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap">' + origDst + '</td>';
+            h += ipCell(origSrc, e.orig_src_host, e.orig_src_geo, e.orig_src_asn, '');
+            h += ipCell(origDst, e.orig_dst_host, e.orig_dst_geo, e.orig_dst_asn, '');
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replSrcHL + '>' + replSrc + '</td>';
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replDstHL + '>' + replDst + '</td>';
             h += '<td><span class="nat-badge ' + e.nat_type + '">' + (e.nat_type || 'none').toUpperCase() + '</span></td>';


### PR DESCRIPTION
Only enrich original source and destination (not reply direction):
- orig_src_host, orig_src_geo, orig_src_asn
- orig_dst_host, orig_dst_geo, orig_dst_asn

Backend: enrichEntries() uses shared async DNS + GeoIP caches. Frontend: shows hostname, country flag, ASN below orig_src and orig_dst. Reply columns stay plain IPs with NAT highlight coloring. Search matches hostnames and ASN org names.