### PR TITLE
feat: add custom User-Agent header and dynamic version injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,12 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           VERSION="${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}"
-          go build -ldflags="-s -w -X main.version=${VERSION}" -o bandwidth-monitor .
+          COMMIT="$(echo $GITHUB_SHA | cut -c1-7)"
+          LDFLAGS="-s -w -X bandwidth-monitor/version.Commit=${COMMIT}"
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            LDFLAGS="${LDFLAGS} -X bandwidth-monitor/version.Version=${{ github.ref_name }}"
+          fi
+          go build -ldflags="${LDFLAGS}" -o bandwidth-monitor .
 
       - name: Prepare packaging service file
         run: |
@@ -130,8 +135,12 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOMIPS: ${{ matrix.gomips }}
         run: |
-          VERSION="${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}"
-          go build -ldflags="-s -w -X main.version=${VERSION}" -o bandwidth-monitor .
+          COMMIT="$(echo $GITHUB_SHA | cut -c1-7)"
+          LDFLAGS="-s -w -X bandwidth-monitor/version.Commit=${COMMIT}"
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            LDFLAGS="${LDFLAGS} -X bandwidth-monitor/version.Version=${{ github.ref_name }}"
+          fi
+          go build -ldflags="${LDFLAGS}" -o bandwidth-monitor .
           file bandwidth-monitor
           echo "BINARY=${{ github.workspace }}/bandwidth-monitor" >> $GITHUB_ENV
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ BINARY=bandwidth-monitor
 INSTALL_DIR=/opt/bandwidth-monitor
 SERVICE_FILE=bandwidth-monitor.service
 
+# Version injection: use git tag if on a tag, otherwise short commit hash.
+GIT_VERSION := $(shell git describe --tags --exact-match 2>/dev/null)
+GIT_COMMIT  := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+LDFLAGS_VERSION := -X bandwidth-monitor/version.Commit=$(GIT_COMMIT)
+ifneq ($(GIT_VERSION),)
+  LDFLAGS_VERSION += -X bandwidth-monitor/version.Version=$(GIT_VERSION)
+endif
+
 GEOLITE2_CITY=GeoLite2-City.mmdb
 GEOLITE2_ASN=GeoLite2-ASN.mmdb
 GEOLITE2_CITY_URL=https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb
@@ -10,11 +18,11 @@ GEOLITE2_ASN_URL=https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-AS
 .PHONY: build run clean geoip install uninstall
 
 build:
-	go build -o $(BINARY) .
+	go build -ldflags="$(LDFLAGS_VERSION)" -o $(BINARY) .
 
 build_stripped:
 	# Build and strip the binary. 
-	go build -ldflags="-s -w" -o $(BINARY) .
+	go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o $(BINARY) .
 
 geoip:
 	@[ -f $(GEOLITE2_CITY) ] || { echo "Downloading GeoLite2-City.mmdb..."; curl -fSL -o $(GEOLITE2_CITY) $(GEOLITE2_CITY_URL); }

--- a/adguard/adguard.go
+++ b/adguard/adguard.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"bandwidth-monitor/dns"
+	"bandwidth-monitor/httputil"
 )
 
 // Client polls ADGuard Home's REST API for DNS statistics.
@@ -58,7 +59,7 @@ func New(baseURL, user, pass string, pollInterval time.Duration) *Client {
 		user:       user,
 		pass:       pass,
 		interval:   pollInterval,
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		httpClient: &http.Client{Timeout: 10 * time.Second, Transport: httputil.WrapTransport(nil)},
 		stopCh:     make(chan struct{}),
 	}
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,10 @@
           nativeBuildInputs = [ pkgs.pkg-config ];
 
           CGO_ENABLED = 1;
-          ldflags = [ "-s" "-w" ];
+          ldflags = [
+            "-s" "-w"
+            "-X" "bandwidth-monitor/version.Version=${bandwidth-monitor.version}"
+          ];
 
           postInstall = ''
             # Install GeoIP databases from flake inputs

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -18,6 +18,7 @@ import (
 	"bandwidth-monitor/debug"
 	"bandwidth-monitor/dns"
 	"bandwidth-monitor/geoip"
+	"bandwidth-monitor/httputil"
 	"bandwidth-monitor/latency"
 	"bandwidth-monitor/resolver"
 	"bandwidth-monitor/speedtest"
@@ -581,7 +582,7 @@ func (o *originResolver) doResolve(c *collector.Collector) *originGeo {
 // fetchExternalIP queries ip.ffmuc.net to get the public IP when all
 // WAN addresses are behind CGNAT or not globally routable.
 func fetchExternalIP() string {
-	client := &http.Client{Timeout: 3 * time.Second}
+	client := &http.Client{Timeout: 3 * time.Second, Transport: httputil.WrapTransport(nil)}
 	resp, err := client.Get("https://ip.ffmuc.net")
 	if err != nil {
 		return ""

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,0 +1,33 @@
+// Package httputil provides a shared User-Agent transport wrapper so every
+// outgoing HTTP request identifies itself as bandwidth-monitor.
+package httputil
+
+import (
+	"net/http"
+
+	"bandwidth-monitor/version"
+)
+
+// Transport wraps an existing http.RoundTripper and injects the User-Agent
+// header on every outgoing request.
+type Transport struct {
+	// Base is the underlying RoundTripper. If nil, http.DefaultTransport is used.
+	Base http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("User-Agent", version.UserAgent())
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+// WrapTransport is a convenience that wraps an existing RoundTripper (which
+// may be nil) in a Transport that sets the User-Agent header.
+func WrapTransport(base http.RoundTripper) *Transport {
+	return &Transport{Base: base}
+}

--- a/latency/latency.go
+++ b/latency/latency.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"time"
 
+	"bandwidth-monitor/httputil"
+
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
@@ -57,10 +59,10 @@ type TargetStatus struct {
 	// Per-protocol summary stats
 	ICMPStats  *ProbeStats `json:"icmp_stats,omitempty"`
 	HTTPSStats *ProbeStats `json:"https_stats,omitempty"`
-	ICMPv4  []Point `json:"icmp_v4,omitempty"`
-	ICMPv6  []Point `json:"icmp_v6,omitempty"`
-	HTTPSv4 []Point `json:"https_v4,omitempty"`
-	HTTPSv6 []Point `json:"https_v6,omitempty"`
+	ICMPv4     []Point     `json:"icmp_v4,omitempty"`
+	ICMPv6     []Point     `json:"icmp_v6,omitempty"`
+	HTTPSv4    []Point     `json:"https_v4,omitempty"`
+	HTTPSv6    []Point     `json:"https_v6,omitempty"`
 	// Legacy fields (preferred stack) for backward compat
 	ICMP  []Point `json:"icmp"`
 	HTTPS []Point `json:"https"`
@@ -114,7 +116,7 @@ func newDirectHTTPSClient(ip net.IP, hostname string) *http.Client {
 	dialer := &net.Dialer{Timeout: httpsTimeout}
 	return &http.Client{
 		Timeout: httpsTimeout,
-		Transport: &http.Transport{
+		Transport: httputil.WrapTransport(&http.Transport{
 			TLSClientConfig: &tls.Config{
 				ServerName: hostname,
 			},
@@ -124,7 +126,7 @@ func newDirectHTTPSClient(ip net.IP, hostname string) *http.Client {
 				_, port, _ := net.SplitHostPort(addr)
 				return dialer.DialContext(ctx, network, ipStr+":"+port)
 			},
-		},
+		}),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"bandwidth-monitor/speedtest"
 	"bandwidth-monitor/talkers"
 	"bandwidth-monitor/unifi"
+	"bandwidth-monitor/version"
 	"bandwidth-monitor/wifi"
 )
 
@@ -293,7 +294,7 @@ func main() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
-	log.Printf("server: starting on %s", listenAddr)
+	log.Printf("server: bandwidth-monitor %s starting on %s", version.String(), listenAddr)
 	if strings.HasPrefix(listenAddr, ":") {
 		log.Printf("server: open http://localhost%s in your browser", listenAddr)
 	} else {
@@ -366,6 +367,8 @@ func buildIndexHTML(embedded embed.FS, versions map[string]string) []byte {
 		// Replace src="app.js"     → src="app.js?v=abcd1234"
 		html = strings.ReplaceAll(html, `"`+name+`"`, `"`+name+"?v="+ver+`"`)
 	}
+	// Inject the build version into the header.
+	html = strings.Replace(html, "Bandwidth Monitor<span>v1.0</span>", "Bandwidth Monitor<span>"+version.String()+"</span>", 1)
 	return []byte(html)
 }
 
@@ -373,7 +376,7 @@ func buildIndexHTML(embedded embed.FS, versions map[string]string) []byte {
 // on every response, allowing clients to verify they're talking to the right service.
 func withSignature(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Bandwidth-Monitor", "1")
+		w.Header().Set("X-Bandwidth-Monitor", version.String())
 		h.ServeHTTP(w, r)
 	})
 }

--- a/nextdns/nextdns.go
+++ b/nextdns/nextdns.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"bandwidth-monitor/dns"
+	"bandwidth-monitor/httputil"
 )
 
 const apiBase = "https://api.nextdns.io"
@@ -62,7 +63,7 @@ func New(profile, apiKey string, pollInterval time.Duration) *Client {
 		profile:  profile,
 		apiKey:   apiKey,
 		interval: pollInterval,
-		httpC:    &http.Client{Timeout: 15 * time.Second},
+		httpC:    &http.Client{Timeout: 15 * time.Second, Transport: httputil.WrapTransport(nil)},
 		stopCh:   make(chan struct{}),
 	}
 }

--- a/omada/omada.go
+++ b/omada/omada.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"bandwidth-monitor/httputil"
 	"bandwidth-monitor/wifi"
 )
 
@@ -55,9 +56,9 @@ func New(baseURL, user, pass, siteName string, pollInterval time.Duration) *Clie
 		httpC: &http.Client{
 			Timeout: 15 * time.Second,
 			Jar:     jar,
-			Transport: &http.Transport{
+			Transport: httputil.WrapTransport(&http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			}),
 		},
 		stopCh: make(chan struct{}),
 	}

--- a/pihole/pihole.go
+++ b/pihole/pihole.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"bandwidth-monitor/dns"
+	"bandwidth-monitor/httputil"
 )
 
 // Client polls a Pi-hole v6 instance for DNS statistics.
@@ -115,9 +116,9 @@ func New(baseURL, password string, pollInterval time.Duration) *Client {
 		interval: pollInterval,
 		httpClient: &http.Client{
 			Timeout: 15 * time.Second,
-			Transport: &http.Transport{
+			Transport: httputil.WrapTransport(&http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			}),
 		},
 		stopCh: make(chan struct{}),
 	}

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"bandwidth-monitor/httputil"
 )
 
 // Result holds the outcome of a single speed test run.
@@ -146,7 +148,8 @@ func (t *Tester) run(ch chan<- Progress) {
 
 func measurePing(server string, samples int) (avgMs, jitterMs float64, err error) {
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout:   10 * time.Second,
+		Transport: httputil.WrapTransport(nil),
 	}
 
 	var pings []float64
@@ -217,7 +220,8 @@ func measureDownload(server string, ch chan<- Progress) (float64, error) {
 		go func() {
 			defer wg.Done()
 			client := &http.Client{
-				Timeout: duration + 5*time.Second,
+				Timeout:   duration + 5*time.Second,
+				Transport: httputil.WrapTransport(nil),
 			}
 			buf := make([]byte, 256*1024)
 			for time.Now().Before(deadline) {
@@ -302,7 +306,8 @@ func measureUpload(server string, ch chan<- Progress) (float64, error) {
 		go func() {
 			defer wg.Done()
 			client := &http.Client{
-				Timeout: duration + 5*time.Second,
+				Timeout:   duration + 5*time.Second,
+				Transport: httputil.WrapTransport(nil),
 			}
 			data := make([]byte, chunkSize)
 			rand.Read(data)

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"bandwidth-monitor/httputil"
 	"bandwidth-monitor/wifi"
 )
 
@@ -54,9 +55,9 @@ func New(baseURL, user, pass, site string, pollInterval time.Duration) *Client {
 		httpClient: &http.Client{
 			Timeout: 15 * time.Second,
 			Jar:     jar,
-			Transport: &http.Transport{
+			Transport: httputil.WrapTransport(&http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
+			}),
 		},
 		stopCh: make(chan struct{}),
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,42 @@
+// Package version holds build-time version information injected via ldflags.
+//
+// When building a tagged release the Makefile / CI sets:
+//
+//	-ldflags "-X bandwidth-monitor/version.Version=v0.1.0"
+//
+// For untagged (development) builds it falls back to the git commit:
+//
+//	-ldflags "-X bandwidth-monitor/version.Commit=abc1234"
+//
+// If neither is set (plain `go build`) the values stay "dev" / "unknown".
+package version
+
+import "fmt"
+
+// Version is the semantic version tag (e.g. "v0.1.0").
+// Set at build time via -ldflags "-X bandwidth-monitor/version.Version=...".
+var Version = "dev"
+
+// Commit is the short git commit hash.
+// Set at build time via -ldflags "-X bandwidth-monitor/version.Commit=...".
+var Commit = "unknown"
+
+// String returns a human-readable version string.
+// Tagged releases: "v0.1.0"
+// Dev builds:      "dev (abc1234)"
+func String() string {
+	if Version != "dev" {
+		return Version
+	}
+	if Commit != "unknown" {
+		return fmt.Sprintf("dev (%s)", Commit)
+	}
+	return "dev"
+}
+
+// UserAgent returns the value to use in HTTP User-Agent headers.
+// Tagged releases: "bandwidth-monitor/v0.1.0"
+// Dev builds:      "bandwidth-monitor/dev (abc1234)"
+func UserAgent() string {
+	return "bandwidth-monitor/" + String()
+}


### PR DESCRIPTION
## Summary

Replaces Go's default `Go-http-client/1.1` User-Agent with `bandwidth-monitor/<version>` on all outgoing HTTP requests, and adds build-time version injection throughout the app.

## Changes

### New packages
- **`httputil`** — `Transport` wrapper (implements `http.RoundTripper`) that injects the User-Agent header on every request. Each package keeps its own `http.Client` config but wraps its transport via `httputil.WrapTransport()`.
- **`version`** — Exports `Version` and `Commit` variables set via `-ldflags` at build time. Provides `String()` (human-readable) and `UserAgent()` helpers.

### Version logic
| Build type | `version.String()` | User-Agent |
|---|---|---|
| Tagged release (`v0.1.0`) | `v0.1.0` | `bandwidth-monitor/v0.1.0` |
| Dev build (commit `abc1234`) | `dev (abc1234)` | `bandwidth-monitor/dev (abc1234)` |
| Plain `go build` (no ldflags) | `dev` | `bandwidth-monitor/dev` |

### HTTP clients wrapped
All 8 packages that make outgoing HTTP calls now use `httputil.WrapTransport`:
- `speedtest` (ping, download, upload)
- `latency` (HTTPS probes)
- `handler` (ip.ffmuc.net lookup)
- `omada`, `unifi`, `pihole` (TLS-skip-verify transports wrapped)
- `adguard`, `nextdns` (nil transport wrapped)

### Version displayed in
- HTML header title (replaces hardcoded `v1.0`)
- `X-Bandwidth-Monitor` response header
- Startup log line
- User-Agent on all outgoing requests

### Build system
- **Makefile** — auto-detects git tag/commit and injects ldflags
- **flake.nix** — passes version via ldflags
- **CI workflow** — both linux-packages and openwrt jobs now inject `-X bandwidth-monitor/version.{Version,Commit}`
