### PR TITLE
fix: correct BPF filter for L3 interfaces, IPv4 Len, and VLAN ID extraction

### DIFF
--- a/collector/span.go
+++ b/collector/span.go
@@ -53,7 +53,7 @@ func (s *spanOverlay) run() {
 	}
 	defer unix.Close(handle)
 
-	if err := packets.ApplyBPFFilter(handle, packets.AnyIpFilter); err != nil {
+	if err := packets.ApplyBPFFilter(handle, packets.BPFFilterForDevice(s.device)); err != nil {
 		fmt.Fprintf(os.Stderr, "span: BPF filter error: %v\n", err)
 	}
 

--- a/packets/packets.go
+++ b/packets/packets.go
@@ -13,7 +13,8 @@ import (
 
 var (
 	SnapLen int32 = 128
-	// Setup BPF filter here to capture ipv4/ipv6 traffic, including 802.1Q VLAN-tagged frames.
+	// AnyIpFilter is a BPF program for Layer 2 (Ethernet) interfaces.
+	// It accepts IPv4, IPv6, and 802.1Q VLAN-tagged IP frames.
 	AnyIpFilter = []bpf.Instruction{
 		// Load EtherType at standard Ethernet header offset (12 bytes).
 		bpf.LoadAbsolute{Off: 12, Size: 2},
@@ -35,6 +36,24 @@ var (
 		// Drop.
 		bpf.RetConstant{Val: 0},
 	}
+
+	// RawIpFilter is a BPF program for Layer 3 (raw IP) interfaces such as
+	// WireGuard, tun, or PPP. There is no Ethernet header; the first byte
+	// contains the IP version nibble.
+	RawIpFilter = []bpf.Instruction{
+		// Load the first byte (IP version + IHL for v4, or version + traffic class for v6).
+		bpf.LoadAbsolute{Off: 0, Size: 1},
+		// Shift right 4 to isolate the version nibble.
+		bpf.ALUOpConstant{Op: bpf.ALUOpShiftRight, Val: 4},
+		// If version == 4 (IPv4), accept.
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 4, SkipTrue: 1},
+		// If version == 6 (IPv6), accept; otherwise drop.
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 6, SkipTrue: 0, SkipFalse: 1},
+		// Accept.
+		bpf.RetConstant{Val: uint32(SnapLen)},
+		// Drop.
+		bpf.RetConstant{Val: 0},
+	}
 )
 
 const (
@@ -52,10 +71,6 @@ type Packet struct {
 	Version      int
 	SrcInterface string
 	Dot1qTag     int
-}
-
-func extractUint16(a uint32, offset, n uint) uint16 {
-	return uint16((a >> offset) & (1<<n - 1))
 }
 
 // ParseIPPacket attempts to parse an IP packet from a slice of bytes.
@@ -118,29 +133,29 @@ func parseEthernetFrame(pkt []byte) Packet {
 		headerOffsets := EthHeaderSize + offset
 		pktType := binary.BigEndian.Uint16(pkt[headerOffsets-2 : headerOffsets])
 		if offset != 0 {
-			dot1QTag := pkt[12+offset : 16+offset]
-			// Take the last 12 bits from
-			ret.Dot1qTag = int(extractUint16(binary.BigEndian.Uint32(dot1QTag), 22, 12))
+			// The VLAN TCI sits right after the 802.1Q EtherType marker.
+			// For offset=4 (single tag): TCI is at pkt[14:16].
+			// For offset=8 (QinQ inner): TCI is at pkt[18:20].
+			tciStart := EthHeaderSize + offset - 4
+			tci := binary.BigEndian.Uint16(pkt[tciStart : tciStart+2])
+			ret.Dot1qTag = int(tci & 0x0FFF)
 		}
 		switch pktType {
 		case unix.ETH_P_IP:
 			ret.Version = 4
-			headerSize := pkt[headerOffsets : headerOffsets+2]
-			headerSizeBits := uint64(extractUint16(uint32(binary.BigEndian.Uint16(headerSize)), 8, 4) * 8)
-			// Src IP is the range of 16 to 20 bytes into IP header, which starts 14 bytes into ethernet header
 			ret.SrcIP = net.IP(pkt[headerOffsets+12 : headerOffsets+16])
 			ret.DstIP = net.IP(pkt[headerOffsets+16 : headerOffsets+20])
 			ret.Proto = uint8(pkt[v4ProtoOffset+offset])
-			ret.Len = uint64(binary.BigEndian.Uint16(pkt[headerOffsets+2:headerOffsets+4])) + uint64(headerOffsets) + headerSizeBits
+			// IPv4 Total Length field already includes the IP header.
+			ret.Len = uint64(binary.BigEndian.Uint16(pkt[headerOffsets+2 : headerOffsets+4]))
 			return ret
 		case unix.ETH_P_IPV6:
 			ret.Version = 6
-			// Src IP is the range of 8 to 24 bytes into IP header, which starts 14 bytes into ethernet header
 			ret.SrcIP = net.IP(pkt[headerOffsets+8 : headerOffsets+24])
 			ret.DstIP = net.IP(pkt[headerOffsets+24 : headerOffsets+40])
 			ret.Proto = uint8(pkt[v6ProtoOffset+offset])
-			// Include the header length AND ethernet header size itself in the calculation.
-			ret.Len = uint64(binary.BigEndian.Uint16(pkt[headerOffsets+4:headerOffsets+6])) + uint64(headerOffsets) + v6HeaderSize
+			// IPv6 Payload Length excludes the 40-byte fixed header.
+			ret.Len = uint64(binary.BigEndian.Uint16(pkt[headerOffsets+4:headerOffsets+6])) + v6HeaderSize
 			return ret
 		}
 	}
@@ -215,4 +230,34 @@ func CreateEpoller(sockFD int) (int, error) {
 
 func htons(i uint16) uint16 {
 	return (i<<8)&0xff00 | i>>8
+}
+
+// IsL3Device returns true if the named interface is a Layer 3 (point-to-point,
+// no Ethernet header) device such as WireGuard, tun, or PPP. This is detected
+// via the interface's ARPHRD type: ARPHRD_NONE (0xFFFE) or ARPHRD_PPP (512)
+// indicate L3, while ARPHRD_ETHER (1) indicates L2.
+func IsL3Device(dev string) bool {
+	iface, err := net.InterfaceByName(dev)
+	if err != nil {
+		return false
+	}
+	// net.Interface doesn't expose ARPHRD directly, but point-to-point
+	// L3 interfaces (wg, tun, ppp) have the PointToPoint flag set and
+	// a zero HardwareAddr (no MAC address).
+	if iface.Flags&net.FlagPointToPoint != 0 {
+		return true
+	}
+	if len(iface.HardwareAddr) == 0 {
+		return true
+	}
+	return false
+}
+
+// BPFFilterForDevice returns the appropriate BPF filter for the given device:
+// RawIpFilter for L3 interfaces, AnyIpFilter for L2 (Ethernet) interfaces.
+func BPFFilterForDevice(dev string) []bpf.Instruction {
+	if IsL3Device(dev) {
+		return RawIpFilter
+	}
+	return AnyIpFilter
 }

--- a/packets/packets_test.go
+++ b/packets/packets_test.go
@@ -25,7 +25,7 @@ func TestParseIPPacket(t *testing.T) {
 			want: packets.Packet{
 				SrcIP:   net.ParseIP("192.0.2.1"),
 				DstIP:   net.ParseIP("192.0.2.0"),
-				Len:     1514,
+				Len:     1460,
 				Proto:   6,
 				Version: 4,
 			},
@@ -36,7 +36,7 @@ func TestParseIPPacket(t *testing.T) {
 			want: packets.Packet{
 				SrcIP:   net.ParseIP("dead:beef:dead:beef:dead:beef:dead:beef"),
 				DstIP:   net.ParseIP("dead:beef:dead:beef:dead:beef:dead:beef"),
-				Len:     1294,
+				Len:     1280,
 				Proto:   6,
 				Version: 6,
 			},
@@ -47,10 +47,51 @@ func TestParseIPPacket(t *testing.T) {
 			want: packets.Packet{
 				SrcIP:    net.ParseIP("131.151.32.21"),
 				DstIP:    net.ParseIP("131.151.32.129"),
-				Len:      678,
+				Len:      620,
 				Proto:    6,
 				Version:  4,
 				Dot1qTag: 32,
+			},
+		},
+		{
+			name: "test success - dot1q v6 packet",
+			// 802.1Q-tagged IPv6: dst MAC, src MAC, 0x8100, VLAN 100, 0x86dd, IPv6 header
+			pkt: []byte{
+				// Ethernet: dst MAC
+				0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+				// Ethernet: src MAC
+				0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb,
+				// 802.1Q EtherType
+				0x81, 0x00,
+				// TCI: VLAN ID 100 (0x0064)
+				0x00, 0x64,
+				// Inner EtherType: IPv6
+				0x86, 0xdd,
+				// IPv6 header: version=6, traffic class=0, flow label=0
+				0x60, 0x00, 0x00, 0x00,
+				// Payload length: 32
+				0x00, 0x20,
+				// Next header: TCP (6), Hop limit: 64
+				0x06, 0x40,
+				// Src IP: 2001:db8::1
+				0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+				// Dst IP: 2001:db8::2
+				0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+				// 32 bytes TCP payload (padding)
+				0x00, 0x50, 0x00, 0x51, 0x00, 0x00, 0x00, 0x01,
+				0x00, 0x00, 0x00, 0x00, 0x50, 0x02, 0xff, 0xff,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+			want: packets.Packet{
+				SrcIP:    net.ParseIP("2001:db8::1"),
+				DstIP:    net.ParseIP("2001:db8::2"),
+				Len:      72, // payload 32 + IPv6 header 40
+				Proto:    6,
+				Version:  6,
+				Dot1qTag: 100,
 			},
 		},
 		{

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -253,7 +253,7 @@ func (t *Tracker) captureDevice(device string) {
 	}
 	defer unix.Close(handle)
 	log.Printf("Applying BPF filter %s \n", device)
-	if err := packets.ApplyBPFFilter(handle, packets.AnyIpFilter); err != nil {
+	if err := packets.ApplyBPFFilter(handle, packets.BPFFilterForDevice(device)); err != nil {
 		fmt.Fprintf(os.Stderr, "talkers: BPF filter error on %s: %v\n", device, err)
 	}
 	// Use epoll to read from the socket.


### PR DESCRIPTION
## Summary

Fixes three packet parsing bugs in the `packets` package that affect top-talker accuracy and L3 interface (WireGuard/tun/PPP) support.

## Bugs fixed

### 1. BPF filter drops packets on L3 interfaces
The `AnyIpFilter` BPF checks EtherType at Ethernet header offset 12. On L3 interfaces (`wg0`, `tun0`, `ppp0`), `AF_PACKET` delivers raw IP — no Ethernet header. The BPF reads IP header bytes as EtherType values, causing undefined accept/drop behavior.

**Fix:** Added `RawIpFilter` — checks the IP version nibble at byte 0 (accepts 4 or 6). `IsL3Device()` detects point-to-point/no-MAC interfaces, and `BPFFilterForDevice()` auto-selects the correct filter.

### 2. IPv4/IPv6 Len double-counts headers
`parseEthernetFrame` computed IPv4 `Len` as `TotalLength + EthernetOffset + IHL*8`. The IPv4 Total Length field already includes the IP header, so IHL was double-counted. Similarly, IPv6 added `PayloadLength + EthernetOffset + 40`, inflating counts by the Ethernet offset.

**Fix:** Use just the IP-layer length: `TotalLength` for IPv4, `PayloadLength + 40` for IPv6. This matches `parseRawIP` which was already correct.

### 3. VLAN ID extraction from wrong bytes
The Dot1qTag was extracted from `pkt[12+offset : 16+offset]` — which points at the inner EtherType + IP header, not the TCI. The `extractUint16` bit-shift on those wrong bytes coincidentally produced the right VLAN ID for the single existing test case.

**Fix:** Read the TCI from its correct position (2 bytes after the `0x8100` marker) and mask the low 12 bits. Removed the now-unused `extractUint16` function.

## Tests
- Updated IPv4, IPv6, and dot1q v4 Len expectations
- Added dot1q IPv6 test case with VLAN ID 100
