### PR TITLE
feat: show city name in traffic, NAT, and host overlay

### DIFF
--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -65,9 +65,11 @@ type Entry struct {
 	OrigDPort   string `json:"orig_dport,omitempty"`
 	OrigSrcHost string `json:"orig_src_host,omitempty"`
 	OrigSrcGeo  string `json:"orig_src_geo,omitempty"`
+	OrigSrcCity string `json:"orig_src_city,omitempty"`
 	OrigSrcASN  string `json:"orig_src_asn,omitempty"`
 	OrigDstHost string `json:"orig_dst_host,omitempty"`
 	OrigDstGeo  string `json:"orig_dst_geo,omitempty"`
+	OrigDstCity string `json:"orig_dst_city,omitempty"`
 	OrigDstASN  string `json:"orig_dst_asn,omitempty"`
 
 	// Reply direction
@@ -91,6 +93,7 @@ type HostStat struct {
 	NATType     string `json:"nat_type,omitempty"`
 	Country     string `json:"country,omitempty"`
 	CountryName string `json:"country_name,omitempty"`
+	City        string `json:"city,omitempty"`
 	ASN         uint   `json:"asn,omitempty"`
 	ASOrg       string `json:"as_org,omitempty"`
 }
@@ -481,6 +484,7 @@ func (t *Tracker) enrichHosts(hosts []HostStat) {
 			if geo := t.geoDB.Lookup(ip); geo != nil {
 				hosts[i].Country = geo.Country
 				hosts[i].CountryName = geo.CountryName
+				hosts[i].City = geo.City
 				hosts[i].ASN = geo.ASN
 				hosts[i].ASOrg = geo.ASOrg
 			}
@@ -512,6 +516,7 @@ func (t *Tracker) enrichEntries(entries []Entry) {
 				if geo.Country != "" {
 					e.OrigSrcGeo = geo.Country
 				}
+				e.OrigSrcCity = geo.City
 				if geo.ASOrg != "" {
 					e.OrigSrcASN = fmt.Sprintf("AS%d %s", geo.ASN, geo.ASOrg)
 				}
@@ -520,6 +525,7 @@ func (t *Tracker) enrichEntries(entries []Entry) {
 				if geo.Country != "" {
 					e.OrigDstGeo = geo.Country
 				}
+				e.OrigDstCity = geo.City
 				if geo.ASOrg != "" {
 					e.OrigDstASN = fmt.Sprintf("AS%d %s", geo.ASN, geo.ASOrg)
 				}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -143,6 +143,7 @@ func HostDetail(t *talkers.Tracker, ct *conntrack.Tracker, geoDB *geoip.DB) http
 			detail.Hostname = totals.Hostname
 			detail.Country = totals.Country
 			detail.CountryName = totals.CountryName
+			detail.City = totals.City
 			detail.ASN = totals.ASN
 			detail.ASOrg = totals.ASOrg
 			detail.TotalBytes = totals.TotalBytes
@@ -154,8 +155,8 @@ func HostDetail(t *talkers.Tracker, ct *conntrack.Tracker, geoDB *geoip.DB) http
 			detail.TxRate = totals.TxRate
 		}
 
-		// GeoIP city (not in TalkerStat)
-		if geoDB != nil && geoDB.Available() {
+		// GeoIP fallback (in case TalkerStat had no geo data)
+		if geoDB != nil && geoDB.Available() && detail.Country == "" {
 			if geo := geoDB.Lookup(ip); geo != nil {
 				detail.City = geo.City
 				if detail.Country == "" {

--- a/static/app.js
+++ b/static/app.js
@@ -496,8 +496,9 @@
             var pct = ((t[vk] / mx) * 100).toFixed(1);
             var flag = t.country ? countryFlag(t.country) + ' ' : '';
             var geo = '';
-            if (t.as_org) geo = '<span class="hostname">' + flag + (t.country_name || '') + ' &middot; AS' + (t.asn || '') + ' ' + t.as_org + '</span>';
-            else if (t.country_name) geo = '<span class="hostname">' + flag + t.country_name + '</span>';
+            var geoName = (t.city && t.country_name) ? t.city + ', ' + t.country_name : (t.country_name || '');
+            if (t.as_org) geo = '<span class="hostname">' + flag + geoName + ' &middot; AS' + (t.asn || '') + ' ' + t.as_org + '</span>';
+            else if (geoName) geo = '<span class="hostname">' + flag + geoName + '</span>';
             var host = t.hostname && t.hostname !== t.ip
                 ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span><span class="hostname">' + t.hostname + '</span>' + geo
                 : '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span>' + geo;
@@ -1062,8 +1063,9 @@
             var display = useBytes ? formatBytes(val) : val.toLocaleString();
             var flag = host.country ? countryFlag(host.country) + ' ' : '';
             var geo = '';
-            if (host.as_org) geo = '<span class="hostname">' + flag + (host.country_name || '') + ' &middot; AS' + (host.asn || '') + ' ' + host.as_org + '</span>';
-            else if (host.country_name) geo = '<span class="hostname">' + flag + host.country_name + '</span>';
+            var geoName = (host.city && host.country_name) ? host.city + ', ' + host.country_name : (host.country_name || '');
+            if (host.as_org) geo = '<span class="hostname">' + flag + geoName + ' &middot; AS' + (host.asn || '') + ' ' + host.as_org + '</span>';
+            else if (geoName) geo = '<span class="hostname">' + flag + geoName + '</span>';
             var cell = host.hostname
                 ? '<span class="ip-cell ip-clickable" data-ip="' + host.ip + '">' + host.ip + '</span><span class="hostname">' + host.hostname + '</span>' + geo
                 : '<span class="ip-cell ip-clickable" data-ip="' + host.ip + '">' + host.ip + '</span>' + geo;
@@ -1125,11 +1127,12 @@
             var replDstHL = (e.repl_dst !== e.orig_src) ? ' style="color:var(--rx);font-weight:600"' : '';
 
             // Helper: render IP cell with optional enrichment below
-            function ipCell(addr, host, geo, asn, hlStyle) {
+            function ipCell(addr, host, geo, city, asn, hlStyle) {
                 var s = '<td' + (hlStyle || '') + '><div style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap">' + addr + '</div>';
                 var info = [];
                 if (host) info.push(host);
-                if (geo) info.push(countryFlag(geo) + ' ' + geo);
+                if (city && geo) info.push(countryFlag(geo) + ' ' + city + ', ' + geo);
+                else if (geo) info.push(countryFlag(geo) + ' ' + geo);
                 if (asn) info.push(asn);
                 if (info.length) s += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px">' + info.join(' · ') + '</div>';
                 s += '</td>';
@@ -1139,8 +1142,8 @@
             h += '<tr>';
             h += '<td style="font-size:12px;font-weight:500">' + (e.protocol || '').toUpperCase() + '</td>';
             h += '<td>' + (e.state ? '<span class="nat-state-badge ' + stateClass + '">' + e.state + '</span>' : '<span style="color:var(--text-2)">—</span>') + '</td>';
-            h += ipCell(origSrc, e.orig_src_host, e.orig_src_geo, e.orig_src_asn, '');
-            h += ipCell(origDst, e.orig_dst_host, e.orig_dst_geo, e.orig_dst_asn, '');
+            h += ipCell(origSrc, e.orig_src_host, e.orig_src_geo, e.orig_src_city, e.orig_src_asn, '');
+            h += ipCell(origDst, e.orig_dst_host, e.orig_dst_geo, e.orig_dst_city, e.orig_dst_asn, '');
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replSrcHL + '>' + replSrc + '</td>';
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replDstHL + '>' + replDst + '</td>';
             h += '<td><span class="nat-badge ' + e.nat_type + '">' + (e.nat_type || 'none').toUpperCase() + '</span></td>';
@@ -1911,9 +1914,9 @@
         var flag = d.country ? countryFlag(d.country) + ' ' : '';
         titleEl.textContent = flag + (d.hostname || d.ip);
         var sub = d.ip;
-        if (d.country_name) sub += ' \u00b7 ' + d.country_name;
+        if (d.city && d.country_name) sub += ' \u00b7 ' + d.city + ', ' + d.country_name;
+        else if (d.country_name) sub += ' \u00b7 ' + d.country_name;
         if (d.as_org) sub += ' \u00b7 AS' + (d.asn || '') + ' ' + d.as_org;
-        if (d.city) sub += ' \u00b7 ' + d.city;
         subtitleEl.textContent = sub;
 
         var h = '';

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -38,6 +38,7 @@ type TalkerStat struct {
 	Hostname    string  `json:"hostname"`
 	Country     string  `json:"country,omitempty"`
 	CountryName string  `json:"country_name,omitempty"`
+	City        string  `json:"city,omitempty"`
 	Latitude    float64 `json:"lat,omitempty"`
 	Longitude   float64 `json:"lon,omitempty"`
 	ASN         uint    `json:"asn,omitempty"`
@@ -713,6 +714,7 @@ func (t *Tracker) enrichGeo(s *TalkerStat) {
 	}
 	s.Country = geo.Country
 	s.CountryName = geo.CountryName
+	s.City = geo.City
 	s.Latitude = geo.Latitude
 	s.Longitude = geo.Longitude
 	s.ASN = geo.ASN


### PR DESCRIPTION
## Summary

Adds city-level location display to IPs shown in traffic tables, NAT tables, and the host detail overlay. Uses the existing shared GeoIP cache everywhere -- no duplicate lookups.

## Display format

- **With city:** `Frankfurt, Germany · AS13335 Cloudflare`
- **Without city (fallback):** `Germany · AS13335 Cloudflare`
- **Without ASN:** `Frankfurt, Germany` or just `Germany`

## Go changes

| File | Change |
|------|--------|
| `talkers/talkers.go` | Added `City` field to `TalkerStat`, populated in `enrichGeo()` |
| `conntrack/conntrack.go` | Added `City` to `HostStat`, `OrigSrcCity`/`OrigDstCity` to `Entry`, populated in `enrichHosts()` and `enrichEntries()` |
| `handler/handler.go` | Copy `City` from `TalkerStat` in `HostDetail`, GeoIP fallback only fires when country is missing |

All GeoIP lookups go through the same `geoDB.Lookup()` which uses the shared LRU cache -- no redundant MMDB reads.

## JS changes

City is displayed consistently in 4 locations:

1. **Top bandwidth/volume talker tables** (`renderTalkers`)
2. **NAT LAN clients / remote destinations** (`renderHostTable`)
3. **NAT entry table** (`ipCell` helper -- added `city` parameter)
4. **Host detail modal subtitle** (`renderHostModal`)

All locations use the same pattern: `city + ', ' + country_name` when city is non-empty, falling back to just `country_name`.
