### PR TITLE
fix(talkers): filter local/private/self IPs from geo country breakdown

### DIFF
--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -679,6 +679,19 @@ func (t *Tracker) GetGeoBreakdown() *GeoBreakdown {
 	asns := make(map[uint]*asnAcc)
 
 	for ip, bytes := range ipTotals {
+		// Skip local/private/self IPs — they have no GeoIP data and
+		// inflate the "Unknown" category.
+		parsedIP := net.ParseIP(ip)
+		if parsedIP != nil && (parsedIP.IsPrivate() || parsedIP.IsLoopback() || parsedIP.IsLinkLocalUnicast()) {
+			continue
+		}
+		if parsedIP != nil && t.isLocalNet(parsedIP) {
+			continue
+		}
+		if _, isSelf := t.selfIPs[ip]; isSelf {
+			continue
+		}
+
 		geo := t.geoDB.Lookup(ip)
 
 		// Country aggregation


### PR DESCRIPTION
The GetGeoBreakdown function counted ALL IPs including private (RFC 1918), loopback, link-local, localNets, and router self-IPs. These have no GeoIP data and inflated the "Unknown (XX)" category.

Now applies the same filters as TopByBandwidth/TopByVolume: skip private, loopback, link-local, localNets subnets, and self-IPs.