### PR TITLE
ci: trigger workflow on pull_request to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - '**'
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
Workflow only triggered on push, so external PRs from forks never ran CI. Add pull_request trigger for the main branch so PRs get build checks. First-time contributors still require manual approval per GitHub's default security setting.