### PR TITLE
feat: add MTU Discovery tool to Debug tab

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -376,6 +376,282 @@ func sendProbeV6(conn *icmp.PacketConn, dest net.IP, ttl int, seq int) (string, 
 	}
 }
 
+// ── Path MTU Discovery ──
+
+// MTUProbeResult holds the result of a single MTU probe.
+type MTUProbeResult struct {
+	Size    int     `json:"size"`
+	Success bool    `json:"success"`
+	RTT     float64 `json:"rtt_ms"`
+	Error   string  `json:"error,omitempty"`
+}
+
+// MTUResult is the complete result returned to the frontend.
+type MTUResult struct {
+	Target     string           `json:"target"`
+	ResolvedIP string           `json:"resolved_ip"`
+	PathMTU    int              `json:"path_mtu"`
+	LocalMTU   int              `json:"local_mtu,omitempty"`
+	Probes     []MTUProbeResult `json:"probes"`
+	Timestamp  int64            `json:"timestamp"`
+}
+
+// MTUProgress is sent via SSE while running.
+type MTUProgress struct {
+	Phase   string     `json:"phase"` // "running", "done", "error"
+	Message string     `json:"message"`
+	Size    int        `json:"size,omitempty"`
+	Result  *MTUResult `json:"result,omitempty"`
+}
+
+// RunMTUDiscovery performs a binary-search path MTU discovery by sending
+// ICMP echo packets with the DF (Don't Fragment) bit set. It streams
+// progress updates over the returned channel.
+func RunMTUDiscovery(target string) <-chan MTUProgress {
+	ch := make(chan MTUProgress, 64)
+
+	go func() {
+		defer close(ch)
+
+		// Resolve target
+		ips, err := net.LookupIP(target)
+		if err != nil {
+			ch <- MTUProgress{Phase: "error", Message: fmt.Sprintf("cannot resolve %s", target)}
+			return
+		}
+
+		var destIP net.IP
+		for _, ip := range ips {
+			if ip.To4() != nil {
+				destIP = ip.To4()
+				break
+			}
+		}
+		if destIP == nil {
+			ch <- MTUProgress{Phase: "error", Message: "MTU discovery requires an IPv4 target"}
+			return
+		}
+
+		log.Printf("debug/mtu: starting path MTU discovery to %s (%s)", target, destIP)
+		ch <- MTUProgress{Phase: "running", Message: fmt.Sprintf("Path MTU discovery to %s (%s)", target, destIP)}
+
+		// Detect the local interface MTU for the route to destIP
+		localMTU := detectLocalMTU(destIP)
+
+		// Open a raw ICMP socket via net.ListenPacket so we can access
+		// the underlying fd to set the Don't Fragment socket option.
+		rawPC, err := net.ListenPacket("ip4:icmp", "0.0.0.0")
+		if err != nil {
+			ch <- MTUProgress{Phase: "error", Message: fmt.Sprintf("cannot open ICMP socket (need root/CAP_NET_RAW): %v", err)}
+			return
+		}
+		defer rawPC.Close()
+
+		// Set the Don't Fragment bit on the socket
+		setDontFragment(rawPC)
+
+		// Binary search for the path MTU between 68 (IPv4 minimum) and 1500
+		// (standard Ethernet). Upper bound may be raised if local MTU is higher.
+		upper := 1500
+		if localMTU > 1500 {
+			upper = localMTU
+		}
+		lower := 68
+		var probes []MTUProbeResult
+
+		// First, check if the upper bound works — skip binary search if so
+		ok, rtt, probeErr := probeMTU(rawPC, destIP, upper)
+		probes = append(probes, MTUProbeResult{Size: upper, Success: ok, RTT: rtt, Error: probeErr})
+		ch <- MTUProgress{Phase: "running", Message: fmt.Sprintf("Testing %d bytes: %s", upper, mtuStatus(ok)), Size: upper}
+
+		if ok {
+			// Full size works — path MTU is at least the upper bound
+			result := &MTUResult{
+				Target:     target,
+				ResolvedIP: destIP.String(),
+				PathMTU:    upper,
+				LocalMTU:   localMTU,
+				Probes:     probes,
+				Timestamp:  time.Now().UnixMilli(),
+			}
+			ch <- MTUProgress{Phase: "done", Message: fmt.Sprintf("Path MTU: %d bytes (full size passes)", upper), Result: result}
+			log.Printf("debug/mtu: finished %s — path MTU %d", target, upper)
+			return
+		}
+
+		// Also verify the minimum works
+		ok, rtt, probeErr = probeMTU(rawPC, destIP, lower)
+		probes = append(probes, MTUProbeResult{Size: lower, Success: ok, RTT: rtt, Error: probeErr})
+		ch <- MTUProgress{Phase: "running", Message: fmt.Sprintf("Testing %d bytes: %s", lower, mtuStatus(ok)), Size: lower}
+
+		if !ok {
+			result := &MTUResult{
+				Target:     target,
+				ResolvedIP: destIP.String(),
+				PathMTU:    0,
+				LocalMTU:   localMTU,
+				Probes:     probes,
+				Timestamp:  time.Now().UnixMilli(),
+			}
+			ch <- MTUProgress{Phase: "done", Message: "Host unreachable or blocks ICMP — cannot determine MTU", Result: result}
+			log.Printf("debug/mtu: finished %s — host unreachable", target)
+			return
+		}
+
+		// Binary search
+		for upper-lower > 1 {
+			mid := (lower + upper) / 2
+			ok, rtt, probeErr = probeMTU(rawPC, destIP, mid)
+			probes = append(probes, MTUProbeResult{Size: mid, Success: ok, RTT: rtt, Error: probeErr})
+			ch <- MTUProgress{Phase: "running", Message: fmt.Sprintf("Testing %d bytes: %s (range %d–%d)", mid, mtuStatus(ok), lower, upper), Size: mid}
+
+			if ok {
+				lower = mid
+			} else {
+				upper = mid
+			}
+		}
+
+		// Sort probes by size for display
+		sortProbes(probes)
+
+		result := &MTUResult{
+			Target:     target,
+			ResolvedIP: destIP.String(),
+			PathMTU:    lower,
+			LocalMTU:   localMTU,
+			Probes:     probes,
+			Timestamp:  time.Now().UnixMilli(),
+		}
+		ch <- MTUProgress{Phase: "done", Message: fmt.Sprintf("Path MTU: %d bytes", lower), Result: result}
+		log.Printf("debug/mtu: finished %s — path MTU %d, local MTU %d", target, lower, localMTU)
+	}()
+
+	return ch
+}
+
+func mtuStatus(ok bool) string {
+	if ok {
+		return "pass"
+	}
+	return "blocked (DF bit set, packet too large)"
+}
+
+func sortProbes(probes []MTUProbeResult) {
+	for i := 1; i < len(probes); i++ {
+		for j := i; j > 0 && probes[j].Size < probes[j-1].Size; j-- {
+			probes[j], probes[j-1] = probes[j-1], probes[j]
+		}
+	}
+}
+
+// probeMTU sends an ICMP echo with DF bit at the given packet size and returns
+// whether it succeeded. Size is total IP packet size (header + payload).
+func probeMTU(pc net.PacketConn, dest net.IP, size int) (bool, float64, string) {
+	// IP header is 20 bytes, ICMP header is 8 bytes
+	payloadSize := size - 20 - 8
+	if payloadSize < 0 {
+		payloadSize = 0
+	}
+
+	pc.SetDeadline(time.Now().Add(2 * time.Second))
+
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = 'M'
+	}
+	id := uint16(size & 0xFFFF)
+	msg := icmp.Message{
+		Type: ipv4.ICMPTypeEcho,
+		Code: 0,
+		Body: &icmp.Echo{
+			ID:   int(id),
+			Seq:  size,
+			Data: payload,
+		},
+	}
+	wb, err := msg.Marshal(nil)
+	if err != nil {
+		return false, 0, sanitizeError(err)
+	}
+
+	dst := &net.IPAddr{IP: dest}
+	start := time.Now()
+	if _, err := pc.WriteTo(wb, dst); err != nil {
+		errStr := err.Error()
+		if strings.Contains(errStr, "message too long") {
+			return false, 0, "packet too large for local interface"
+		}
+		return false, 0, sanitizeError(err)
+	}
+
+	// Wait for reply — retry a couple of times in case of spurious ICMP
+	rb := make([]byte, 1500)
+	for attempts := 0; attempts < 3; attempts++ {
+		n, _, err := pc.ReadFrom(rb)
+		if err != nil {
+			return false, 0, "timeout"
+		}
+		rtt := float64(time.Since(start).Microseconds()) / 1000.0
+		rm, err := icmp.ParseMessage(1, rb[:n])
+		if err != nil {
+			continue
+		}
+
+		switch rm.Type {
+		case ipv4.ICMPTypeEchoReply:
+			if echo, ok := rm.Body.(*icmp.Echo); ok {
+				if uint16(echo.ID) == id {
+					return true, rtt, ""
+				}
+			}
+			continue
+		case ipv4.ICMPTypeDestinationUnreachable:
+			// Code 4 = fragmentation needed but DF set
+			if rm.Code == 4 {
+				return false, rtt, "fragmentation needed (DF set)"
+			}
+			return false, rtt, fmt.Sprintf("destination unreachable (code %d)", rm.Code)
+		}
+	}
+	return false, 0, "timeout"
+}
+
+// detectLocalMTU finds the MTU of the interface that routes to the given IP.
+func detectLocalMTU(dest net.IP) int {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return 0
+	}
+	// Try to find the interface that can reach dest by checking routes
+	// Heuristic: match the interface whose subnet contains dest, or default
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ipnet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			if ipnet.Contains(dest) {
+				return iface.MTU
+			}
+		}
+	}
+	// Fallback: return the MTU of the first non-loopback interface
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp != 0 && iface.Flags&net.FlagLoopback == 0 {
+			return iface.MTU
+		}
+	}
+	return 0
+}
+
 // ── DNS Checks ──
 
 // DNSRecord holds a single DNS record result.

--- a/debug/mtu_linux.go
+++ b/debug/mtu_linux.go
@@ -1,0 +1,24 @@
+package debug
+
+import (
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// setDontFragment enables the Don't Fragment bit on the IPv4 socket by
+// setting IP_MTU_DISCOVER to IP_PMTUDISC_DO on Linux.
+func setDontFragment(pc net.PacketConn) {
+	sc, ok := pc.(syscall.Conn)
+	if !ok {
+		return
+	}
+	rawConn, err := sc.SyscallConn()
+	if err != nil {
+		return
+	}
+	rawConn.Control(func(fd uintptr) {
+		unix.SetsockoptInt(int(fd), unix.IPPROTO_IP, unix.IP_MTU_DISCOVER, unix.IP_PMTUDISC_DO)
+	})
+}

--- a/debug/mtu_other.go
+++ b/debug/mtu_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package debug
+
+import "net"
+
+// setDontFragment is a no-op on non-Linux platforms.
+// On macOS/BSD the DF bit is typically set by default for ICMP echo,
+// and the "message too long" error from WriteTo covers local MTU.
+func setDontFragment(_ net.PacketConn) {}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -415,6 +415,63 @@ func DebugTraceroute(dns *resolver.Resolver) http.HandlerFunc {
 	}
 }
 
+// DebugMTU performs a path MTU discovery to a target and streams progress as SSE.
+func DebugMTU() http.HandlerFunc {
+	var mu sync.Mutex
+	running := false
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+
+		target := r.URL.Query().Get("target")
+		if target == "" {
+			http.Error(w, "target parameter required", http.StatusBadRequest)
+			return
+		}
+
+		if len(target) > 253 {
+			http.Error(w, "target too long", http.StatusBadRequest)
+			return
+		}
+
+		// Rate limit: only one MTU test at a time
+		mu.Lock()
+		if running {
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]string{"error": "MTU test already running"})
+			return
+		}
+		running = true
+		mu.Unlock()
+		defer func() { mu.Lock(); running = false; mu.Unlock() }()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		ch := debug.RunMTUDiscovery(target)
+		for p := range ch {
+			data, _ := json.Marshal(p)
+			w.Write([]byte("data: "))
+			w.Write(data)
+			w.Write([]byte("\n\n"))
+			flusher.Flush()
+		}
+	}
+}
+
 // DebugDNS runs DNS checks against multiple servers.
 func DebugDNS() http.HandlerFunc {
 	var mu sync.Mutex

--- a/main.go
+++ b/main.go
@@ -264,6 +264,7 @@ func main() {
 	mux.HandleFunc("/api/speedtest/results", handler.SpeedTestResults(speedTester))
 	mux.HandleFunc("/api/debug/traceroute", handler.DebugTraceroute(dnsResolver))
 	mux.HandleFunc("/api/debug/dns", handler.DebugDNS())
+	mux.HandleFunc("/api/debug/mtu", handler.DebugMTU())
 	mux.HandleFunc("/api/summary", handler.MenuBarSummary(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker))
 	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor, geoDB))
 	staticSub, err := fs.Sub(staticFiles, "static")

--- a/static/app.js
+++ b/static/app.js
@@ -2490,6 +2490,156 @@
         tb.innerHTML = h;
     }
 
+    // ── Debug: MTU Discovery ──
+    var _mtuRunning = false;
+    window._runMTUDiscovery = function() {
+        if (_mtuRunning) return;
+        var target = (document.getElementById('mtuTarget').value || '').trim();
+        if (!target) { alert('Enter an IP or hostname'); return; }
+
+        _mtuRunning = true;
+        var btn = document.getElementById('mtuBtn');
+        btn.disabled = true;
+        btn.innerHTML = '<span class="speedtest-spinner"></span> Testing...';
+
+        var wrap = document.getElementById('mtuProgressWrap');
+        wrap.style.display = '';
+        var bar = document.getElementById('mtuProgressBar');
+        var phase = document.getElementById('mtuPhase');
+        bar.style.width = '0%';
+        bar.className = 'speedtest-progress-bar-fill ping';
+        phase.textContent = 'Starting MTU discovery...';
+
+        document.getElementById('mtuResults').style.display = 'none';
+
+        var probeCount = 0;
+        fetch('/api/debug/mtu?target=' + encodeURIComponent(target), { method: 'POST' })
+        .then(function(resp) {
+            var reader = resp.body.getReader();
+            var decoder = new TextDecoder();
+            var buffer = '';
+
+            function processChunk() {
+                return reader.read().then(function(result) {
+                    if (result.done) return;
+                    buffer += decoder.decode(result.value, { stream: true });
+                    var lines = buffer.split('\n');
+                    buffer = lines.pop();
+                    for (var i = 0; i < lines.length; i++) {
+                        var line = lines[i].trim();
+                        if (!line.startsWith('data: ')) continue;
+                        try {
+                            var p = JSON.parse(line.substring(6));
+                            handleMTUProgress(p);
+                        } catch(e) {}
+                    }
+                    return processChunk();
+                });
+            }
+
+            function handleMTUProgress(p) {
+                if (p.phase === 'running') {
+                    phase.textContent = p.message;
+                    probeCount++;
+                    // Binary search of 1500 range ~ 11 steps; animate progress
+                    bar.style.width = Math.min(probeCount * 8, 99) + '%';
+                } else if (p.phase === 'done' && p.result) {
+                    phase.textContent = p.message;
+                    bar.style.width = '100%';
+                    bar.className = 'speedtest-progress-bar-fill done';
+                    renderMTUResults(p.result);
+                    finishMTU();
+                } else if (p.phase === 'error') {
+                    phase.textContent = p.message;
+                    bar.className = 'speedtest-progress-bar-fill error';
+                    finishMTU();
+                }
+            }
+
+            return processChunk();
+        }).catch(function() {
+            phase.textContent = 'Connection error';
+            finishMTU();
+        });
+
+        function finishMTU() {
+            _mtuRunning = false;
+            btn.disabled = false;
+            btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><path d="M12 2v20M2 12h20"/></svg> Discover';
+            setTimeout(function() { wrap.style.display = 'none'; }, 2000);
+        }
+    };
+
+    function renderMTUResults(result) {
+        document.getElementById('mtuResults').style.display = '';
+        var mtu = result.path_mtu;
+        var titleText = 'Path MTU to ' + result.target + ' (' + result.resolved_ip + ')';
+        document.getElementById('mtuResultTitle').textContent = titleText;
+
+        var subParts = [];
+        if (mtu > 0) {
+            subParts.push('Path MTU: ' + mtu + ' bytes');
+        } else {
+            subParts.push('Could not determine path MTU');
+        }
+        if (result.local_mtu > 0) subParts.push('Local interface MTU: ' + result.local_mtu + ' bytes');
+        subParts.push(result.probes.length + ' probes sent');
+        document.getElementById('mtuResultSub').textContent = subParts.join(' — ');
+
+        var body = document.getElementById('mtuResultBody');
+        var h = '';
+
+        // Summary banner
+        if (mtu > 0) {
+            var mtuColor = mtu >= 1500 ? 'var(--success)' : (mtu >= 1400 ? 'var(--warning)' : 'var(--danger)');
+            var mtuNote = '';
+            if (mtu >= 1500) {
+                mtuNote = 'Standard Ethernet MTU — no issues expected';
+            } else if (mtu >= 1400) {
+                mtuNote = 'Slightly reduced — common with VPN/PPPoE tunnels';
+            } else if (mtu >= 1280) {
+                mtuNote = 'Below standard — possible tunnel or misconfigured link';
+            } else {
+                mtuNote = 'Very low MTU — likely causing performance issues';
+            }
+            h += '<div style="padding:16px 20px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:16px">';
+            h += '<div style="font-size:32px;font-weight:700;font-family:JetBrains Mono,monospace;color:' + mtuColor + '">' + mtu + '</div>';
+            h += '<div>';
+            h += '<div style="font-size:13px;font-weight:600;color:var(--text-0)">bytes path MTU</div>';
+            h += '<div style="font-size:12px;color:var(--text-2);margin-top:2px">' + mtuNote + '</div>';
+            if (result.local_mtu > 0 && result.local_mtu !== mtu) {
+                h += '<div style="font-size:11px;color:var(--warning);margin-top:4px">⚠ Local interface MTU (' + result.local_mtu + ') differs from path MTU (' + mtu + ')</div>';
+            }
+            h += '</div></div>';
+        } else {
+            h += '<div style="padding:16px 20px;border-bottom:1px solid var(--border);color:var(--warning);font-size:13px">';
+            h += '⚠ Could not determine path MTU — host may be unreachable or blocking ICMP</div>';
+        }
+
+        // Probe table
+        if (result.probes && result.probes.length) {
+            h += '<div style="max-height:400px;overflow-y:auto">';
+            h += '<table><thead><tr>';
+            h += '<th>Packet Size</th><th>Result</th><th>RTT (ms)</th><th>Detail</th>';
+            h += '</tr></thead><tbody>';
+            for (var i = 0; i < result.probes.length; i++) {
+                var p = result.probes[i];
+                var statusColor = p.success ? 'var(--success)' : 'var(--danger)';
+                var statusIcon = p.success ? '✓ Pass' : '✗ Blocked';
+                var bg = p.size === mtu ? 'background:color-mix(in srgb, var(--success) 10%, transparent)' : '';
+                h += '<tr style="' + bg + '">';
+                h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + p.size + ' bytes' + (p.size === mtu ? ' ←' : '') + '</td>';
+                h += '<td style="color:' + statusColor + ';font-weight:600;font-size:12px">' + statusIcon + '</td>';
+                h += '<td style="font-variant-numeric:tabular-nums;font-size:12px">' + (p.rtt_ms > 0 ? p.rtt_ms.toFixed(2) + ' ms' : '—') + '</td>';
+                h += '<td style="font-size:11px;color:var(--text-2)">' + (p.error || '') + '</td>';
+                h += '</tr>';
+            }
+            h += '</tbody></table></div>';
+        }
+
+        body.innerHTML = h;
+    }
+
     // ── Debug: DNS Check ──
     window._runDNSCheck = function() {
         var domain = (document.getElementById('dnsCheckDomain').value || '').trim();

--- a/static/index.html
+++ b/static/index.html
@@ -888,6 +888,44 @@
             </div>
         </div>
 
+        <!-- MTU Discovery Section -->
+        <div class="card" style="margin-bottom:16px">
+            <div class="card-header">
+                <div>
+                    <div class="card-title">MTU Discovery</div>
+                    <div class="card-subtitle">Detect path MTU using ICMP with Don&rsquo;t Fragment &mdash; find packet-size issues causing silent drops</div>
+                </div>
+            </div>
+            <div style="padding:12px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;border-top:1px solid var(--border)">
+                <input type="text" id="mtuTarget" placeholder="IP or hostname (e.g. 1.1.1.1)" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;width:220px;outline:none;font-family:'JetBrains Mono',monospace">
+                <button class="speedtest-btn" id="mtuBtn" onclick="window._runMTUDiscovery()">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><path d="M12 2v20M2 12h20"/></svg>
+                    Discover
+                </button>
+            </div>
+        </div>
+
+        <div id="mtuProgressWrap" style="display:none">
+            <div class="speedtest-progress-wrap" style="margin-bottom:16px">
+                <div class="speedtest-progress-phase" id="mtuPhase">Waiting...</div>
+                <div class="speedtest-progress-bar-bg">
+                    <div class="speedtest-progress-bar-fill" id="mtuProgressBar" style="width:0%"></div>
+                </div>
+            </div>
+        </div>
+
+        <div id="mtuResults" style="display:none">
+            <div class="card" style="margin-bottom:16px">
+                <div class="card-header">
+                    <div>
+                        <div class="card-title" id="mtuResultTitle">MTU Results</div>
+                        <div class="card-subtitle" id="mtuResultSub"></div>
+                    </div>
+                </div>
+                <div id="mtuResultBody"></div>
+            </div>
+        </div>
+
         </div><!-- /tabDebug -->
 
         <div class="footer"><span id="clock"></span></div>


### PR DESCRIPTION
Add path MTU discovery using ICMP echo with Don't Fragment (DF) bit. Binary-searches packet sizes to find the exact path MTU to any target.

- Backend: RunMTUDiscovery() in debug package with SSE streaming
- Linux: sets IP_MTU_DISCOVER=IP_PMTUDISC_DO via syscall
- API: POST /api/debug/mtu?target=<host> (rate-limited, one at a time)
- Frontend: MTU Discovery card in Debug tab with progress bar and color-coded results (green ≥1500, yellow ≥1400, red <1280)
- Detects local interface MTU and warns on mismatch
- Probe table shows each tested size with pass/fail and RTT