### PR TITLE
refactor: deduplicate JS charts and Go wifi rate calculation (-133 lines)

### DIFF
--- a/omada/omada.go
+++ b/omada/omada.go
@@ -35,12 +35,10 @@ type Client struct {
 	loggedIn  bool
 	csrfToken string
 	lastPoll  time.Time
-	prevAP    map[string]byteSnap
-	prevCli   map[string]byteSnap
-	prevSSID  map[string]byteSnap
+	prevAP    map[string]wifi.ByteSnap
+	prevCli   map[string]wifi.ByteSnap
+	prevSSID  map[string]wifi.ByteSnap
 }
-
-type byteSnap struct{ tx, rx int64 }
 
 // New creates an Omada controller client.
 func New(baseURL, user, pass, siteName string, pollInterval time.Duration) *Client {
@@ -137,17 +135,17 @@ func (c *Client) poll() {
 	}
 	sum := c.buildSummary(devices, clients, dt)
 
-	newAP := make(map[string]byteSnap, len(sum.APs))
+	newAP := make(map[string]wifi.ByteSnap, len(sum.APs))
 	for _, ap := range sum.APs {
-		newAP[ap.MAC] = byteSnap{tx: ap.TxBytes, rx: ap.RxBytes}
+		newAP[ap.MAC] = wifi.ByteSnap{Tx: ap.TxBytes, Rx: ap.RxBytes}
 	}
-	newSSID := make(map[string]byteSnap, len(sum.SSIDs))
+	newSSID := make(map[string]wifi.ByteSnap, len(sum.SSIDs))
 	for _, s := range sum.SSIDs {
-		newSSID[s.Name] = byteSnap{tx: s.TxBytes, rx: s.RxBytes}
+		newSSID[s.Name] = wifi.ByteSnap{Tx: s.TxBytes, Rx: s.RxBytes}
 	}
-	newCli := make(map[string]byteSnap, len(sum.Clients))
+	newCli := make(map[string]wifi.ByteSnap, len(sum.Clients))
 	for _, cl := range sum.Clients {
-		newCli[cl.MAC] = byteSnap{tx: cl.TxBytes, rx: cl.RxBytes}
+		newCli[cl.MAC] = wifi.ByteSnap{Tx: cl.TxBytes, Rx: cl.RxBytes}
 	}
 
 	c.mu.Lock()
@@ -393,8 +391,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		}
 		if dt > 0 {
 			if prev, ok := c.prevAP[d.MAC]; ok {
-				ap.TxRate = clamp(float64(d.TxBytes-prev.tx) / dt)
-				ap.RxRate = clamp(float64(d.RxBytes-prev.rx) / dt)
+				ap.TxRate, ap.RxRate = wifi.ComputeRates(d.TxBytes, d.RxBytes, prev, dt)
 			}
 		}
 		aps = append(aps, ap)
@@ -430,8 +427,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		s := wifi.SSIDStat{Name: name, NumClients: a.n, TxBytes: a.tx, RxBytes: a.rx}
 		if dt > 0 {
 			if prev, ok := c.prevSSID[name]; ok {
-				s.TxRate = clamp(float64(a.tx-prev.tx) / dt)
-				s.RxRate = clamp(float64(a.rx-prev.rx) / dt)
+				s.TxRate, s.RxRate = wifi.ComputeRates(a.tx, a.rx, prev, dt)
 			}
 		}
 		ssids = append(ssids, s)
@@ -460,8 +456,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		}
 		if dt > 0 {
 			if prev, ok := c.prevCli[cl.MAC]; ok {
-				ci.TxRate = clamp(float64(cl.TxBytes-prev.tx) / dt)
-				ci.RxRate = clamp(float64(cl.RxBytes-prev.rx) / dt)
+				ci.TxRate, ci.RxRate = wifi.ComputeRates(cl.TxBytes, cl.RxBytes, prev, dt)
 			}
 		}
 		cis = append(cis, ci)
@@ -491,13 +486,6 @@ func radioName(id int) string {
 	default:
 		return ""
 	}
-}
-
-func clamp(r float64) float64 {
-	if r < 0 {
-		return 0
-	}
-	return r
 }
 
 // String returns a debug representation.

--- a/static/app.js
+++ b/static/app.js
@@ -593,20 +593,7 @@
         var order = ['TCP', 'UDP', 'ICMP', 'Other'], labels = [], values = [], colors = [];
         for (var i = 0; i < order.length; i++) { if (data[order[i]]) { labels.push(order[i]); values.push(data[order[i]]); colors.push(protoColors[order[i]]); } }
         for (var k in data) { if (order.indexOf(k) === -1) { labels.push(k); values.push(data[k]); colors.push('#71717a'); } }
-        protoChart.data.labels = labels;
-        protoChart.data.datasets[0].data = values;
-        protoChart.data.datasets[0].backgroundColor = colors;
-        protoChart.update('none');
-        var total = 0; for (var i = 0; i < values.length; i++) total += values[i];
-        var h = '';
-        for (var i = 0; i < labels.length; i++) {
-            var pct = total > 0 ? ((values[i] / total) * 100).toFixed(1) : '0.0';
-            h += '<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">';
-            h += '<div style="width:10px;height:10px;border-radius:2px;background:' + colors[i] + ';flex-shrink:0"></div>';
-            h += '<div><div style="font-size:13px;font-weight:600;color:var(--text-0)">' + labels[i] + '</div>';
-            h += '<div style="font-size:11px;color:var(--text-2)">' + formatBytes(values[i]) + ' &middot; ' + pct + '%</div></div></div>';
-        }
-        document.getElementById('protoLegend').innerHTML = h;
+        updateSimpleDoughnut(protoChart, document.getElementById('protoLegend'), labels, values, colors);
     }
 
     function updateCountries(countries) {
@@ -618,55 +605,16 @@
             legend.innerHTML = '<div style="text-align:center;color:var(--text-2);font-size:12px;padding:8px">No data</div>';
             return;
         }
-        // Chart: top 8 + rest
-        var chartMax = 8, chartLabels = [], chartValues = [], chartColors = [], rest = 0;
-        var total = 0;
-        for (var i = 0; i < countries.length; i++) total += countries[i].bytes;
-        for (var i = 0; i < countries.length; i++) {
-            if (i < chartMax) {
-                var flag = countryFlag(countries[i].country);
-                chartLabels.push(flag + ' ' + (countries[i].country_name || countries[i].country));
-                chartValues.push(countries[i].bytes);
-                chartColors.push(geoChartPalette[i % geoChartPalette.length]);
-            } else { rest += countries[i].bytes; }
-        }
-        if (rest > 0) { chartLabels.push('Others'); chartValues.push(rest); chartColors.push('#52525b'); }
-        countryChart.data.labels = chartLabels;
-        countryChart.data.datasets[0].data = chartValues;
-        countryChart.data.datasets[0].backgroundColor = chartColors;
-        countryChart.update('none');
-        // Legend: top entries
-        var lh = '';
-        var legendCount = Math.min(countries.length, chartMax);
-        for (var i = 0; i < legendCount; i++) {
-            var pct = total > 0 ? ((countries[i].bytes / total) * 100).toFixed(1) : '0.0';
-            var flag = countryFlag(countries[i].country);
-            lh += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">';
-            lh += '<div style="width:8px;height:8px;border-radius:2px;background:' + chartColors[i] + ';flex-shrink:0"></div>';
-            lh += '<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-0);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + flag + ' ' + (countries[i].country_name || countries[i].country) + '</div>';
-            lh += '<div style="font-size:10px;color:var(--text-2)">' + formatBytes(countries[i].bytes) + ' &middot; ' + pct + '%</div></div></div>';
-        }
-        if (rest > 0) {
-            var rpct = total > 0 ? ((rest / total) * 100).toFixed(1) : '0.0';
-            lh += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">';
-            lh += '<div style="width:8px;height:8px;border-radius:2px;background:#52525b;flex-shrink:0"></div>';
-            lh += '<div style="flex:1"><div style="font-size:12px;font-weight:500;color:var(--text-0)">Others</div>';
-            lh += '<div style="font-size:10px;color:var(--text-2)">' + formatBytes(rest) + ' &middot; ' + rpct + '%</div></div></div>';
-        }
-        legend.innerHTML = lh;
-        // Detail table
-        var mx = countries[0].bytes || 1, h = '';
-        for (var i = 0; i < countries.length; i++) {
-            var c = countries[i];
-            var pct = ((c.bytes / mx) * 100).toFixed(1);
-            var flag = countryFlag(c.country);
-            h += '<tr><td><span class="' + rankClass(i) + '">' + (i + 1) + '</span></td>';
-            h += '<td>' + flag + ' <span style="font-weight:500">' + (c.country_name || c.country) + '</span> <span class="hostname" style="display:inline">' + c.country + '</span></td>';
-            h += '<td style="font-variant-numeric:tabular-nums">' + c.connections + '</td>';
-            h += '<td style="white-space:nowrap">' + formatBytes(c.bytes) + '</td>';
-            h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill bw" style="width:' + pct + '%"></div></td></tr>';
-        }
-        tb.innerHTML = h;
+        fillDoughnut(countryChart, legend, countries,
+            function(c) { return countryFlag(c.country) + ' ' + (c.country_name || c.country); },
+            function(c) { return c.bytes; },
+            function(v) { return formatBytes(v); }
+        );
+        fillDetailTable('countryTable', countries,
+            function(c) { return countryFlag(c.country) + ' <span style="font-weight:500">' + (c.country_name || c.country) + '</span> <span class="hostname" style="display:inline">' + c.country + '</span>'; },
+            function(c) { return c.bytes; },
+            function(v) { return formatBytes(v); }, 'bw'
+        );
     }
 
     var ipvColors = { 'IPv4': '#60a5fa', 'IPv6': '#a855f7' };
@@ -678,22 +626,10 @@
             legend.innerHTML = '<div style="text-align:center;color:var(--text-2);font-size:12px;padding:8px">No data</div>';
             return;
         }
-        var labels = [], values = [], colors = [], total = 0;
-        if (data['IPv4']) { labels.push('IPv4'); values.push(data['IPv4']); colors.push(ipvColors['IPv4']); total += data['IPv4']; }
-        if (data['IPv6']) { labels.push('IPv6'); values.push(data['IPv6']); colors.push(ipvColors['IPv6']); total += data['IPv6']; }
-        ipvChart.data.labels = labels;
-        ipvChart.data.datasets[0].data = values;
-        ipvChart.data.datasets[0].backgroundColor = colors;
-        ipvChart.update('none');
-        var h = '';
-        for (var i = 0; i < labels.length; i++) {
-            var pct = total > 0 ? ((values[i] / total) * 100).toFixed(1) : '0.0';
-            h += '<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">';
-            h += '<div style="width:10px;height:10px;border-radius:2px;background:' + colors[i] + ';flex-shrink:0"></div>';
-            h += '<div><div style="font-size:13px;font-weight:600;color:var(--text-0)">' + labels[i] + '</div>';
-            h += '<div style="font-size:11px;color:var(--text-2)">' + formatBytes(values[i]) + ' &middot; ' + pct + '%</div></div></div>';
-        }
-        legend.innerHTML = h;
+        var labels = [], values = [], colors = [];
+        if (data['IPv4']) { labels.push('IPv4'); values.push(data['IPv4']); colors.push(ipvColors['IPv4']); }
+        if (data['IPv6']) { labels.push('IPv6'); values.push(data['IPv6']); colors.push(ipvColors['IPv6']); }
+        updateSimpleDoughnut(ipvChart, legend, labels, values, colors);
     }
 
     function updateASNs(asns) {
@@ -705,52 +641,16 @@
             legend.innerHTML = '<div style="text-align:center;color:var(--text-2);font-size:12px;padding:8px">No data</div>';
             return;
         }
-        // Chart: top 8 + rest
-        var chartMax = 8, chartLabels = [], chartValues = [], chartColors = [], rest = 0;
-        var total = 0;
-        for (var i = 0; i < asns.length; i++) total += asns[i].bytes;
-        for (var i = 0; i < asns.length; i++) {
-            if (i < chartMax) {
-                chartLabels.push((asns[i].as_org || 'AS' + asns[i].asn));
-                chartValues.push(asns[i].bytes);
-                chartColors.push(geoChartPalette[i % geoChartPalette.length]);
-            } else { rest += asns[i].bytes; }
-        }
-        if (rest > 0) { chartLabels.push('Others'); chartValues.push(rest); chartColors.push('#52525b'); }
-        asnChart.data.labels = chartLabels;
-        asnChart.data.datasets[0].data = chartValues;
-        asnChart.data.datasets[0].backgroundColor = chartColors;
-        asnChart.update('none');
-        // Legend: top entries
-        var lh = '';
-        var legendCount = Math.min(asns.length, chartMax);
-        for (var i = 0; i < legendCount; i++) {
-            var pct = total > 0 ? ((asns[i].bytes / total) * 100).toFixed(1) : '0.0';
-            lh += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">';
-            lh += '<div style="width:8px;height:8px;border-radius:2px;background:' + chartColors[i] + ';flex-shrink:0"></div>';
-            lh += '<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-0);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + (asns[i].as_org || 'Unknown') + '</div>';
-            lh += '<div style="font-size:10px;color:var(--text-2)">AS' + asns[i].asn + ' &middot; ' + formatBytes(asns[i].bytes) + ' &middot; ' + pct + '%</div></div></div>';
-        }
-        if (rest > 0) {
-            var rpct = total > 0 ? ((rest / total) * 100).toFixed(1) : '0.0';
-            lh += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">';
-            lh += '<div style="width:8px;height:8px;border-radius:2px;background:#52525b;flex-shrink:0"></div>';
-            lh += '<div style="flex:1"><div style="font-size:12px;font-weight:500;color:var(--text-0)">Others</div>';
-            lh += '<div style="font-size:10px;color:var(--text-2)">' + formatBytes(rest) + ' &middot; ' + rpct + '%</div></div></div>';
-        }
-        legend.innerHTML = lh;
-        // Detail table
-        var mx = asns[0].bytes || 1, h = '';
-        for (var i = 0; i < asns.length; i++) {
-            var a = asns[i];
-            var pct = ((a.bytes / mx) * 100).toFixed(1);
-            h += '<tr><td><span class="' + rankClass(i) + '">' + (i + 1) + '</span></td>';
-            h += '<td><span style="font-weight:500">' + (a.as_org || 'Unknown') + '</span> <span class="hostname" style="display:inline">AS' + a.asn + '</span></td>';
-            h += '<td style="font-variant-numeric:tabular-nums">' + a.connections + '</td>';
-            h += '<td style="white-space:nowrap">' + formatBytes(a.bytes) + '</td>';
-            h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill vol" style="width:' + pct + '%"></div></td></tr>';
-        }
-        tb.innerHTML = h;
+        fillDoughnut(asnChart, legend, asns,
+            function(a) { return a.as_org || 'AS' + a.asn; },
+            function(a) { return a.bytes; },
+            function(v) { return formatBytes(v); }
+        );
+        fillDetailTable('asnTable', asns,
+            function(a) { return '<span style="font-weight:500">' + (a.as_org || 'Unknown') + '</span> <span class="hostname" style="display:inline">AS' + a.asn + '</span>'; },
+            function(a) { return a.bytes; },
+            function(v) { return formatBytes(v); }, 'vol'
+        );
     }
 
     var sse = null;
@@ -1570,62 +1470,46 @@
             var icmpV6 = t.icmp_v6 && t.icmp_v6.length > 1 ? t.icmp_v6 : null;
             var icmpLegacy = t.icmp && t.icmp.length > 1 ? t.icmp : null;
 
-            if (icmpV4 && icmpV6) {
-                h += '<div style="margin-bottom:10px">';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">ICMP Ping <span style="color:#22d3ee">IPv4</span></div>';
-                h += renderLatencyChart(icmpV4, '#22d3ee', '#22d3ee');
-                h += '</div>';
-                h += '<div style="margin-bottom:10px">';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">ICMP Ping <span style="color:#34d399">IPv6</span></div>';
-                h += renderLatencyChart(icmpV6, '#34d399', '#34d399');
-                h += '</div>';
-            } else if (icmpV4) {
-                h += '<div style="margin-bottom:10px">';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">ICMP Ping (IPv4)</div>';
-                h += renderLatencyChart(icmpV4, '#22d3ee', '#22d3ee');
-                h += '</div>';
-            } else if (icmpV6) {
-                h += '<div style="margin-bottom:10px">';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">ICMP Ping (IPv6)</div>';
-                h += renderLatencyChart(icmpV6, '#34d399', '#34d399');
-                h += '</div>';
-            } else if (icmpLegacy) {
-                h += '<div style="margin-bottom:10px">';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">ICMP Ping</div>';
-                h += renderLatencyChart(icmpLegacy, '#22d3ee', '#22d3ee');
-                h += '</div>';
+            // Helper: render a latency chart section with label
+            function latencySection(label, v4Data, v6Data, legacyData, v4Color, v6Color, marginBottom) {
+                var mb = marginBottom ? 'margin-bottom:10px' : '';
+                var out = '';
+                if (v4Data && v6Data) {
+                    out += '<div style="margin-bottom:10px">';
+                    out += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">' + label + ' <span style="color:' + v4Color + '">IPv4</span></div>';
+                    out += renderLatencyChart(v4Data, v4Color, v4Color);
+                    out += '</div>';
+                    out += '<div style="' + mb + '">';
+                    out += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">' + label + ' <span style="color:' + v6Color + '">IPv6</span></div>';
+                    out += renderLatencyChart(v6Data, v6Color, v6Color);
+                    out += '</div>';
+                } else if (v4Data) {
+                    out += '<div style="' + mb + '">';
+                    out += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">' + label + ' (IPv4)</div>';
+                    out += renderLatencyChart(v4Data, v4Color, v4Color);
+                    out += '</div>';
+                } else if (v6Data) {
+                    out += '<div style="' + mb + '">';
+                    out += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">' + label + ' (IPv6)</div>';
+                    out += renderLatencyChart(v6Data, v6Color, v6Color);
+                    out += '</div>';
+                } else if (legacyData) {
+                    out += '<div style="' + mb + '">';
+                    out += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">' + label + '</div>';
+                    out += renderLatencyChart(legacyData, v4Color, v4Color);
+                    out += '</div>';
+                }
+                return out;
             }
+
+            h += latencySection('ICMP Ping', icmpV4, icmpV6, icmpLegacy, '#22d3ee', '#34d399', true);
 
             // HTTPS charts — show v4 and v6 separately if dual-stack
             var httpsV4 = t.https_v4 && t.https_v4.length > 1 ? t.https_v4 : null;
             var httpsV6 = t.https_v6 && t.https_v6.length > 1 ? t.https_v6 : null;
             var httpsLegacy = t.https && t.https.length > 1 ? t.https : null;
 
-            if (httpsV4 && httpsV6) {
-                h += '<div style="margin-bottom:10px">';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">HTTPS <span style="color:#a78bfa">IPv4</span></div>';
-                h += renderLatencyChart(httpsV4, '#a78bfa', '#a78bfa');
-                h += '</div>';
-                h += '<div>';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">HTTPS <span style="color:#fb923c">IPv6</span></div>';
-                h += renderLatencyChart(httpsV6, '#fb923c', '#fb923c');
-                h += '</div>';
-            } else if (httpsV4) {
-                h += '<div>';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">HTTPS (IPv4)</div>';
-                h += renderLatencyChart(httpsV4, '#a78bfa', '#a78bfa');
-                h += '</div>';
-            } else if (httpsV6) {
-                h += '<div>';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">HTTPS (IPv6)</div>';
-                h += renderLatencyChart(httpsV6, '#fb923c', '#fb923c');
-                h += '</div>';
-            } else if (httpsLegacy) {
-                h += '<div>';
-                h += '<div style="font-size:11px;font-weight:600;color:var(--text-2);margin-bottom:4px">HTTPS</div>';
-                h += renderLatencyChart(httpsLegacy, '#a78bfa', '#a78bfa');
-                h += '</div>';
-            }
+            h += latencySection('HTTPS', httpsV4, httpsV6, httpsLegacy, '#a78bfa', '#fb923c', false);
 
             h += '</div>';
         }

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -24,7 +24,7 @@ type Client struct {
 	interval   time.Duration
 	httpClient *http.Client
 	mu         sync.RWMutex
-	summary    *Summary
+	summary    *wifi.Summary
 	stopCh     chan struct{}
 
 	// API variant detection
@@ -35,20 +35,10 @@ type Client struct {
 
 	// rate tracking
 	lastPoll time.Time
-	prevAP   map[string]byteSnap // keyed by MAC
-	prevSSID map[string]byteSnap // keyed by SSID name
-	prevCli  map[string]byteSnap // keyed by client MAC
+	prevAP   map[string]wifi.ByteSnap // keyed by MAC
+	prevSSID map[string]wifi.ByteSnap // keyed by SSID name
+	prevCli  map[string]wifi.ByteSnap // keyed by client MAC
 }
-
-type byteSnap struct {
-	tx int64
-	rx int64
-}
-
-type APInfo = wifi.APInfo
-type SSIDStat = wifi.SSIDStat
-type ClientInfo = wifi.ClientInfo
-type Summary = wifi.Summary
 
 func New(baseURL, user, pass, site string, pollInterval time.Duration) *Client {
 	if site == "" {
@@ -144,17 +134,17 @@ func (c *Client) poll() {
 	sum := c.buildSummary(devices, clients, dt)
 
 	// Store current counters for next delta
-	newAP := make(map[string]byteSnap, len(sum.APs))
+	newAP := make(map[string]wifi.ByteSnap, len(sum.APs))
 	for _, ap := range sum.APs {
-		newAP[ap.MAC] = byteSnap{tx: ap.TxBytes, rx: ap.RxBytes}
+		newAP[ap.MAC] = wifi.ByteSnap{Tx: ap.TxBytes, Rx: ap.RxBytes}
 	}
-	newSSID := make(map[string]byteSnap, len(sum.SSIDs))
+	newSSID := make(map[string]wifi.ByteSnap, len(sum.SSIDs))
 	for _, s := range sum.SSIDs {
-		newSSID[s.Name] = byteSnap{tx: s.TxBytes, rx: s.RxBytes}
+		newSSID[s.Name] = wifi.ByteSnap{Tx: s.TxBytes, Rx: s.RxBytes}
 	}
-	newCli := make(map[string]byteSnap, len(sum.Clients))
+	newCli := make(map[string]wifi.ByteSnap, len(sum.Clients))
 	for _, cl := range sum.Clients {
-		newCli[cl.MAC] = byteSnap{tx: cl.TxBytes, rx: cl.RxBytes}
+		newCli[cl.MAC] = wifi.ByteSnap{Tx: cl.TxBytes, Rx: cl.RxBytes}
 	}
 
 	c.mu.Lock()
@@ -327,8 +317,8 @@ func (c *Client) fetchClients() ([]rawClient, error) {
 	return cr.Data, nil
 }
 
-func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float64) *Summary {
-	var aps []APInfo
+func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float64) *wifi.Summary {
+	var aps []wifi.APInfo
 	for _, d := range devices {
 		if d.Type != "uap" {
 			continue
@@ -337,7 +327,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		if d.State == 1 {
 			status = "connected"
 		}
-		ap := APInfo{
+		ap := wifi.APInfo{
 			Name:       d.Name,
 			Model:      d.Model,
 			MAC:        d.MAC,
@@ -351,14 +341,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		}
 		if dt > 0 {
 			if prev, ok := c.prevAP[d.MAC]; ok {
-				ap.TxRate = float64(d.TxBytes-prev.tx) / dt
-				ap.RxRate = float64(d.RxBytes-prev.rx) / dt
-				if ap.TxRate < 0 {
-					ap.TxRate = 0
-				}
-				if ap.RxRate < 0 {
-					ap.RxRate = 0
-				}
+				ap.TxRate, ap.RxRate = wifi.ComputeRates(d.TxBytes, d.RxBytes, prev, dt)
 			}
 		}
 		aps = append(aps, ap)
@@ -389,19 +372,12 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		}
 	}
 
-	var ssids []SSIDStat
+	var ssids []wifi.SSIDStat
 	for name, a := range ssidMap {
-		s := SSIDStat{Name: name, NumClients: a.count, TxBytes: a.txBytes, RxBytes: a.rxBytes}
+		s := wifi.SSIDStat{Name: name, NumClients: a.count, TxBytes: a.txBytes, RxBytes: a.rxBytes}
 		if dt > 0 {
 			if prev, ok := c.prevSSID[name]; ok {
-				s.TxRate = float64(a.txBytes-prev.tx) / dt
-				s.RxRate = float64(a.rxBytes-prev.rx) / dt
-				if s.TxRate < 0 {
-					s.TxRate = 0
-				}
-				if s.RxRate < 0 {
-					s.RxRate = 0
-				}
+				s.TxRate, s.RxRate = wifi.ComputeRates(a.txBytes, a.rxBytes, prev, dt)
 			}
 		}
 		ssids = append(ssids, s)
@@ -415,12 +391,12 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 	}
 
 	// Build per-client list (wireless only), sorted by total traffic descending
-	var clientInfos []ClientInfo
+	var clientInfos []wifi.ClientInfo
 	for _, cl := range clients {
 		if cl.IsWired {
 			continue
 		}
-		ci := ClientInfo{
+		ci := wifi.ClientInfo{
 			MAC:      cl.MAC,
 			Hostname: cl.Hostname,
 			IP:       cl.IP,
@@ -435,14 +411,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		}
 		if dt > 0 {
 			if prev, ok := c.prevCli[cl.MAC]; ok {
-				ci.TxRate = float64(cl.TxBytes-prev.tx) / dt
-				ci.RxRate = float64(cl.RxBytes-prev.rx) / dt
-				if ci.TxRate < 0 {
-					ci.TxRate = 0
-				}
-				if ci.RxRate < 0 {
-					ci.RxRate = 0
-				}
+				ci.TxRate, ci.RxRate = wifi.ComputeRates(cl.TxBytes, cl.RxBytes, prev, dt)
 			}
 		}
 		clientInfos = append(clientInfos, ci)
@@ -452,7 +421,7 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 			(clientInfos[j].TxBytes + clientInfos[j].RxBytes)
 	})
 
-	return &Summary{
+	return &wifi.Summary{
 		ProviderName: "UniFi",
 		TotalAPs:     len(aps),
 		TotalClients: totalWireless,

--- a/wifi/wifi.go
+++ b/wifi/wifi.go
@@ -61,3 +61,29 @@ type ClientInfo struct {
 	TxRate   float64 `json:"tx_rate"`
 	RxRate   float64 `json:"rx_rate"`
 }
+
+// ByteSnap stores TX/RX byte counters for rate delta computation.
+type ByteSnap struct {
+	Tx int64
+	Rx int64
+}
+
+// Clamp returns r if r >= 0, otherwise 0.
+// Used to handle counter wraps from controller restarts.
+func Clamp(r float64) float64 {
+	if r < 0 {
+		return 0
+	}
+	return r
+}
+
+// ComputeRates calculates TX/RX rates from current and previous byte counters.
+// Returns (txRate, rxRate). Clamps negative deltas to 0.
+func ComputeRates(curTx, curRx int64, prev ByteSnap, dt float64) (float64, float64) {
+	if dt <= 0 {
+		return 0, 0
+	}
+	txRate := Clamp(float64(curTx-prev.Tx) / dt)
+	rxRate := Clamp(float64(curRx-prev.Rx) / dt)
+	return txRate, rxRate
+}


### PR DESCRIPTION
## Summary

Deduplication and KISS refactor: **-133 net lines** (117 added, 250 removed).

## JS Frontend (~250 lines removed)

### 1. `updateCountries` / `updateASNs` -> `fillDoughnut` + `fillDetailTable`
Replaced ~120 lines of inline chart + legend + detail table code with calls to the existing `fillDoughnut` and `fillDetailTable` helpers that were already used by DNS and WiFi sections.

### 2. `updateProtoChart` / `updateIPVersions` -> `updateSimpleDoughnut`
Replaced ~60 lines of inline chart + legend rendering with calls to `updateSimpleDoughnut` which already existed for NAT charts.

### 3. Latency chart branch deduplication
Collapsed 8 near-identical `if/else if` branches (ICMP x v4/v6/legacy + HTTPS x v4/v6/legacy) into a single `latencySection()` helper. ~70 lines reduced to ~30.

## Go Backend

### 4. Shared WiFi rate helpers (`wifi/wifi.go`)
Added to the `wifi` package:
- `ByteSnap` — shared TX/RX counter snapshot type (was duplicated as unexported `byteSnap` in both unifi and omada)
- `Clamp(float64)` — clamp negative rates to 0 (was inline x6 in unifi, local helper in omada)
- `ComputeRates(curTx, curRx, prev, dt)` — shared rate delta calculation

### 5. UniFi cleanup
- Removed 4 unused type aliases (`APInfo`, `SSIDStat`, `ClientInfo`, `Summary`)
- Replaced 6 inline negative-rate clamps with `wifi.ComputeRates`
- Uses `wifi.ByteSnap` instead of local `byteSnap`

### 6. Omada cleanup
- Replaced local `byteSnap` and `clamp()` with shared `wifi.ByteSnap` and `wifi.ComputeRates`
- Both providers now share identical rate delta logic
