### PR TITLE
fix: remove clock-skew timestamp check that broke Windows rendering

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1634,7 +1634,6 @@
         sse.onmessage = function(e) {
             try {
                 var d = JSON.parse(e.data);
-                if (d.timestamp && (Date.now() - d.timestamp) > 5000) return;
                 process(d);
             } catch(ex) { console.error(ex); }
         };


### PR DESCRIPTION
The SSE handler silently dropped every message when the client clock was more than 5 seconds ahead of or behind the server clock:
  if (d.timestamp && (Date.now() - d.timestamp) > 5000) return;

Windows machines commonly have clock drift vs Linux routers, causing the dashboard to show 'waiting for data' despite SSE data arriving. The visibility-change reconnect handler already covers the stale-data scenario this was meant to prevent (laptop sleep/resume).