### PR TITLE
feat(nat): add traffic volume to host tables with toggle

### DIFF
--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -87,6 +87,7 @@ type HostStat struct {
 	IP          string `json:"ip"`
 	Hostname    string `json:"hostname,omitempty"`
 	Connections int    `json:"connections"`
+	Bytes       uint64 `json:"bytes"`
 	NATType     string `json:"nat_type,omitempty"`
 	Country     string `json:"country,omitempty"`
 	CountryName string `json:"country_name,omitempty"`
@@ -269,8 +270,10 @@ func (t *Tracker) poll() {
 		s.UsagePct = float64(count) / float64(max) * 100
 	}
 
-	srcCount := make(map[string]int) // LAN clients (local sources)
-	dstCount := make(map[string]int) // remote destinations (non-local destinations)
+	srcCount := make(map[string]int)    // LAN clients (local sources)
+	dstCount := make(map[string]int)    // remote destinations (non-local destinations)
+	srcBytes := make(map[string]uint64) // bytes per LAN client
+	dstBytes := make(map[string]uint64) // bytes per remote destination
 
 	var ipv4Entries, ipv6Entries []Entry
 
@@ -299,14 +302,16 @@ func (t *Tracker) poll() {
 		// Classify: local sources → LAN clients, non-local destinations → remote hosts
 		if t.isLocal(e.OrigSrc) {
 			srcCount[e.OrigSrc]++
+			srcBytes[e.OrigSrc] += e.Bytes
 		}
 		if !t.isLocal(e.OrigDst) && !t.isLoopback(e.OrigDst) {
 			dstCount[e.OrigDst]++
+			dstBytes[e.OrigDst] += e.Bytes
 		}
 	}
 
-	s.TopLANClients = topHosts(srcCount, 20)
-	s.TopRemoteDestinations = topHosts(dstCount, 20)
+	s.TopLANClients = topHosts(srcCount, srcBytes, 20)
+	s.TopRemoteDestinations = topHosts(dstCount, dstBytes, 20)
 
 	// Enrich top hosts with reverse DNS and GeoIP (outside the hot path).
 	t.enrichHosts(s.TopLANClients)
@@ -426,12 +431,16 @@ func detectNAT(e Entry) string {
 	}
 }
 
-func topHosts(counts map[string]int, n int) []HostStat {
+func topHosts(counts map[string]int, bytes map[string]uint64, n int) []HostStat {
 	list := make([]HostStat, 0, len(counts))
 	for ip, c := range counts {
-		list = append(list, HostStat{IP: ip, Connections: c})
+		list = append(list, HostStat{IP: ip, Connections: c, Bytes: bytes[ip]})
 	}
+	// Sort by bytes descending, then by connections as tiebreaker.
 	sort.Slice(list, func(i, j int) bool {
+		if list[i].Bytes != list[j].Bytes {
+			return list[i].Bytes > list[j].Bytes
+		}
 		return list[i].Connections > list[j].Connections
 	})
 	if len(list) > n {

--- a/static/app.js
+++ b/static/app.js
@@ -903,13 +903,41 @@
         legendEl.innerHTML = h || '<div style="text-align:center;color:var(--text-2);font-size:12px;padding:8px">No data</div>';
     }
 
-    function renderHostTable(tbId, hosts) {
+    var _natHostSortMode = { natSrc: 'bytes', natDst: 'bytes' };
+    var _natHostData = { natSrc: [], natDst: [] };
+
+    window._toggleHostSort = function(btn) {
+        var target = btn.getAttribute('data-target');
+        var mode = btn.getAttribute('data-mode');
+        _natHostSortMode[target] = mode;
+        var siblings = btn.parentElement.querySelectorAll('.toggle-btn');
+        for (var i = 0; i < siblings.length; i++) siblings[i].classList.remove('active');
+        btn.classList.add('active');
+        var subtitle = mode === 'bytes' ? 'By traffic volume' : 'By connection count';
+        var header = mode === 'bytes' ? 'Traffic' : 'Connections';
+        document.getElementById(target + 'Subtitle').textContent = subtitle;
+        document.getElementById(target + 'MetricHeader').textContent = header;
+        renderHostTable(target + 'Table', _natHostData[target], mode);
+    };
+
+    function renderHostTable(tbId, hosts, mode) {
+        if (!mode) mode = _natHostSortMode[tbId.replace('Table', '')] || 'bytes';
+        var target = tbId.replace('Table', '');
+        _natHostData[target] = hosts;
         var tb = document.getElementById(tbId);
         if (!hosts || !hosts.length) { tb.innerHTML = '<tr><td colspan="4" class="empty-state">No data</td></tr>'; return; }
-        var mx = hosts[0].connections || 1, h = '';
+        hosts = hosts.slice().sort(function(a, b) {
+            if (mode === 'bytes') return (b.bytes || 0) - (a.bytes || 0);
+            return (b.connections || 0) - (a.connections || 0);
+        });
+        var useBytes = mode === 'bytes';
+        var mx = useBytes ? (hosts[0].bytes || 1) : (hosts[0].connections || 1);
+        var h = '';
         for (var i = 0; i < hosts.length; i++) {
             var host = hosts[i];
-            var pct = ((host.connections / mx) * 100).toFixed(1);
+            var val = useBytes ? (host.bytes || 0) : host.connections;
+            var pct = ((val / mx) * 100).toFixed(1);
+            var display = useBytes ? formatBytes(val) : val.toLocaleString();
             var flag = host.country ? countryFlag(host.country) + ' ' : '';
             var geo = '';
             if (host.as_org) geo = '<span class="hostname">' + flag + (host.country_name || '') + ' &middot; AS' + (host.asn || '') + ' ' + host.as_org + '</span>';
@@ -919,7 +947,7 @@
                 : '<span class="ip-cell">' + host.ip + '</span>' + geo;
             h += '<tr><td><span class="' + rankClass(i) + '">' + (i + 1) + '</span></td>';
             h += '<td>' + cell + '</td>';
-            h += '<td style="font-variant-numeric:tabular-nums">' + host.connections.toLocaleString() + '</td>';
+            h += '<td style="font-variant-numeric:tabular-nums">' + display + '</td>';
             h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill bw" style="width:' + pct + '%"></div></td></tr>';
         }
         tb.innerHTML = h;

--- a/static/index.html
+++ b/static/index.html
@@ -268,11 +268,15 @@
                     <div class="card-header">
                         <div>
                             <div class="card-title">Top LAN Clients</div>
-                            <div class="card-subtitle">By connection count</div>
+                            <div class="card-subtitle" id="natSrcSubtitle">By traffic volume</div>
+                        </div>
+                        <div class="toggle-group">
+                            <button class="toggle-btn active" data-target="natSrc" data-mode="bytes" onclick="window._toggleHostSort(this)">Traffic</button>
+                            <button class="toggle-btn" data-target="natSrc" data-mode="conns" onclick="window._toggleHostSort(this)">Connections</button>
                         </div>
                     </div>
                     <table>
-                        <thead><tr><th>#</th><th>LAN Host</th><th>Connections</th><th style="width:28%"></th></tr></thead>
+                        <thead><tr><th>#</th><th>LAN Host</th><th id="natSrcMetricHeader">Traffic</th><th style="width:28%"></th></tr></thead>
                         <tbody id="natSrcTable">
                             <tr><td colspan="4" class="empty-state">Waiting for data</td></tr>
                         </tbody>
@@ -282,11 +286,15 @@
                     <div class="card-header">
                         <div>
                             <div class="card-title">Top Remote Destinations</div>
-                            <div class="card-subtitle">By connection count</div>
+                            <div class="card-subtitle" id="natDstSubtitle">By traffic volume</div>
+                        </div>
+                        <div class="toggle-group">
+                            <button class="toggle-btn active" data-target="natDst" data-mode="bytes" onclick="window._toggleHostSort(this)">Traffic</button>
+                            <button class="toggle-btn" data-target="natDst" data-mode="conns" onclick="window._toggleHostSort(this)">Connections</button>
                         </div>
                     </div>
                     <table>
-                        <thead><tr><th>#</th><th>Remote Host</th><th>Connections</th><th style="width:28%"></th></tr></thead>
+                        <thead><tr><th>#</th><th>Remote Host</th><th id="natDstMetricHeader">Traffic</th><th style="width:28%"></th></tr></thead>
                         <tbody id="natDstTable">
                             <tr><td colspan="4" class="empty-state">Waiting for data</td></tr>
                         </tbody>
@@ -302,7 +310,7 @@
                 <div class="card-header">
                     <div>
                         <div class="card-title" id="natTableTitle">IPv4 NAT Translations</div>
-                        <div class="card-subtitle" id="natTableSubtitle">Active conntrack entries (top 200 by TTL)</div>
+                        <div class="card-subtitle" id="natTableSubtitle">Active conntrack entries (top 200 by traffic volume)</div>
                     </div>
                     <div style="display:flex;gap:8px;align-items:center">
                         <input type="text" id="natSearch" placeholder="Filter entries…" style="padding:4px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text-1);font-size:12px;width:200px;outline:none">

--- a/static/style.css
+++ b/static/style.css
@@ -936,6 +936,35 @@ canvas { outline: none; }
     border-color: rgba(59,130,246,0.15);
 }
 
+.toggle-group {
+    display: flex;
+    gap: 2px;
+    background: var(--bg-2);
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.toggle-btn {
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    color: var(--text-2);
+    background: transparent;
+    border: none;
+    transition: all 0.15s;
+    font-family: 'Inter', sans-serif;
+}
+
+.toggle-btn:hover { color: var(--text-0); }
+
+.toggle-btn.active {
+    background: var(--card);
+    color: var(--text-0);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+}
+
 .nat-badge {
     display: inline-block;
     font-size: 10px;


### PR DESCRIPTION
## Summary

Adds per-host traffic volume (bytes) to the NAT tab Top LAN Clients and Top Remote Destinations tables, with a toggle to switch between traffic and connection count views.

## Problem

The host tables only showed connection count, so a host making many small DNS queries ranked above a host streaming video over one connection. The entry table below sorted by bytes, creating an inconsistency.

## Changes

**Backend:**
- Added `Bytes` field to `HostStat` (accumulated from conntrack per-flow counters)
- Default sort: bytes descending, connections as tiebreaker

**Frontend:**
- Traffic/Connections toggle buttons on both host tables
- Default view: traffic volume, switchable to connection count
- Client-side re-sort preserves the user's choice across SSE updates

**Also fixed:** NAT entry table subtitle said "top 200 by TTL" but entries are sorted by traffic volume.
