### PR TITLE
feat: system overview, pps rates, latency P95/P99, speedtest tuning

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -20,6 +20,7 @@ type InterfaceStat struct {
 	VPNRouting      bool     `json:"vpn_routing"`
 	VPNRoutingSince string   `json:"vpn_routing_since,omitempty"`
 	VPNTracked      bool     `json:"vpn_tracked"`
+	Speed           int      `json:"speed,omitempty"`
 	RxBytes         uint64   `json:"rx_bytes"`
 	TxBytes         uint64   `json:"tx_bytes"`
 	RxPackets       uint64   `json:"rx_packets"`
@@ -30,6 +31,12 @@ type InterfaceStat struct {
 	TxDropped       uint64   `json:"tx_dropped"`
 	RxRate          float64  `json:"rx_rate"`
 	TxRate          float64  `json:"tx_rate"`
+	RxPPS           float64  `json:"rx_pps"`
+	TxPPS           float64  `json:"tx_pps"`
+	RxErrorRate     float64  `json:"rx_error_rate"`
+	TxErrorRate     float64  `json:"tx_error_rate"`
+	RxDropRate      float64  `json:"rx_drop_rate"`
+	TxDropRate      float64  `json:"tx_drop_rate"`
 	Timestamp       int64    `json:"timestamp"`
 }
 
@@ -223,6 +230,7 @@ type linkInfo struct {
 	ifType    string // classified type: physical, vpn, vlan, ppp, loopback, span
 	encapType string // ARPHRD text form: "ether", "loopback", "none", "ppp", etc.
 	linkKind  string // IFLA_INFO_KIND: wireguard, vlan, bridge, bond, gre, ...
+	speed     int    // link speed in Mbps (0 = unknown)
 	stats     *rawStat
 	addrs     []string
 }
@@ -277,6 +285,11 @@ func (c *Collector) poll() {
 			encapType: attrs.EncapType,
 			addrs:     c.addrCache[attrs.Index],
 		}
+
+		// Link speed (Mbps) — available for physical Ethernet interfaces.
+		// Note: vishvananda/netlink doesn't expose Speed directly, but
+		// we can check if the link is Device type which has Attrs().
+		// For now, expose 0 and let the frontend hide it.
 
 		// Extract IFLA_INFO_KIND via link type name
 		li.linkKind = link.Type()
@@ -341,6 +354,7 @@ func (c *Collector) poll() {
 			VPNRouting:      vs.routing,
 			VPNRoutingSince: vs.since,
 			VPNTracked:      vpnTracked,
+			Speed:           li.speed,
 			RxBytes:         cur.rxBytes,
 			TxBytes:         cur.txBytes,
 			RxPackets:       cur.rxPackets,
@@ -358,6 +372,12 @@ func (c *Collector) poll() {
 			if dt > 0 {
 				iface.RxRate = float64(cur.rxBytes-prev.rxBytes) / dt
 				iface.TxRate = float64(cur.txBytes-prev.txBytes) / dt
+				iface.RxPPS = float64(cur.rxPackets-prev.rxPackets) / dt
+				iface.TxPPS = float64(cur.txPackets-prev.txPackets) / dt
+				iface.RxErrorRate = float64(cur.rxErrors-prev.rxErrors) / dt
+				iface.TxErrorRate = float64(cur.txErrors-prev.txErrors) / dt
+				iface.RxDropRate = float64(cur.rxDropped-prev.rxDropped) / dt
+				iface.TxDropRate = float64(cur.txDropped-prev.txDropped) / dt
 			}
 		}
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -377,6 +379,10 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 		"asns":          geo.ASNs,
 		"top_bandwidth": t.TopByBandwidth(10),
 		"top_volume":    t.TopByVolume(10),
+		"unique_ips":    t.UniqueIPs(),
+		"uptime_secs":   readUptime(),
+		"load_avg":      readLoadAvg(),
+		"processes":     func() map[string]int { r, t := readProcessCount(); return map[string]int{"running": r, "total": t} }(),
 		"timestamp":     time.Now().UnixMilli(),
 	}
 	if dp != nil {
@@ -472,4 +478,54 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 			}
 		}
 	}
+}
+
+// readUptime reads the system uptime from /proc/uptime in seconds.
+func readUptime() float64 {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return 0
+	}
+	parts := strings.Fields(string(data))
+	if len(parts) < 1 {
+		return 0
+	}
+	v, _ := strconv.ParseFloat(parts[0], 64)
+	return v
+}
+
+// readLoadAvg reads the 1/5/15 minute load averages from /proc/loadavg.
+func readLoadAvg() [3]float64 {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return [3]float64{}
+	}
+	parts := strings.Fields(string(data))
+	if len(parts) < 3 {
+		return [3]float64{}
+	}
+	var la [3]float64
+	la[0], _ = strconv.ParseFloat(parts[0], 64)
+	la[1], _ = strconv.ParseFloat(parts[1], 64)
+	la[2], _ = strconv.ParseFloat(parts[2], 64)
+	return la
+}
+
+// readProcessCount reads the running/total process count from /proc/loadavg.
+func readProcessCount() (running, total int) {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return 0, 0
+	}
+	parts := strings.Fields(string(data))
+	if len(parts) < 4 {
+		return 0, 0
+	}
+	// Format: "running/total"
+	rt := strings.SplitN(parts[3], "/", 2)
+	if len(rt) == 2 {
+		running, _ = strconv.Atoi(rt[0])
+		total, _ = strconv.Atoi(rt[1])
+	}
+	return
 }

--- a/latency/latency.go
+++ b/latency/latency.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -71,6 +72,8 @@ type ProbeStats struct {
 	AvgRTT  float64 `json:"avg_rtt_ms"`
 	MinRTT  float64 `json:"min_rtt_ms"`
 	MaxRTT  float64 `json:"max_rtt_ms"`
+	P95RTT  float64 `json:"p95_rtt_ms"`
+	P99RTT  float64 `json:"p99_rtt_ms"`
 	Jitter  float64 `json:"jitter_ms"`
 	LossPct float64 `json:"loss_pct"`
 }
@@ -311,6 +314,18 @@ func buildProbeStats(pts []Point) *ProbeStats {
 	last := pts[len(pts)-1]
 	s.RTT = last.RTT
 	s.AvgRTT, s.MinRTT, s.MaxRTT, s.Jitter = computeStats(pts)
+	// Percentiles from sorted good values
+	var good []float64
+	for _, p := range pts {
+		if p.RTT >= 0 {
+			good = append(good, p.RTT)
+		}
+	}
+	if len(good) > 0 {
+		sort.Float64s(good)
+		s.P95RTT = good[int(float64(len(good))*0.95)%len(good)]
+		s.P99RTT = good[int(float64(len(good))*0.99)%len(good)]
+	}
 	var lost int
 	for _, p := range pts {
 		if p.RTT < 0 {

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -202,7 +202,7 @@ func measurePing(server string, samples int) (avgMs, jitterMs float64, err error
 
 func measureDownload(server string, ch chan<- Progress) (float64, error) {
 	const (
-		duration    = 10 * time.Second
+		duration    = 15 * time.Second
 		parallelism = 6
 	)
 
@@ -219,7 +219,7 @@ func measureDownload(server string, ch chan<- Progress) (float64, error) {
 			client := &http.Client{
 				Timeout: duration + 5*time.Second,
 			}
-			buf := make([]byte, 128*1024)
+			buf := make([]byte, 256*1024)
 			for time.Now().Before(deadline) {
 				resp, e := client.Get(server + "/downloading")
 				if e != nil {
@@ -286,9 +286,9 @@ loop:
 
 func measureUpload(server string, ch chan<- Progress) (float64, error) {
 	const (
-		duration    = 10 * time.Second
+		duration    = 15 * time.Second
 		parallelism = 6
-		chunkSize   = 1 * 1024 * 1024
+		chunkSize   = 4 * 1024 * 1024
 	)
 
 	var totalBytes int64

--- a/static/app.js
+++ b/static/app.js
@@ -116,6 +116,23 @@
 
     function rankClass(i) { return i === 0 ? 'rank rank-1' : 'rank'; }
 
+    function formatPPS(pps) {
+        if (pps === 0) return '0 pps';
+        if (pps < 1000) return pps.toFixed(0) + ' pps';
+        if (pps < 1e6) return (pps / 1000).toFixed(1) + ' Kpps';
+        return (pps / 1e6).toFixed(1) + ' Mpps';
+    }
+
+    function formatUptime(secs) {
+        if (!secs || secs <= 0) return '—';
+        var d = Math.floor(secs / 86400);
+        var h = Math.floor((secs % 86400) / 3600);
+        var m = Math.floor((secs % 3600) / 60);
+        if (d > 0) return d + 'd ' + h + 'h';
+        if (h > 0) return h + 'h ' + m + 'm';
+        return m + 'm';
+    }
+
     // Convert ISO 3166-1 alpha-2 to flag emoji
     function countryFlag(cc) {
         if (!cc || cc.length !== 2) return '';
@@ -327,7 +344,42 @@
         loopback: { label: 'Loopback', order: 4 }
     };
 
-    function renderStatsRow(ifaces) {
+    function renderSystemCard(ifaces, d) {
+        var totalRxRate = 0, totalTxRate = 0, totalRxBytes = 0, totalTxBytes = 0;
+        for (var f of ifaces) {
+            totalRxRate += f.rx_rate || 0;
+            totalTxRate += f.tx_rate || 0;
+            totalRxBytes += f.rx_bytes || 0;
+            totalTxBytes += f.tx_bytes || 0;
+        }
+        var el = document.getElementById('systemStats');
+        var sub = document.getElementById('systemSubtitle');
+        if (!el) return;
+        function stat(label, value, cls) {
+            return '<div style="padding:8px 4px"><div style="font-size:10px;color:var(--text-2);margin-bottom:4px">' + label + '</div><div style="font-size:15px;font-weight:700;font-variant-numeric:tabular-nums' + (cls ? ';color:var(--' + cls + ')' : '') + '">' + value + '</div></div>';
+        }
+        var h = '';
+        h += stat('Uptime', d && d.uptime_secs ? formatUptime(d.uptime_secs) : '—');
+        if (d && d.load_avg) {
+            h += stat('Load 1m', d.load_avg[0].toFixed(2));
+            h += stat('Load 5m', d.load_avg[1].toFixed(2));
+            h += stat('Load 15m', d.load_avg[2].toFixed(2));
+        }
+        h += stat('Processes', d && d.processes ? d.processes.running + ' / ' + d.processes.total : '—');
+        h += stat('Bandwidth', formatRate(totalRxRate + totalTxRate));
+        h += stat('RX Rate', formatRate(totalRxRate), 'rx');
+        h += stat('TX Rate', formatRate(totalTxRate), 'tx');
+        h += stat('Total RX', formatBytes(totalRxBytes), 'rx');
+        h += stat('Total TX', formatBytes(totalTxBytes), 'tx');
+        h += stat('IPs (24h)', d && d.unique_ips ? (d.unique_ips).toLocaleString() : '—');
+        el.innerHTML = h;
+        if (sub && d && d.uptime_secs) {
+            sub.textContent = ifaces.length + ' interfaces · up ' + formatUptime(d.uptime_secs);
+        }
+    }
+
+    function renderStatsRow(ifaces, d) {
+        renderSystemCard(ifaces, d);
         var groups = {};
         for (var f of ifaces) {
             var g = classifyIface(f);
@@ -341,12 +393,12 @@
         });
         var h = '';
         for (var i = 0; i < keys.length; i++) {
-            var k = keys[i], meta = groupMeta[k] || { label: k }, d = groups[k];
+            var k = keys[i], meta = groupMeta[k] || { label: k }, grp = groups[k];
             h += '<div class="stats-group">';
-            h += '<div class="stats-group-header">' + meta.label + '<span>' + d.count + '</span></div>';
+            h += '<div class="stats-group-header">' + meta.label + '<span>' + grp.count + '</span></div>';
             h += '<div class="stats-group-body">';
-            h += '<div><div class="stat-mini-label">RX</div><div class="stat-mini-value rx">' + formatRate(d.rx) + '</div></div>';
-            h += '<div><div class="stat-mini-label">TX</div><div class="stat-mini-value tx">' + formatRate(d.tx) + '</div></div>';
+            h += '<div><div class="stat-mini-label">RX</div><div class="stat-mini-value rx">' + formatRate(grp.rx) + '</div></div>';
+            h += '<div><div class="stat-mini-label">TX</div><div class="stat-mini-value tx">' + formatRate(grp.tx) + '</div></div>';
             h += '</div></div>';
         }
         document.getElementById('statsRow').innerHTML = h;
@@ -371,10 +423,10 @@
         h += '<div><div class="iface-stat-label label-tx">TX Rate</div><div class="iface-stat-value" style="color:var(--tx)">' + formatRate(f.tx_rate || 0) + '</div></div>';
         h += '<div><div class="iface-stat-label">RX Total</div><div class="iface-stat-value">' + formatBytes(f.rx_bytes || 0) + '</div></div>';
         h += '<div><div class="iface-stat-label">TX Total</div><div class="iface-stat-value">' + formatBytes(f.tx_bytes || 0) + '</div></div>';
-        h += '<div><div class="iface-stat-label">RX Pkts</div><div class="iface-stat-value">' + (f.rx_packets || 0).toLocaleString() + '</div></div>';
-        h += '<div><div class="iface-stat-label">TX Pkts</div><div class="iface-stat-value">' + (f.tx_packets || 0).toLocaleString() + '</div></div>';
-        if (hasErr) h += '<div><div class="iface-stat-label label-err">Errors RX/TX</div><div class="iface-stat-value" style="color:var(--danger)">' + f.rx_errors + ' / ' + f.tx_errors + '</div></div>';
-        if (hasDrop) h += '<div><div class="iface-stat-label">Drops RX/TX</div><div class="iface-stat-value" style="color:var(--warning)">' + f.rx_dropped + ' / ' + f.tx_dropped + '</div></div>';
+        h += '<div><div class="iface-stat-label">RX Pkts</div><div class="iface-stat-value">' + formatPPS(f.rx_pps || 0) + '</div></div>';
+        h += '<div><div class="iface-stat-label">TX Pkts</div><div class="iface-stat-value">' + formatPPS(f.tx_pps || 0) + '</div></div>';
+        if (hasErr || (f.rx_error_rate || 0) + (f.tx_error_rate || 0) > 0) h += '<div><div class="iface-stat-label label-err">Errors</div><div class="iface-stat-value" style="color:var(--danger)">' + (f.rx_error_rate > 0 || f.tx_error_rate > 0 ? formatPPS(f.rx_error_rate || 0) + ' / ' + formatPPS(f.tx_error_rate || 0) + '/s' : f.rx_errors + ' / ' + f.tx_errors) + '</div></div>';
+        if (hasDrop || (f.rx_drop_rate || 0) + (f.tx_drop_rate || 0) > 0) h += '<div><div class="iface-stat-label">Drops</div><div class="iface-stat-value" style="color:var(--warning)">' + (f.rx_drop_rate > 0 || f.tx_drop_rate > 0 ? formatPPS(f.rx_drop_rate || 0) + ' / ' + formatPPS(f.tx_drop_rate || 0) + '/s' : f.rx_dropped + ' / ' + f.tx_dropped) + '</div></div>';
         h += '</div>';
         if (f.addrs && f.addrs.length) {
             var v4 = [], v6 = [];
@@ -1100,13 +1152,21 @@
         tb.innerHTML = h;
     }
 
-    // Wire search/filter on NAT entry table to re-render
-    ['natSearch', 'natFilter'].forEach(function(id) {
-        var el = document.getElementById(id);
-        if (el) el.addEventListener(id === 'natSearch' ? 'input' : 'change', function() {
+    // Wire search/filter on NAT entry table to re-render (with debounce on search)
+    var _natSearchTimer = null;
+    (function() {
+        var searchEl = document.getElementById('natSearch');
+        if (searchEl) searchEl.addEventListener('input', function() {
+            clearTimeout(_natSearchTimer);
+            _natSearchTimer = setTimeout(function() {
+                if (_lastConntrack) renderNATEntries(_lastConntrack);
+            }, 150);
+        });
+        var filterEl = document.getElementById('natFilter');
+        if (filterEl) filterEl.addEventListener('change', function() {
             if (_lastConntrack) renderNATEntries(_lastConntrack);
         });
-    });
+    })();
 
     // ── World Traffic Map ──
     // Country centroids (ISO alpha-2 → [lat, lon]) for map visualization.
@@ -1413,12 +1473,13 @@
             // Stats grid — per protocol
             function statsRow(label, labelColor, s) {
                 if (!s) return '';
-                var r = '<div style="display:grid;grid-template-columns:auto repeat(5,1fr);gap:8px;text-align:center;align-items:center">';
+                var r = '<div style="display:grid;grid-template-columns:auto repeat(6,1fr);gap:8px;text-align:center;align-items:center">';
                 r += '<div style="text-align:left;font-size:11px;font-weight:700;color:' + labelColor + '">' + label + '</div>';
                 var items = [
                     ['RTT', s.rtt_ms >= 0 ? s.rtt_ms.toFixed(1) : '—', 'ms'],
                     ['Avg', s.avg_rtt_ms > 0 ? s.avg_rtt_ms.toFixed(1) : '—', 'ms'],
-                    ['Min', s.min_rtt_ms > 0 ? s.min_rtt_ms.toFixed(1) : '—', 'ms'],
+                    ['P95', s.p95_rtt_ms > 0 ? s.p95_rtt_ms.toFixed(1) : '—', 'ms'],
+                    ['P99', s.p99_rtt_ms > 0 ? s.p99_rtt_ms.toFixed(1) : '—', 'ms'],
                     ['Jitter', s.jitter_ms > 0 ? s.jitter_ms.toFixed(2) : '—', 'ms'],
                     ['Loss', s.loss_pct.toFixed(1), '%']
                 ];
@@ -1808,7 +1869,7 @@
         var rx = 0, tx = 0;
         for (var f of ifaces) { rx += f.rx_rate || 0; tx += f.tx_rate || 0; knownIfaces.add(f.name); }
 
-        renderStatsRow(ifaces);
+        renderStatsRow(ifaces, d);
 
         // VPN routing banner
         var vpnActive = false, vpnSince = '', vpnName = '';

--- a/static/index.html
+++ b/static/index.html
@@ -45,6 +45,16 @@
             <span class="vpn-banner-text">Traffic routed via VPN <span class="vpn-banner-since" id="vpnBannerSince"></span></span>
         </div>
 
+        <div class="card" id="systemCard" style="margin-bottom:16px">
+            <div class="card-header">
+                <div>
+                    <div class="card-title">System Overview</div>
+                    <div class="card-subtitle" id="systemSubtitle">Loading…</div>
+                </div>
+            </div>
+            <div id="systemStats" style="padding:0 16px 16px;display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:12px"></div>
+        </div>
+
         <div class="stats-row" id="statsRow"></div>
 
         <div class="iface-groups" id="ifaceGroups"></div>

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -584,3 +584,21 @@ func (t *Tracker) isLocalNet(ip net.IP) bool {
 	}
 	return false
 }
+
+// UniqueIPs returns the number of distinct external IPs seen in the 24h window.
+func (t *Tracker) UniqueIPs() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	seen := make(map[string]struct{})
+	for _, b := range t.buckets {
+		for ip := range b.hosts {
+			seen[ip] = struct{}{}
+		}
+	}
+	if t.current != nil {
+		for ip := range t.current.hosts {
+			seen[ip] = struct{}{}
+		}
+	}
+	return len(seen)
+}


### PR DESCRIPTION
## Summary

A collection of quick wins: new System Overview card, per-second rates, latency percentiles, and speedtest tuning.

## System Overview Card
New card at the top of the Traffic tab showing:
- **Uptime** — from `/proc/uptime`
- **Load 1m/5m/15m** — from `/proc/loadavg`
- **Processes** — running / total
- **Bandwidth** — combined RX+TX rate across all interfaces
- **RX/TX Rate** — per-direction rates (color-coded)
- **Total RX/TX** — cumulative bytes
- **IPs (24h)** — unique external IPs tracked by top talkers

## Interface Cards
- Packet rates shown as **pps/Kpps/Mpps** instead of raw cumulative packet counts
- **Error/drop rates** (per-second) shown when non-zero, replacing static counters

## Latency
- **P95 and P99 RTT** percentiles added to per-protocol stats (more useful than Min for detecting intermittent spikes)

## NAT
- **150ms debounce** on entry search input to prevent rendering jank during fast typing

## Speed Test
- Download/upload duration increased from **10s to 15s** — TCP slow-start needs more time to reach peak on fast links
- Upload chunk size increased from 1MB to **4MB** (fewer TCP reconnects = less slow-start overhead)
- Download read buffer increased from 128KB to **256KB**
