### PR TITLE
fix(map): use WAN GeoIP for map origin instead of hardcoded Germany

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,6 +3,9 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -111,23 +114,23 @@ func HostDetail(t *talkers.Tracker, ct *conntrack.Tracker, geoDB *geoip.DB) http
 		}
 
 		type hostDetail struct {
-			IP          string               `json:"ip"`
-			Hostname    string               `json:"hostname,omitempty"`
-			Country     string               `json:"country,omitempty"`
-			CountryName string               `json:"country_name,omitempty"`
-			City        string               `json:"city,omitempty"`
-			ASN         uint                 `json:"asn,omitempty"`
-			ASOrg       string               `json:"as_org,omitempty"`
-			TotalBytes  uint64               `json:"total_bytes"`
-			RxBytes     uint64               `json:"rx_bytes"`
-			TxBytes     uint64               `json:"tx_bytes"`
-			Packets     uint64               `json:"packets"`
-			RateBytes   float64              `json:"rate_bytes"`
-			RxRate      float64              `json:"rx_rate"`
-			TxRate      float64              `json:"tx_rate"`
+			IP          string                `json:"ip"`
+			Hostname    string                `json:"hostname,omitempty"`
+			Country     string                `json:"country,omitempty"`
+			CountryName string                `json:"country_name,omitempty"`
+			City        string                `json:"city,omitempty"`
+			ASN         uint                  `json:"asn,omitempty"`
+			ASOrg       string                `json:"as_org,omitempty"`
+			TotalBytes  uint64                `json:"total_bytes"`
+			RxBytes     uint64                `json:"rx_bytes"`
+			TxBytes     uint64                `json:"tx_bytes"`
+			Packets     uint64                `json:"packets"`
+			RateBytes   float64               `json:"rate_bytes"`
+			RxRate      float64               `json:"rx_rate"`
+			TxRate      float64               `json:"tx_rate"`
 			History     []talkers.BucketPoint `json:"history"`
 			Connections []conntrack.Entry     `json:"connections"`
-			Timestamp   int64                `json:"timestamp"`
+			Timestamp   int64                 `json:"timestamp"`
 		}
 
 		detail := hostDetail{
@@ -452,8 +455,142 @@ func DebugDNS() http.HandlerFunc {
 	}
 }
 
+// originResolver determines the WAN's geographic country code for the map
+// origin point.  It caches the result and refreshes periodically.
+type originResolver struct {
+	mu      sync.RWMutex
+	country string
+	last    time.Time
+	ttl     time.Duration
+	geoDB   *geoip.DB
+}
+
+func newOriginResolver(geoDB *geoip.DB) *originResolver {
+	return &originResolver{
+		geoDB: geoDB,
+		ttl:   10 * time.Minute,
+	}
+}
+
+// cgnatNet is RFC 6598 (100.64.0.0/10) used by Carrier-Grade NAT.
+var cgnatNet = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
+// isGlobalUnicast returns true if the IP is a globally routable unicast address.
+// Returns false for private, loopback, link-local, CGNAT, ULA (fc00::/7), etc.
+func isGlobalUnicast(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
+		return false
+	}
+	if cgnatNet.Contains(ip) {
+		return false
+	}
+	// IPv6 ULA (fc00::/7) — IsPrivate covers this in Go 1.17+, but be safe
+	if len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc {
+		return false
+	}
+	return ip.IsGlobalUnicast()
+}
+
+// resolve determines the origin country from the WAN interface IPs.
+// Priority: global IPv4 > global IPv6 > ip.ffmuc.net fallback.
+func (o *originResolver) resolve(c *collector.Collector) string {
+	o.mu.RLock()
+	if o.country != "" && time.Since(o.last) < o.ttl {
+		cc := o.country
+		o.mu.RUnlock()
+		return cc
+	}
+	o.mu.RUnlock()
+
+	cc := o.doResolve(c)
+
+	o.mu.Lock()
+	o.country = cc
+	o.last = time.Now()
+	o.mu.Unlock()
+
+	return cc
+}
+
+func (o *originResolver) doResolve(c *collector.Collector) string {
+	if o.geoDB == nil || !o.geoDB.Available() {
+		return ""
+	}
+
+	// Find WAN interface IPs
+	var wanIPv4, wanIPv6 string
+	for _, iface := range c.GetAll() {
+		if !iface.WAN {
+			continue
+		}
+		for _, addrStr := range iface.Addrs {
+			ip, _, err := net.ParseCIDR(addrStr)
+			if err != nil {
+				continue
+			}
+			if ip.To4() != nil && wanIPv4 == "" {
+				if isGlobalUnicast(ip) {
+					wanIPv4 = ip.String()
+				}
+			} else if ip.To4() == nil && wanIPv6 == "" {
+				if isGlobalUnicast(ip) {
+					wanIPv6 = ip.String()
+				}
+			}
+		}
+	}
+
+	// Try IPv4 first, then IPv6
+	for _, ipStr := range []string{wanIPv4, wanIPv6} {
+		if ipStr == "" {
+			continue
+		}
+		if r := o.geoDB.Lookup(ipStr); r != nil && r.Country != "" {
+			log.Printf("geo origin: %s -> %s", ipStr, r.Country)
+			return r.Country
+		}
+	}
+
+	// Fallback: no globally routable WAN IP found, query ip.ffmuc.net
+	log.Printf("geo origin: no globally routable WAN IP, trying ip.ffmuc.net")
+	if extIP := fetchExternalIP(); extIP != "" {
+		if r := o.geoDB.Lookup(extIP); r != nil && r.Country != "" {
+			log.Printf("geo origin: ip.ffmuc.net %s -> %s", extIP, r.Country)
+			return r.Country
+		}
+	}
+
+	return ""
+}
+
+// fetchExternalIP queries ip.ffmuc.net to get the public IP when all
+// WAN addresses are behind CGNAT or not globally routable.
+func fetchExternalIP() string {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("https://ip.ffmuc.net")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256))
+	if err != nil {
+		return ""
+	}
+	ip := strings.TrimSpace(string(body))
+	if net.ParseIP(ip) == nil {
+		return ""
+	}
+	return ip
+}
+
 // buildPayload assembles the JSON payload sent over the SSE stream.
-func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor) map[string]interface{} {
+func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, origin *originResolver) map[string]interface{} {
 	geo := t.GetGeoBreakdown()
 	payload := map[string]interface{}{
 		"interfaces":    c.GetAll(),
@@ -469,6 +606,11 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 		"load_avg":      readLoadAvg(),
 		"processes":     func() map[string]int { r, t := readProcessCount(); return map[string]int{"running": r, "total": t} }(),
 		"timestamp":     time.Now().UnixMilli(),
+	}
+	if origin != nil {
+		if cc := origin.resolve(c); cc != "" {
+			payload["origin_country"] = cc
+		}
 	}
 	if dp != nil {
 		payload["dns"] = dp.GetSummary()
@@ -495,7 +637,8 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 // backed up (e.g. hibernating laptop, congested link), only the most recent
 // payload is kept — preventing kernel send-buffer buildup (same backpressure
 // logic that PR #18 added to the old WebSocket handler).
-func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor) http.HandlerFunc {
+func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, geoDB *geoip.DB) http.HandlerFunc {
+	origin := newOriginResolver(geoDB)
 	return func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
@@ -526,7 +669,7 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 		}()
 
 		// Send initial payload immediately.
-		data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm))
+		data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, origin))
 		if err != nil {
 			close(sendCh)
 			return
@@ -545,7 +688,7 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 			case <-writerDone:
 				return
 			case <-ticker.C:
-				data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm))
+				data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, origin))
 				if err != nil {
 					continue
 				}

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func main() {
 	mux.HandleFunc("/api/debug/traceroute", handler.DebugTraceroute(dnsResolver))
 	mux.HandleFunc("/api/debug/dns", handler.DebugDNS())
 	mux.HandleFunc("/api/summary", handler.MenuBarSummary(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker))
-	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor))
+	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor, geoDB))
 	staticSub, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		log.Fatalf("Failed to create sub filesystem: %v", err)

--- a/static/app.js
+++ b/static/app.js
@@ -65,7 +65,7 @@
         } else if (tab === 'monitor') {
             var now = Date.now();
             if (force || !window._lastMapUpdate || now - window._lastMapUpdate > 5000) {
-                updateWorldMap(d.countries, bw);
+                updateWorldMap(d.countries, bw, d.origin_country);
                 window._lastMapUpdate = now;
             }
             if (force || !window._lastLatUpdate || now - window._lastLatUpdate > 2000) {
@@ -1172,7 +1172,7 @@
     // Country centroids (ISO alpha-2 → [lat, lon]) for map visualization.
     var countryCentroids = {"AF":[33,65],"AL":[41,20],"DZ":[28,3],"AO":[-12,17],"AR":[-34,-64],"AM":[40,45],"AU":[-25,134],"AT":[47,14],"AZ":[41,48],"BD":[24,90],"BY":[53,28],"BE":[51,4],"BJ":[9,2],"BO":[-17,-65],"BA":[44,18],"BW":[-22,24],"BR":[-10,-55],"BG":[43,25],"BF":[12,-2],"KH":[13,105],"CM":[6,12],"CA":[56,-96],"CF":[7,21],"TD":[15,19],"CL":[-30,-71],"CN":[35,105],"CO":[4,-72],"CD":[-3,24],"CG":[-1,15],"CR":[10,-84],"CI":[8,-5],"HR":[45,16],"CU":[22,-80],"CY":[35,33],"CZ":[50,15],"DK":[56,10],"DO":[19,-70],"EC":[-2,-78],"EG":[27,30],"SV":[14,-89],"EE":[59,26],"ET":[9,40],"FI":[64,26],"FR":[46,2],"GA":[0,12],"DE":[51,9],"GH":[8,-2],"GR":[39,22],"GT":[16,-90],"GN":[11,-12],"HT":[19,-72],"HN":[15,-87],"HU":[47,20],"IS":[65,-18],"IN":[21,78],"ID":[-5,120],"IR":[32,53],"IQ":[33,44],"IE":[53,-8],"IL":[31,35],"IT":[43,12],"JM":[18,-77],"JP":[36,138],"JO":[31,37],"KZ":[48,68],"KE":[-1,38],"KW":[29,48],"KG":[41,75],"LA":[18,105],"LV":[57,25],"LB":[34,36],"LY":[27,17],"LT":[56,24],"LU":[50,6],"MG":[-19,47],"MY":[4,109],"ML":[17,-4],"MX":[23,-102],"MD":[47,29],"MN":[48,106],"ME":[43,19],"MA":[32,-5],"MZ":[-18,35],"MM":[22,96],"NA":[-22,17],"NP":[28,84],"NL":[52,5],"NZ":[-41,174],"NI":[13,-85],"NE":[18,8],"NG":[10,8],"KP":[40,127],"NO":[62,10],"OM":[21,57],"PK":[30,70],"PA":[9,-80],"PY":[-23,-58],"PE":[-10,-76],"PH":[13,122],"PL":[52,20],"PT":[39,-8],"QA":[25,51],"RO":[46,25],"RU":[62,105],"RW":[-2,30],"SA":[24,45],"SN":[14,-14],"RS":[44,21],"SG":[1,104],"SK":[49,20],"SI":[46,15],"ZA":[-29,24],"KR":[36,128],"ES":[40,-4],"LK":[8,81],"SD":[13,30],"SE":[62,16],"CH":[47,8],"SY":[35,38],"TW":[24,121],"TJ":[39,69],"TZ":[-7,35],"TH":[15,101],"TN":[34,9],"TR":[39,35],"TM":[39,60],"UA":[49,32],"AE":[24,54],"GB":[54,-2],"US":[38,-97],"UY":[-33,-56],"UZ":[41,65],"VE":[8,-66],"VN":[16,108],"YE":[16,48],"ZM":[-14,28],"ZW":[-19,30]};
 
-    function updateWorldMap(countries, topBW) {
+    function updateWorldMap(countries, topBW, originCountry) {
         if (!countries || !countries.length) return;
         var wc = window._worldCountries || {};
 
@@ -1261,7 +1261,9 @@
 
         // Flow lines from top bandwidth talkers
         if (topBW && topBW.length) {
-            var center = proj(50, 10);
+            // Origin: use WAN GeoIP country, fall back to Germany (DE)
+            var oc = originCountry && countryCentroids[originCountry] ? originCountry : 'DE';
+            var center = proj(countryCentroids[oc][0], countryCentroids[oc][1]);
             svg += '<circle cx="' + center[0] + '" cy="' + center[1] + '" r="3" fill="' + flowColor + '" opacity="0.8"><animate attributeName="r" values="2;6;2" dur="2s" repeatCount="indefinite"/></circle>';
             // Find max rate for relative line thickness
             var maxRate = 1;


### PR DESCRIPTION
The world map flow lines now originate from the actual geographic location of the WAN interface instead of hardcoded Germany (50, 10).

**Detection priority:**
1. WAN interface globally routable IPv4
2. WAN interface globally routable IPv6
3. `ip.ffmuc.net` fallback (when all WAN IPs are CGNAT/RFC1918/ULA)

**Non-global detection covers:**
- RFC 1918 (10/8, 172.16/12, 192.168/16)
- CGNAT RFC 6598 (100.64/10)
- IPv6 ULA (fc00::/7)
- Loopback, link-local

Result is cached for 10 minutes. Frontend falls back to DE if no origin available.

**Files changed:**
- `handler/handler.go` — new `originResolver` with GeoIP + ip.ffmuc.net fallback
- `main.go` — pass `geoDB` to SSE handler
- `static/app.js` — use `origin_country` from SSE payload for map center