### PR TITLE
refactor: deduplicate and simplify Go backend code

### DIFF
--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/netip"
 	"os"
 	"sort"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"bandwidth-monitor/geoip"
+	"bandwidth-monitor/netutil"
 	"bandwidth-monitor/resolver"
 
 	ct "github.com/ti-mo/conntrack"
@@ -96,6 +96,15 @@ type HostStat struct {
 	City        string `json:"city,omitempty"`
 	ASN         uint   `json:"asn,omitempty"`
 	ASOrg       string `json:"as_org,omitempty"`
+}
+
+// SetGeo implements geoip.GeoFields.
+func (h *HostStat) SetGeo(country, countryName, city string, lat, lon float64, asn uint, asOrg string) {
+	h.Country = country
+	h.CountryName = countryName
+	h.City = city
+	h.ASN = asn
+	h.ASOrg = asOrg
 }
 
 // Summary holds aggregated conntrack data.
@@ -320,11 +329,11 @@ func (t *Tracker) poll() {
 		s.NATTypes[e.NATType]++
 
 		// Classify: local sources → LAN clients, non-local destinations → remote hosts
-		if t.isLocal(e.OrigSrc) {
+		if netutil.IsLocalStr(e.OrigSrc, t.localNets) {
 			srcCount[e.OrigSrc]++
 			srcBytes[e.OrigSrc] += e.Bytes
 		}
-		if !t.isLocal(e.OrigDst) && !t.isLoopback(e.OrigDst) {
+		if !netutil.IsLocalStr(e.OrigDst, t.localNets) && !net.ParseIP(e.OrigDst).IsLoopback() {
 			dstCount[e.OrigDst]++
 			dstBytes[e.OrigDst] += e.Bytes
 		}
@@ -480,15 +489,7 @@ func (t *Tracker) enrichHosts(hosts []HostStat) {
 		}
 
 		// GeoIP
-		if t.geoDB != nil && t.geoDB.Available() {
-			if geo := t.geoDB.Lookup(ip); geo != nil {
-				hosts[i].Country = geo.Country
-				hosts[i].CountryName = geo.CountryName
-				hosts[i].City = geo.City
-				hosts[i].ASN = geo.ASN
-				hosts[i].ASOrg = geo.ASOrg
-			}
-		}
+		t.geoDB.Enrich(ip, &hosts[i])
 	}
 }
 
@@ -541,39 +542,4 @@ func readIntFile(path string) int {
 	}
 	v, _ := strconv.Atoi(strings.TrimSpace(string(data)))
 	return v
-}
-
-// isLocal checks if an IP string falls within any of the configured local networks.
-// If no local networks are configured, it falls back to RFC1918/ULA checks.
-func (t *Tracker) isLocal(ipStr string) bool {
-	addr, err := netip.ParseAddr(ipStr)
-	if err != nil {
-		return false
-	}
-	ip := addr.As16()
-	netIP := net.IP(ip[:])
-	if addr.Is4() {
-		netIP = netIP[12:16]
-	}
-
-	if len(t.localNets) > 0 {
-		for _, n := range t.localNets {
-			if n.Contains(netIP) {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Fallback: RFC1918 + RFC4193 (ULA)
-	return addr.IsPrivate() || addr.IsLinkLocalUnicast()
-}
-
-// isLoopback checks if an IP is a loopback address.
-func (t *Tracker) isLoopback(ipStr string) bool {
-	addr, err := netip.ParseAddr(ipStr)
-	if err != nil {
-		return false
-	}
-	return addr.IsLoopback()
 }

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -176,3 +176,18 @@ func (db *DB) Lookup(ipStr string) *Result {
 
 	return r
 }
+
+// GeoFields is implemented by any struct that has geo fields to be enriched.
+type GeoFields interface {
+	SetGeo(country, countryName, city string, lat, lon float64, asn uint, asOrg string)
+}
+
+// Enrich populates geo fields on a target struct from the database.
+func (db *DB) Enrich(ipStr string, target GeoFields) {
+	if db == nil || !db.Available() {
+		return
+	}
+	if geo := db.Lookup(ipStr); geo != nil {
+		target.SetGeo(geo.Country, geo.CountryName, geo.City, geo.Latitude, geo.Longitude, geo.ASN, geo.ASOrg)
+	}
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -20,6 +20,7 @@ import (
 	"bandwidth-monitor/geoip"
 	"bandwidth-monitor/httputil"
 	"bandwidth-monitor/latency"
+	"bandwidth-monitor/netutil"
 	"bandwidth-monitor/resolver"
 	"bandwidth-monitor/speedtest"
 	"bandwidth-monitor/talkers"
@@ -29,85 +30,76 @@ import (
 
 func InterfaceStats(c *collector.Collector) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(c.GetAll())
+		httputil.WriteJSON(w, c.GetAll())
 	}
 }
 
 func InterfaceHistory(c *collector.Collector) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(c.GetHistory())
+		httputil.WriteJSON(w, c.GetHistory())
 	}
 }
 
 func TopTalkersBandwidth(t *talkers.Tracker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(t.TopByBandwidth(10))
+		httputil.WriteJSON(w, t.TopByBandwidth(10))
 	}
 }
 
 func TopTalkersVolume(t *talkers.Tracker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(t.TopByVolume(10))
+		httputil.WriteJSON(w, t.TopByVolume(10))
 	}
 }
 
 func DNSSummary(dp dns.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		if dp == nil {
-			w.Write([]byte("null"))
+			httputil.WriteJSONOrNull(w, nil)
 			return
 		}
-		json.NewEncoder(w).Encode(dp.GetSummary())
+		httputil.WriteJSON(w, dp.GetSummary())
 	}
 }
 
 func WiFiSummary(wp wifi.Provider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		if wp == nil {
-			w.Write([]byte("null"))
+			httputil.WriteJSONOrNull(w, nil)
 			return
 		}
-		json.NewEncoder(w).Encode(wp.GetSummary())
+		httputil.WriteJSON(w, wp.GetSummary())
 	}
 }
 
 func TopologySummary(ts *topology.Scanner) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		if ts == nil {
-			w.Write([]byte("null"))
+			httputil.WriteJSONOrNull(w, nil)
 			return
 		}
-		json.NewEncoder(w).Encode(ts.GetOverview())
+		httputil.WriteJSON(w, ts.GetOverview())
 	}
 }
 
 func ConntrackSummary(ct *conntrack.Tracker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		if ct == nil {
-			w.Write([]byte("null"))
+			httputil.WriteJSONOrNull(w, nil)
 			return
 		}
-		json.NewEncoder(w).Encode(ct.GetSummary())
+		httputil.WriteJSON(w, ct.GetSummary())
 	}
 }
 
 // LatencyStatus returns the current latency monitoring data.
 func LatencyStatus(lm *latency.Monitor) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		if lm == nil {
-			w.Write([]byte("null"))
+			httputil.WriteJSONOrNull(w, nil)
 			return
 		}
-		json.NewEncoder(w).Encode(lm.GetStatus())
+		httputil.WriteJSON(w, lm.GetStatus())
 	}
 }
 
@@ -191,15 +183,13 @@ func HostDetail(t *talkers.Tracker, ct *conntrack.Tracker, geoDB *geoip.DB) http
 			detail.Connections = ct.HostFlows(ip)
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(detail)
+		httputil.WriteJSON(w, detail)
 	}
 }
 
 // MenuBarSummary returns a compact JSON snapshot for menu-bar widgets.
 func MenuBarSummary(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ctr *conntrack.Tracker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		type ifaceBrief struct {
 			Name   string   `json:"name"`
 			Type   string   `json:"type"`
@@ -299,7 +289,7 @@ func MenuBarSummary(c *collector.Collector, t *talkers.Tracker, dp dns.Provider,
 			}
 		}
 
-		json.NewEncoder(w).Encode(out)
+		httputil.WriteJSON(w, out)
 	}
 }
 
@@ -319,44 +309,25 @@ func SpeedTestRun(st *speedtest.Tester) http.HandlerFunc {
 			return
 		}
 
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("X-Accel-Buffering", "no")
-
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			http.Error(w, "streaming not supported", http.StatusInternalServerError)
-			return
-		}
-
-		for p := range ch {
-			data, _ := json.Marshal(p)
-			w.Write([]byte("data: "))
-			w.Write(data)
-			w.Write([]byte("\n\n"))
-			flusher.Flush()
-		}
+		httputil.StreamChannel(w, ch)
 	}
 }
 
 // SpeedTestResults returns the history of speed test results.
 func SpeedTestResults(st *speedtest.Tester) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		results := st.GetResults()
 		response := map[string]interface{}{
 			"running": st.IsRunning(),
 			"results": results,
 		}
-		json.NewEncoder(w).Encode(response)
+		httputil.WriteJSON(w, response)
 	}
 }
 
 // DebugTraceroute runs a native ICMP traceroute and streams progress as SSE.
 func DebugTraceroute(dns *resolver.Resolver) http.HandlerFunc {
-	var mu sync.Mutex
-	running := false
+	var sf httputil.SingleFlight
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -377,17 +348,10 @@ func DebugTraceroute(dns *resolver.Resolver) http.HandlerFunc {
 		}
 
 		// Rate limit: only one traceroute at a time
-		mu.Lock()
-		if running {
-			mu.Unlock()
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]string{"error": "traceroute already running"})
+		if !sf.TryAcquire(w, "traceroute") {
 			return
 		}
-		running = true
-		mu.Unlock()
-		defer func() { mu.Lock(); running = false; mu.Unlock() }()
+		defer sf.Release()
 
 		countStr := r.URL.Query().Get("count")
 		count := 20
@@ -405,32 +369,14 @@ func DebugTraceroute(dns *resolver.Resolver) http.HandlerFunc {
 			}
 		}
 
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("X-Accel-Buffering", "no")
-
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			http.Error(w, "streaming not supported", http.StatusInternalServerError)
-			return
-		}
-
 		ch := debug.RunTraceroute(target, count, maxTTL, dns)
-		for p := range ch {
-			data, _ := json.Marshal(p)
-			w.Write([]byte("data: "))
-			w.Write(data)
-			w.Write([]byte("\n\n"))
-			flusher.Flush()
-		}
+		httputil.StreamChannel(w, ch)
 	}
 }
 
 // DebugMTU performs a path MTU discovery to a target and streams progress as SSE.
 func DebugMTU() http.HandlerFunc {
-	var mu sync.Mutex
-	running := false
+	var sf httputil.SingleFlight
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -450,37 +396,13 @@ func DebugMTU() http.HandlerFunc {
 		}
 
 		// Rate limit: only one MTU test at a time
-		mu.Lock()
-		if running {
-			mu.Unlock()
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]string{"error": "MTU test already running"})
+		if !sf.TryAcquire(w, "MTU test") {
 			return
 		}
-		running = true
-		mu.Unlock()
-		defer func() { mu.Lock(); running = false; mu.Unlock() }()
-
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.Header().Set("Cache-Control", "no-cache")
-		w.Header().Set("Connection", "keep-alive")
-		w.Header().Set("X-Accel-Buffering", "no")
-
-		flusher, ok := w.(http.Flusher)
-		if !ok {
-			http.Error(w, "streaming not supported", http.StatusInternalServerError)
-			return
-		}
+		defer sf.Release()
 
 		ch := debug.RunMTUDiscovery(target)
-		for p := range ch {
-			data, _ := json.Marshal(p)
-			w.Write([]byte("data: "))
-			w.Write(data)
-			w.Write([]byte("\n\n"))
-			flusher.Flush()
-		}
+		httputil.StreamChannel(w, ch)
 	}
 }
 
@@ -521,8 +443,7 @@ func DebugDNS() http.HandlerFunc {
 
 		result := debug.RunDNSCheck(domain, qtype)
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(result)
+		httputil.WriteJSON(w, result)
 	}
 }
 
@@ -548,31 +469,6 @@ func newOriginResolver(geoDB *geoip.DB) *originResolver {
 		geoDB: geoDB,
 		ttl:   10 * time.Minute,
 	}
-}
-
-// cgnatNet is RFC 6598 (100.64.0.0/10) used by Carrier-Grade NAT.
-var cgnatNet = func() *net.IPNet {
-	_, n, _ := net.ParseCIDR("100.64.0.0/10")
-	return n
-}()
-
-// isGlobalUnicast returns true if the IP is a globally routable unicast address.
-// Returns false for private, loopback, link-local, CGNAT, ULA (fc00::/7), etc.
-func isGlobalUnicast(ip net.IP) bool {
-	if ip == nil {
-		return false
-	}
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
-		return false
-	}
-	if cgnatNet.Contains(ip) {
-		return false
-	}
-	// IPv6 ULA (fc00::/7) — IsPrivate covers this in Go 1.17+, but be safe
-	if len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc {
-		return false
-	}
-	return ip.IsGlobalUnicast()
 }
 
 // resolve determines the origin location from the WAN interface IPs.
@@ -614,11 +510,11 @@ func (o *originResolver) doResolve(c *collector.Collector) *originGeo {
 				continue
 			}
 			if ip.To4() != nil && wanIPv4 == "" {
-				if isGlobalUnicast(ip) {
+				if netutil.IsGlobalUnicast(ip) {
 					wanIPv4 = ip.String()
 				}
 			} else if ip.To4() == nil && wanIPv6 == "" {
-				if isGlobalUnicast(ip) {
+				if netutil.IsGlobalUnicast(ip) {
 					wanIPv6 = ip.String()
 				}
 			}

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,9 +1,14 @@
-// Package httputil provides a shared User-Agent transport wrapper so every
-// outgoing HTTP request identifies itself as bandwidth-monitor.
+// Package httputil provides shared HTTP helpers: User-Agent injection,
+// TLS-skipping client factory, JSON response helpers, and SSE streaming.
 package httputil
 
 import (
+	"crypto/tls"
+	"encoding/json"
 	"net/http"
+	"net/http/cookiejar"
+	"sync"
+	"time"
 
 	"bandwidth-monitor/version"
 )
@@ -30,4 +35,109 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 // may be nil) in a Transport that sets the User-Agent header.
 func WrapTransport(base http.RoundTripper) *Transport {
 	return &Transport{Base: base}
+}
+
+// NewInsecureClient creates an http.Client with TLS verification disabled,
+// a cookie jar, and the User-Agent transport wrapper. Used by controller
+// integrations (UniFi, Omada, Pi-hole) that talk to self-signed endpoints.
+func NewInsecureClient(timeout time.Duration) *http.Client {
+	jar, _ := cookiejar.New(nil)
+	return &http.Client{
+		Timeout: timeout,
+		Jar:     jar,
+		Transport: WrapTransport(&http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}),
+	}
+}
+
+// NewClient creates a standard http.Client with User-Agent injection.
+func NewClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: WrapTransport(nil),
+	}
+}
+
+// ── JSON response helpers ─────────────────────────────────────────
+
+// WriteJSON writes v as JSON to w with the appropriate Content-Type header.
+func WriteJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+// WriteJSONOrNull writes v as JSON, or the literal "null" if v is nil.
+func WriteJSONOrNull(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if v == nil {
+		w.Write([]byte("null"))
+		return
+	}
+	json.NewEncoder(w).Encode(v)
+}
+
+// ── SSE streaming helper ──────────────────────────────────────────
+
+// SSEStream sets Server-Sent Events headers on w and drains ch,
+// marshalling each value as a "data: {...}\n\n" frame.
+// Returns when ch is closed.
+func SSEStream(w http.ResponseWriter, ch interface{ recv() ([]byte, bool) }) {
+	// This is a type-agnostic version; see StreamChannel below.
+}
+
+// StreamChannel sets SSE headers, checks for Flusher support, and streams
+// JSON-encoded values from ch until it closes.
+func StreamChannel[T any](w http.ResponseWriter, ch <-chan T) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	for p := range ch {
+		data, _ := json.Marshal(p)
+		w.Write([]byte("data: "))
+		w.Write(data)
+		w.Write([]byte("\n\n"))
+		flusher.Flush()
+	}
+}
+
+// ── Single-flight guard ───────────────────────────────────────────
+
+// SingleFlight is a simple mutex-based guard that ensures only one operation
+// runs at a time. Returns false (and writes a 409 Conflict) if busy.
+type SingleFlight struct {
+	mu      sync.Mutex
+	running bool
+}
+
+// TryAcquire attempts to acquire the lock. If already running, writes a
+// 409 Conflict JSON response and returns false. On success, returns true
+// and the caller must call Release() when done (typically via defer).
+func (sf *SingleFlight) TryAcquire(w http.ResponseWriter, label string) bool {
+	sf.mu.Lock()
+	if sf.running {
+		sf.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]string{"error": label + " already running"})
+		return false
+	}
+	sf.running = true
+	sf.mu.Unlock()
+	return true
+}
+
+// Release marks the operation as complete.
+func (sf *SingleFlight) Release() {
+	sf.mu.Lock()
+	sf.running = false
+	sf.mu.Unlock()
 }

--- a/netutil/netutil.go
+++ b/netutil/netutil.go
@@ -1,0 +1,55 @@
+// Package netutil provides shared IP classification helpers used across
+// multiple packages (talkers, conntrack, topology, handler).
+package netutil
+
+import "net"
+
+// CGNAT is the RFC 6598 Carrier-Grade NAT range (100.64.0.0/10).
+var CGNAT = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
+// IsLocal returns true if ip falls within any of the given local networks.
+// If localNets is empty, falls back to heuristic: RFC1918 + link-local, excluding CGNAT.
+func IsLocal(ip net.IP, localNets []*net.IPNet) bool {
+	if ip == nil {
+		return false
+	}
+	if len(localNets) > 0 {
+		for _, n := range localNets {
+			if n.Contains(ip) {
+				return true
+			}
+		}
+		return false
+	}
+	if CGNAT.Contains(ip) {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
+
+// IsLocalStr is a convenience wrapper that parses the IP string first.
+func IsLocalStr(ipStr string, localNets []*net.IPNet) bool {
+	return IsLocal(net.ParseIP(ipStr), localNets)
+}
+
+// IsGlobalUnicast returns true if the IP is globally routable unicast.
+// Returns false for private, loopback, link-local, CGNAT, and ULA addresses.
+func IsGlobalUnicast(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
+		return false
+	}
+	if CGNAT.Contains(ip) {
+		return false
+	}
+	// IPv6 ULA (fc00::/7)
+	if len(ip) == net.IPv6len && ip[0]&0xfe == 0xfc {
+		return false
+	}
+	return ip.IsGlobalUnicast()
+}

--- a/omada/omada.go
+++ b/omada/omada.go
@@ -3,14 +3,11 @@
 package omada
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
-	"net/http/cookiejar"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -46,21 +43,14 @@ func New(baseURL, user, pass, siteName string, pollInterval time.Duration) *Clie
 	if siteName == "" {
 		siteName = "Default"
 	}
-	jar, _ := cookiejar.New(nil)
 	return &Client{
 		baseURL:  strings.TrimRight(baseURL, "/"),
 		user:     user,
 		pass:     pass,
 		siteName: siteName,
 		interval: pollInterval,
-		httpC: &http.Client{
-			Timeout: 15 * time.Second,
-			Jar:     jar,
-			Transport: httputil.WrapTransport(&http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}),
-		},
-		stopCh: make(chan struct{}),
+		httpC:    httputil.NewInsecureClient(15 * time.Second),
+		stopCh:   make(chan struct{}),
 	}
 }
 
@@ -134,20 +124,9 @@ func (c *Client) poll() {
 	if c.lastPoll.IsZero() {
 		dt = 0
 	}
-	sum := c.buildSummary(devices, clients, dt)
+	sum := wifi.BuildSummary("Omada", c.normalizeAPs(devices), c.normalizeClients(clients), dt, c.prevAP, c.prevSSID, c.prevCli)
 
-	newAP := make(map[string]wifi.ByteSnap, len(sum.APs))
-	for _, ap := range sum.APs {
-		newAP[ap.MAC] = wifi.ByteSnap{Tx: ap.TxBytes, Rx: ap.RxBytes}
-	}
-	newSSID := make(map[string]wifi.ByteSnap, len(sum.SSIDs))
-	for _, s := range sum.SSIDs {
-		newSSID[s.Name] = wifi.ByteSnap{Tx: s.TxBytes, Rx: s.RxBytes}
-	}
-	newCli := make(map[string]wifi.ByteSnap, len(sum.Clients))
-	for _, cl := range sum.Clients {
-		newCli[cl.MAC] = wifi.ByteSnap{Tx: cl.TxBytes, Rx: cl.RxBytes}
-	}
+	newAP, newSSID, newCli := wifi.StoreSnapshots(sum)
 
 	c.mu.Lock()
 	c.summary = sum
@@ -373,10 +352,10 @@ func (c *Client) setHeaders(req *http.Request) {
 	}
 }
 
-// -- Summary building --
+// -- Normalization --
 
-func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float64) *wifi.Summary {
-	var aps []wifi.APInfo
+func (c *Client) normalizeAPs(devices []rawDevice) []wifi.NormalizedAP {
+	var aps []wifi.NormalizedAP
 	for _, d := range devices {
 		if d.Type != "ap" {
 			continue
@@ -385,95 +364,31 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		if d.Status == 14 {
 			status = "connected"
 		}
-		ap := wifi.APInfo{
+		aps = append(aps, wifi.NormalizedAP{
 			Name: d.Name, Model: d.Model, MAC: d.MAC, IP: d.IP,
 			Version: d.Version, Status: status, NumClients: d.ClientNum,
 			Uptime: d.Uptime, TxBytes: d.TxBytes, RxBytes: d.RxBytes,
-		}
-		if dt > 0 {
-			if prev, ok := c.prevAP[d.MAC]; ok {
-				ap.TxRate, ap.RxRate = wifi.ComputeRates(d.TxBytes, d.RxBytes, prev, dt)
-			}
-		}
-		aps = append(aps, ap)
+		})
 	}
-	sort.Slice(aps, func(i, j int) bool { return aps[i].Name < aps[j].Name })
+	return aps
+}
 
-	type ssidAcc struct {
-		n  int
-		tx int64
-		rx int64
-	}
-	sm := make(map[string]*ssidAcc)
-	tw := 0
+func (c *Client) normalizeClients(clients []rawClient) []wifi.NormalizedClient {
+	var ncs []wifi.NormalizedClient
 	for _, cl := range clients {
-		if !cl.Wireless {
-			continue
-		}
-		tw++
-		if cl.SSID != "" {
-			a, ok := sm[cl.SSID]
-			if !ok {
-				a = &ssidAcc{}
-				sm[cl.SSID] = a
-			}
-			a.n++
-			a.tx += cl.TxBytes
-			a.rx += cl.RxBytes
-		}
-	}
-
-	var ssids []wifi.SSIDStat
-	for name, a := range sm {
-		s := wifi.SSIDStat{Name: name, NumClients: a.n, TxBytes: a.tx, RxBytes: a.rx}
-		if dt > 0 {
-			if prev, ok := c.prevSSID[name]; ok {
-				s.TxRate, s.RxRate = wifi.ComputeRates(a.tx, a.rx, prev, dt)
-			}
-		}
-		ssids = append(ssids, s)
-	}
-	sort.Slice(ssids, func(i, j int) bool { return ssids[i].NumClients > ssids[j].NumClients })
-
-	apNames := make(map[string]string, len(aps))
-	for _, ap := range aps {
-		apNames[ap.MAC] = ap.Name
-	}
-
-	var cis []wifi.ClientInfo
-	for _, cl := range clients {
-		if !cl.Wireless {
-			continue
-		}
 		hn := cl.Hostname
 		if hn == "" {
 			hn = cl.Name
 		}
-		ci := wifi.ClientInfo{
+		ncs = append(ncs, wifi.NormalizedClient{
 			MAC: cl.MAC, Hostname: hn, IP: cl.IP, SSID: cl.SSID,
 			APMAC: cl.APMAC, APName: cl.APName, Signal: cl.SignalDB,
 			Channel: cl.Channel, Radio: radioName(cl.RadioID),
 			TxBytes: cl.TxBytes, RxBytes: cl.RxBytes,
-		}
-		if dt > 0 {
-			if prev, ok := c.prevCli[cl.MAC]; ok {
-				ci.TxRate, ci.RxRate = wifi.ComputeRates(cl.TxBytes, cl.RxBytes, prev, dt)
-			}
-		}
-		cis = append(cis, ci)
+			IsWireless: cl.Wireless,
+		})
 	}
-	sort.Slice(cis, func(i, j int) bool {
-		return (cis[i].TxBytes + cis[i].RxBytes) > (cis[j].TxBytes + cis[j].RxBytes)
-	})
-
-	return &wifi.Summary{
-		ProviderName: "Omada",
-		TotalAPs:     len(aps),
-		TotalClients: tw,
-		APs:          aps,
-		SSIDs:        ssids,
-		Clients:      cis,
-	}
+	return ncs
 }
 
 func radioName(id int) string {

--- a/pihole/pihole.go
+++ b/pihole/pihole.go
@@ -2,7 +2,6 @@ package pihole
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -111,16 +110,11 @@ type historyResp struct {
 // baseURL should be like "http://pi.hole" or "https://192.168.1.2" (no trailing slash).
 func New(baseURL, password string, pollInterval time.Duration) *Client {
 	return &Client{
-		baseURL:  baseURL,
-		password: password,
-		interval: pollInterval,
-		httpClient: &http.Client{
-			Timeout: 15 * time.Second,
-			Transport: httputil.WrapTransport(&http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}),
-		},
-		stopCh: make(chan struct{}),
+		baseURL:    baseURL,
+		password:   password,
+		interval:   pollInterval,
+		httpClient: httputil.NewInsecureClient(15 * time.Second),
+		stopCh:     make(chan struct{}),
 	}
 }
 

--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -203,45 +203,20 @@ func measurePing(server string, samples int) (avgMs, jitterMs float64, err error
 	return avgMs, jitterMs, nil
 }
 
-func measureDownload(server string, ch chan<- Progress) (float64, error) {
-	const (
-		duration    = 15 * time.Second
-		parallelism = 6
-	)
-
+// measureThroughput runs parallelism goroutines calling workerFn for the
+// given duration, reporting progress on ch under the given phase name.
+// Returns the measured throughput in Mbps.
+func measureThroughput(phase string, duration time.Duration, parallelism int, workerFn func(deadline time.Time, counter *int64, mu *sync.Mutex), ch chan<- Progress) (float64, error) {
 	var totalBytes int64
 	var mu sync.Mutex
 	deadline := time.Now().Add(duration)
 
 	var wg sync.WaitGroup
-
 	for i := 0; i < parallelism; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			client := &http.Client{
-				Timeout:   duration + 5*time.Second,
-				Transport: httputil.WrapTransport(nil),
-			}
-			buf := make([]byte, 256*1024)
-			for time.Now().Before(deadline) {
-				resp, e := client.Get(server + "/downloading")
-				if e != nil {
-					return
-				}
-				for time.Now().Before(deadline) {
-					n, e := resp.Body.Read(buf)
-					if n > 0 {
-						mu.Lock()
-						totalBytes += int64(n)
-						mu.Unlock()
-					}
-					if e != nil {
-						break
-					}
-				}
-				resp.Body.Close()
-			}
+			workerFn(deadline, &totalBytes, &mu)
 		}()
 	}
 
@@ -270,7 +245,7 @@ loop:
 			b := totalBytes
 			mu.Unlock()
 			mbps := (float64(b) * 8) / (elapsed * 1e6)
-			ch <- Progress{Phase: "download", Percent: pct, Value: mbps}
+			ch <- Progress{Phase: phase, Percent: pct, Value: mbps}
 		}
 	}
 
@@ -280,12 +255,47 @@ loop:
 
 	elapsed := time.Since(startTime).Seconds()
 	if elapsed == 0 || b == 0 {
-		return 0, fmt.Errorf("no data downloaded")
+		return 0, fmt.Errorf("no data transferred during %s", phase)
 	}
 
 	mbps := (float64(b) * 8) / (elapsed * 1e6)
-	ch <- Progress{Phase: "download", Percent: 100, Value: mbps}
+	ch <- Progress{Phase: phase, Percent: 100, Value: mbps}
 	return mbps, nil
+}
+
+func measureDownload(server string, ch chan<- Progress) (float64, error) {
+	const (
+		duration    = 15 * time.Second
+		parallelism = 6
+	)
+
+	workerFn := func(deadline time.Time, counter *int64, mu *sync.Mutex) {
+		client := &http.Client{
+			Timeout:   duration + 5*time.Second,
+			Transport: httputil.WrapTransport(nil),
+		}
+		buf := make([]byte, 256*1024)
+		for time.Now().Before(deadline) {
+			resp, e := client.Get(server + "/downloading")
+			if e != nil {
+				return
+			}
+			for time.Now().Before(deadline) {
+				n, e := resp.Body.Read(buf)
+				if n > 0 {
+					mu.Lock()
+					*counter += int64(n)
+					mu.Unlock()
+				}
+				if e != nil {
+					break
+				}
+			}
+			resp.Body.Close()
+		}
+	}
+
+	return measureThroughput("download", duration, parallelism, workerFn, ch)
 }
 
 func measureUpload(server string, ch chan<- Progress) (float64, error) {
@@ -295,87 +305,37 @@ func measureUpload(server string, ch chan<- Progress) (float64, error) {
 		chunkSize   = 4 * 1024 * 1024
 	)
 
-	var totalBytes int64
-	var mu sync.Mutex
-	deadline := time.Now().Add(duration)
+	workerFn := func(deadline time.Time, counter *int64, mu *sync.Mutex) {
+		client := &http.Client{
+			Timeout:   duration + 5*time.Second,
+			Transport: httputil.WrapTransport(nil),
+		}
+		data := make([]byte, chunkSize)
+		rand.Read(data)
 
-	var wg sync.WaitGroup
-
-	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			client := &http.Client{
-				Timeout:   duration + 5*time.Second,
-				Transport: httputil.WrapTransport(nil),
+		for time.Now().Before(deadline) {
+			reader := &countingReader{
+				data:    data,
+				mu:      mu,
+				counter: counter,
 			}
-			data := make([]byte, chunkSize)
-			rand.Read(data)
-
-			for time.Now().Before(deadline) {
-				reader := &countingReader{
-					data:    data,
-					mu:      &mu,
-					counter: &totalBytes,
-				}
-				req, e := http.NewRequest("POST", server+"/upload", reader)
-				if e != nil {
-					return
-				}
-				req.ContentLength = int64(chunkSize)
-				req.Header.Set("Content-Type", "application/octet-stream")
-
-				resp, e := client.Do(req)
-				if e != nil {
-					continue
-				}
-				io.Copy(io.Discard, resp.Body)
-				resp.Body.Close()
+			req, e := http.NewRequest("POST", server+"/upload", reader)
+			if e != nil {
+				return
 			}
-		}()
-	}
+			req.ContentLength = int64(chunkSize)
+			req.Header.Set("Content-Type", "application/octet-stream")
 
-	startTime := time.Now()
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-loop:
-	for {
-		select {
-		case <-done:
-			break loop
-		case <-ticker.C:
-			elapsed := time.Since(startTime).Seconds()
-			pct := (elapsed / duration.Seconds()) * 100
-			if pct > 100 {
-				pct = 100
+			resp, e := client.Do(req)
+			if e != nil {
+				continue
 			}
-			mu.Lock()
-			b := totalBytes
-			mu.Unlock()
-			mbps := (float64(b) * 8) / (elapsed * 1e6)
-			ch <- Progress{Phase: "upload", Percent: pct, Value: mbps}
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
 		}
 	}
 
-	mu.Lock()
-	b := totalBytes
-	mu.Unlock()
-
-	elapsed := time.Since(startTime).Seconds()
-	if elapsed == 0 || b == 0 {
-		return 0, fmt.Errorf("no data uploaded")
-	}
-
-	mbps := (float64(b) * 8) / (elapsed * 1e6)
-	ch <- Progress{Phase: "upload", Percent: 100, Value: mbps}
-	return mbps, nil
+	return measureThroughput("upload", duration, parallelism, workerFn, ch)
 }
 
 type countingReader struct {

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"bandwidth-monitor/geoip"
+	"bandwidth-monitor/netutil"
 	"bandwidth-monitor/packets"
 	"bandwidth-monitor/resolver"
 
@@ -71,6 +72,17 @@ type hostAccum struct {
 	rxBytes uint64 // towards local nets (download)
 	txBytes uint64 // from local nets (upload)
 	packets uint64
+}
+
+// parsedPkt holds the pre-parsed fields of a single packet for batch processing.
+type parsedPkt struct {
+	srcStr, dstStr       string
+	srcLocal, dstLocal   bool
+	srcSelf, dstSelf     bool
+	srcLoopLL, dstLoopLL bool
+	wireLen              uint64
+	proto                string
+	ipVersion            string
 }
 
 type Tracker struct {
@@ -255,7 +267,7 @@ func (t *Tracker) TopByVolume(n int) []TalkerStat {
 		if ip != nil && ip.IsLoopback() {
 			continue
 		}
-		s.IsLocal = ip != nil && (ip.IsPrivate() || ip.IsLinkLocalUnicast() || t.isLocalNet(ip))
+		s.IsLocal = ip != nil && netutil.IsLocal(ip, t.localNets)
 		list = append(list, *s)
 	}
 	sort.Slice(list, func(i, j int) bool {
@@ -270,7 +282,7 @@ func (t *Tracker) TopByVolume(n int) []TalkerStat {
 		if t.dns != nil {
 			list[i].Hostname = t.dns.LookupAddrAsync(list[i].IP)
 		}
-		t.enrichGeo(&list[i])
+		t.geoDB.Enrich(list[i].IP, &list[i])
 	}
 	return list
 }
@@ -298,7 +310,7 @@ func (t *Tracker) TopByBandwidth(n int) []TalkerStat {
 		if parsedIP != nil && parsedIP.IsLoopback() {
 			continue
 		}
-		isLocal := parsedIP != nil && (parsedIP.IsPrivate() || parsedIP.IsLinkLocalUnicast() || t.isLocalNet(parsedIP))
+		isLocal := parsedIP != nil && netutil.IsLocal(parsedIP, t.localNets)
 		list = append(list, TalkerStat{
 			IP:         ip,
 			TotalBytes: r.bytes,
@@ -323,7 +335,7 @@ func (t *Tracker) TopByBandwidth(n int) []TalkerStat {
 		if t.dns != nil {
 			list[i].Hostname = t.dns.LookupAddrAsync(list[i].IP)
 		}
-		t.enrichGeo(&list[i])
+		t.geoDB.Enrich(list[i].IP, &list[i])
 	}
 	return list
 }
@@ -359,17 +371,6 @@ func (t *Tracker) captureDevice(device string) {
 	}
 	defer ring.Close()
 	log.Printf("talkers: TPACKET_V3 ring on %s", device)
-
-	// Parsed packet for batch processing — stack-allocated, no heap.
-	type parsedPkt struct {
-		srcStr, dstStr       string
-		srcLocal, dstLocal   bool
-		srcSelf, dstSelf     bool
-		srcLoopLL, dstLoopLL bool
-		wireLen              uint64
-		proto                string
-		ipVersion            string
-	}
 
 	// IP string cache: avoids heap-allocating net.IP.String() for every
 	// packet. At 10 MB/s there are ~7000 pps but only 10-100 unique IPs.
@@ -430,8 +431,8 @@ func (t *Tracker) captureDevice(device string) {
 			batch = append(batch, parsedPkt{
 				srcStr:    srcStr,
 				dstStr:    dstStr,
-				srcLocal:  isLocalIP(srcIP) || t.isLocalNet(srcIP),
-				dstLocal:  isLocalIP(dstIP) || t.isLocalNet(dstIP),
+				srcLocal:  netutil.IsLocal(srcIP, t.localNets),
+				dstLocal:  netutil.IsLocal(dstIP, t.localNets),
 				srcSelf:   srcSelf,
 				dstSelf:   dstSelf,
 				srcLoopLL: srcIP.IsLoopback() || srcIP.IsLinkLocalUnicast(),
@@ -457,95 +458,105 @@ func (t *Tracker) captureDevice(device string) {
 		rSlot := t.rateRing[t.rateRingIdx]
 		for i := range batch {
 			p := &batch[i]
-			// Host accounting
-			for _, entry := range []struct {
-				ip     string
-				local  bool
-				loopLL bool
-			}{
-				{p.srcStr, p.srcLocal, p.srcLoopLL},
-				{p.dstStr, p.dstLocal, p.dstLoopLL},
-			} {
-				if entry.loopLL {
-					continue
-				}
-				if _, ok := t.current.hosts[entry.ip]; !ok {
-					if len(t.current.hosts) >= maxHostsPerBucket {
-						continue
-					}
-					t.current.hosts[entry.ip] = &hostAccum{}
-				}
-				t.current.hosts[entry.ip].bytes += p.wireLen
-				t.current.hosts[entry.ip].packets++
-
-				// Rate ring: mirror byte + packet accounting
-				if rSlot != nil {
-					if _, ok := rSlot.hosts[entry.ip]; !ok {
-						rSlot.hosts[entry.ip] = &hostAccum{}
-					}
-					rSlot.hosts[entry.ip].bytes += p.wireLen
-					rSlot.hosts[entry.ip].packets++
-				}
-			}
-
-			// Direction detection
-			if len(t.localNets) > 0 {
-				if p.srcLocal && !p.dstLocal {
-					if h, ok := t.current.hosts[p.dstStr]; ok {
-						h.txBytes += p.wireLen
-					}
-					if rSlot != nil {
-						if h, ok := rSlot.hosts[p.dstStr]; ok {
-							h.txBytes += p.wireLen
-						}
-					}
-				} else if !p.srcLocal && p.dstLocal {
-					if h, ok := t.current.hosts[p.srcStr]; ok {
-						h.rxBytes += p.wireLen
-					}
-					if rSlot != nil {
-						if h, ok := rSlot.hosts[p.srcStr]; ok {
-							h.rxBytes += p.wireLen
-						}
-					}
-				} else if p.srcLocal && p.dstLocal {
-					if p.srcSelf && !p.dstSelf {
-						if h, ok := t.current.hosts[p.dstStr]; ok {
-							h.txBytes += p.wireLen
-						}
-						if h, ok := t.current.hosts[p.srcStr]; ok {
-							h.txBytes += p.wireLen
-						}
-						if rSlot != nil {
-							if h, ok := rSlot.hosts[p.dstStr]; ok {
-								h.txBytes += p.wireLen
-							}
-							if h, ok := rSlot.hosts[p.srcStr]; ok {
-								h.txBytes += p.wireLen
-							}
-						}
-					} else if p.dstSelf && !p.srcSelf {
-						if h, ok := t.current.hosts[p.srcStr]; ok {
-							h.rxBytes += p.wireLen
-						}
-						if h, ok := t.current.hosts[p.dstStr]; ok {
-							h.rxBytes += p.wireLen
-						}
-						if rSlot != nil {
-							if h, ok := rSlot.hosts[p.srcStr]; ok {
-								h.rxBytes += p.wireLen
-							}
-							if h, ok := rSlot.hosts[p.dstStr]; ok {
-								h.rxBytes += p.wireLen
-							}
-						}
-					}
-				}
-			}
+			t.accountPacket(p, t.current, rSlot)
+			t.accountDirection(p, t.current, rSlot)
 			t.current.protoBytes[p.proto] += p.wireLen
 			t.current.ipVerBytes[p.ipVersion] += p.wireLen
 		}
 		t.mu.Unlock()
+	}
+}
+
+// accountPacket updates host byte/packet counters in the current bucket and
+// rate ring slot for both endpoints of a parsed packet.
+// Must be called with t.mu held.
+func (t *Tracker) accountPacket(p *parsedPkt, current *bucket, rSlot *rateSlot) {
+	for _, entry := range []struct {
+		ip     string
+		loopLL bool
+	}{
+		{p.srcStr, p.srcLoopLL},
+		{p.dstStr, p.dstLoopLL},
+	} {
+		if entry.loopLL {
+			continue
+		}
+		if _, ok := current.hosts[entry.ip]; !ok {
+			if len(current.hosts) >= maxHostsPerBucket {
+				continue
+			}
+			current.hosts[entry.ip] = &hostAccum{}
+		}
+		current.hosts[entry.ip].bytes += p.wireLen
+		current.hosts[entry.ip].packets++
+
+		if rSlot != nil {
+			if _, ok := rSlot.hosts[entry.ip]; !ok {
+				rSlot.hosts[entry.ip] = &hostAccum{}
+			}
+			rSlot.hosts[entry.ip].bytes += p.wireLen
+			rSlot.hosts[entry.ip].packets++
+		}
+	}
+}
+
+// accountDirection updates rx/tx byte counters based on local-net direction
+// detection for a parsed packet.
+// Must be called with t.mu held.
+func (t *Tracker) accountDirection(p *parsedPkt, current *bucket, rSlot *rateSlot) {
+	if len(t.localNets) == 0 {
+		return
+	}
+	if p.srcLocal && !p.dstLocal {
+		if h, ok := current.hosts[p.dstStr]; ok {
+			h.txBytes += p.wireLen
+		}
+		if rSlot != nil {
+			if h, ok := rSlot.hosts[p.dstStr]; ok {
+				h.txBytes += p.wireLen
+			}
+		}
+	} else if !p.srcLocal && p.dstLocal {
+		if h, ok := current.hosts[p.srcStr]; ok {
+			h.rxBytes += p.wireLen
+		}
+		if rSlot != nil {
+			if h, ok := rSlot.hosts[p.srcStr]; ok {
+				h.rxBytes += p.wireLen
+			}
+		}
+	} else if p.srcLocal && p.dstLocal {
+		if p.srcSelf && !p.dstSelf {
+			if h, ok := current.hosts[p.dstStr]; ok {
+				h.txBytes += p.wireLen
+			}
+			if h, ok := current.hosts[p.srcStr]; ok {
+				h.txBytes += p.wireLen
+			}
+			if rSlot != nil {
+				if h, ok := rSlot.hosts[p.dstStr]; ok {
+					h.txBytes += p.wireLen
+				}
+				if h, ok := rSlot.hosts[p.srcStr]; ok {
+					h.txBytes += p.wireLen
+				}
+			}
+		} else if p.dstSelf && !p.srcSelf {
+			if h, ok := current.hosts[p.srcStr]; ok {
+				h.rxBytes += p.wireLen
+			}
+			if h, ok := current.hosts[p.dstStr]; ok {
+				h.rxBytes += p.wireLen
+			}
+			if rSlot != nil {
+				if h, ok := rSlot.hosts[p.srcStr]; ok {
+					h.rxBytes += p.wireLen
+				}
+				if h, ok := rSlot.hosts[p.dstStr]; ok {
+					h.rxBytes += p.wireLen
+				}
+			}
+		}
 	}
 }
 
@@ -697,22 +708,15 @@ type ASNStat struct {
 	Connections int    `json:"connections"`
 }
 
-// enrichGeo populates geo fields on a TalkerStat from the MMDB.
-func (t *Tracker) enrichGeo(s *TalkerStat) {
-	if t.geoDB == nil {
-		return
-	}
-	geo := t.geoDB.Lookup(s.IP)
-	if geo == nil {
-		return
-	}
-	s.Country = geo.Country
-	s.CountryName = geo.CountryName
-	s.City = geo.City
-	s.Latitude = geo.Latitude
-	s.Longitude = geo.Longitude
-	s.ASN = geo.ASN
-	s.ASOrg = geo.ASOrg
+// SetGeo implements geoip.GeoFields.
+func (s *TalkerStat) SetGeo(country, countryName, city string, lat, lon float64, asn uint, asOrg string) {
+	s.Country = country
+	s.CountryName = countryName
+	s.City = city
+	s.Latitude = lat
+	s.Longitude = lon
+	s.ASN = asn
+	s.ASOrg = asOrg
 }
 
 // GeoBreakdown holds both per-country and per-ASN traffic summaries,
@@ -762,10 +766,7 @@ func (t *Tracker) GetGeoBreakdown() *GeoBreakdown {
 		// Skip local/private/self IPs — they have no GeoIP data and
 		// inflate the "Unknown" category.
 		parsedIP := net.ParseIP(ip)
-		if parsedIP != nil && (parsedIP.IsPrivate() || parsedIP.IsLoopback() || parsedIP.IsLinkLocalUnicast()) {
-			continue
-		}
-		if parsedIP != nil && t.isLocalNet(parsedIP) {
+		if parsedIP != nil && (parsedIP.IsLoopback() || netutil.IsLocal(parsedIP, t.localNets)) {
 			continue
 		}
 		if _, isSelf := t.selfIPs[ip]; isSelf {
@@ -835,24 +836,6 @@ func (t *Tracker) GetGeoBreakdown() *GeoBreakdown {
 		Countries: countryResult,
 		ASNs:      asnResult,
 	}
-}
-
-// isLocalIP checks if an IP is private, loopback, or link-local.
-// Uses Go's built-in methods — zero allocations.
-func isLocalIP(ip net.IP) bool {
-	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast()
-}
-
-func (t *Tracker) isLocalNet(ip net.IP) bool {
-	if len(t.localNets) == 0 {
-		return false
-	}
-	for _, n := range t.localNets {
-		if n.Contains(ip) {
-			return true
-		}
-	}
-	return false
 }
 
 // BucketPoint is a single 1-minute data point for a host.
@@ -937,7 +920,7 @@ func (t *Tracker) HostTotals(ip string) *TalkerStat {
 	if t.dns != nil {
 		stat.Hostname = t.dns.LookupAddr(ip)
 	}
-	t.enrichGeo(stat)
+	t.geoDB.Enrich(stat.IP, stat)
 	return stat
 }
 

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -18,6 +19,7 @@ import (
 	vnl "github.com/vishvananda/netlink"
 	"golang.zx2c4.com/wireguard/wgctrl"
 
+	"bandwidth-monitor/netutil"
 	"bandwidth-monitor/resolver"
 	"bandwidth-monitor/wifi"
 )
@@ -153,8 +155,8 @@ func (s *Scanner) scan() {
 	selfNode := s.discoverSelf(nodeMap)
 	gwNode := s.discoverGateway(nodeMap, selfNode)
 	s.discoverWAN(nodeMap, linkSet, selfNode)
-	s.readARPTable(nodeMap)
-	s.readNDPTable(nodeMap)
+	s.readNeighTable(nodeMap, vnl.FAMILY_V4, "arp")
+	s.readNeighTable(nodeMap, vnl.FAMILY_V6, "ndp")
 	s.readLLDP(nodeMap, linkSet)
 	s.mergeWiFiController(nodeMap, linkSet)
 	s.resolveHostnames(nodeMap)
@@ -411,7 +413,7 @@ func (s *Scanner) discoverWireGuard(nodeMap map[string]*Node, linkSet map[string
 				ones, _ := aip.Mask.Size()
 				if (aip.IP.To4() != nil && ones == 32) || (aip.IP.To4() == nil && ones == 128) {
 					ipStr := aip.IP.String()
-					if !containsStr(ips, ipStr) {
+					if !slices.Contains(ips, ipStr) {
 						ips = append(ips, ipStr)
 					}
 				}
@@ -558,13 +560,13 @@ func neighStateStr(state int) string {
 	}
 }
 
-// ── ARP table (via netlink) ────────────────────────────────────────
+// ── Neighbor table (ARP/NDP via netlink) ──────────────────────────────────
 
-func (s *Scanner) readARPTable(nodeMap map[string]*Node) {
+func (s *Scanner) readNeighTable(nodeMap map[string]*Node, family int, sourceTag string) {
 	ifaceNames := nlIfaceNames()
-	neighbors, err := vnl.NeighList(0, vnl.FAMILY_V4)
+	neighbors, err := vnl.NeighList(0, family)
 	if err != nil {
-		log.Printf("topology: netlink NeighList IPv4: %v", err)
+		log.Printf("topology: netlink NeighList %s: %v", sourceTag, err)
 		return
 	}
 
@@ -573,7 +575,7 @@ func (s *Scanner) readARPTable(nodeMap map[string]*Node) {
 			continue
 		}
 		ip := n.IP.String()
-		if !s.isLocalIP(ip) {
+		if !netutil.IsLocalStr(ip, s.localNets) {
 			continue
 		}
 
@@ -586,57 +588,7 @@ func (s *Scanner) readARPTable(nodeMap map[string]*Node) {
 		state := neighStateStr(n.State)
 
 		if existing, ok := nodeMap[mac]; ok {
-			if !containsStr(existing.IPs, ip) {
-				existing.IPs = append(existing.IPs, ip)
-			}
-			if existing.Iface == "" {
-				existing.Iface = iface
-			}
-			if !strings.Contains(existing.Source, "arp") {
-				existing.Source += ",arp"
-			}
-		} else {
-			nodeMap[mac] = &Node{
-				ID:     mac,
-				MAC:    mac,
-				IPs:    []string{ip},
-				Type:   NodeClient,
-				Iface:  iface,
-				State:  state,
-				Source: "arp",
-			}
-		}
-	}
-}
-
-// ── NDP table (via netlink) ────────────────────────────────────────
-
-func (s *Scanner) readNDPTable(nodeMap map[string]*Node) {
-	ifaceNames := nlIfaceNames()
-	neighbors, err := vnl.NeighList(0, vnl.FAMILY_V6)
-	if err != nil {
-		return
-	}
-
-	for _, n := range neighbors {
-		if !neighValid(n) {
-			continue
-		}
-		ip := n.IP.String()
-		if !s.isLocalIP(ip) {
-			continue
-		}
-
-		mac := strings.ToLower(n.HardwareAddr.String())
-		// Skip if this MAC is already tracked as a WAN gateway
-		if _, isWAN := nodeMap["wan-"+mac]; isWAN {
-			continue
-		}
-		iface := ifaceNames[n.LinkIndex]
-		state := neighStateStr(n.State)
-
-		if existing, ok := nodeMap[mac]; ok {
-			if !containsStr(existing.IPs, ip) {
+			if !slices.Contains(existing.IPs, ip) {
 				existing.IPs = append(existing.IPs, ip)
 			}
 			if existing.Iface == "" {
@@ -645,8 +597,8 @@ func (s *Scanner) readNDPTable(nodeMap map[string]*Node) {
 			if existing.State == "" {
 				existing.State = state
 			}
-			if !strings.Contains(existing.Source, "ndp") {
-				existing.Source += ",ndp"
+			if !strings.Contains(existing.Source, sourceTag) {
+				existing.Source += "," + sourceTag
 			}
 		} else {
 			nodeMap[mac] = &Node{
@@ -656,7 +608,7 @@ func (s *Scanner) readNDPTable(nodeMap map[string]*Node) {
 				Type:   NodeClient,
 				Iface:  iface,
 				State:  state,
-				Source: "ndp",
+				Source: sourceTag,
 			}
 		}
 	}
@@ -748,7 +700,7 @@ func (s *Scanner) parseLLDPCtlKeyValue(data string, nodeMap map[string]*Node, li
 			if existing.Hostname == "" && ni.sysName != "" {
 				existing.Hostname = ni.sysName
 			}
-			if ni.mgmtIP != "" && !containsStr(existing.IPs, ni.mgmtIP) {
+			if ni.mgmtIP != "" && !slices.Contains(existing.IPs, ni.mgmtIP) {
 				existing.IPs = append(existing.IPs, ni.mgmtIP)
 			}
 			if !strings.Contains(existing.Source, "lldp") {
@@ -825,7 +777,7 @@ func (s *Scanner) parseLLDPCLI(data string, nodeMap map[string]*Node, linkSet ma
 			if existing.Hostname == "" && sysName != "" {
 				existing.Hostname = sysName
 			}
-			if mgmtIP != "" && !containsStr(existing.IPs, mgmtIP) {
+			if mgmtIP != "" && !slices.Contains(existing.IPs, mgmtIP) {
 				existing.IPs = append(existing.IPs, mgmtIP)
 			}
 			if !strings.Contains(existing.Source, "lldp") {
@@ -908,7 +860,7 @@ func (s *Scanner) mergeWiFiController(nodeMap map[string]*Node, linkSet map[stri
 			if existing.Hostname == "" && ap.Name != "" {
 				existing.Hostname = ap.Name
 			}
-			if ap.IP != "" && !containsStr(existing.IPs, ap.IP) {
+			if ap.IP != "" && !slices.Contains(existing.IPs, ap.IP) {
 				existing.IPs = append(existing.IPs, ap.IP)
 			}
 			if !strings.Contains(existing.Source, providerName) {
@@ -939,7 +891,7 @@ func (s *Scanner) mergeWiFiController(nodeMap map[string]*Node, linkSet map[stri
 		apMAC := strings.ToLower(cl.APMAC)
 
 		if existing, ok := nodeMap[mac]; ok {
-			if cl.IP != "" && !containsStr(existing.IPs, cl.IP) {
+			if cl.IP != "" && !slices.Contains(existing.IPs, cl.IP) {
 				existing.IPs = append(existing.IPs, cl.IP)
 			}
 			if existing.Hostname == "" && cl.Hostname != "" {
@@ -1060,44 +1012,4 @@ func (s *Scanner) inferLinks(nodeMap map[string]*Node, linkSet map[string]*Link,
 			}
 		}
 	}
-}
-
-// ── Helpers ───────────────────────────────────────────────────────
-
-func containsStr(ss []string, s string) bool {
-	for _, v := range ss {
-		if v == s {
-			return true
-		}
-	}
-	return false
-}
-
-// CGNAT range 100.64.0.0/10
-var cgnatNet = func() *net.IPNet {
-	_, n, _ := net.ParseCIDR("100.64.0.0/10")
-	return n
-}()
-
-// isLocalIP returns true if the IP belongs to the configured local networks.
-// If no local networks are configured, falls back to RFC1918/link-local checks.
-// WAN-side addresses (CGNAT, public IPs, etc.) return false.
-func (s *Scanner) isLocalIP(ipStr string) bool {
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return false
-	}
-	if len(s.localNets) > 0 {
-		for _, n := range s.localNets {
-			if n.Contains(ip) {
-				return true
-			}
-		}
-		return false
-	}
-	// No localNets configured — use heuristic: private + link-local, exclude CGNAT
-	if cgnatNet.Contains(ip) {
-		return false
-	}
-	return ip.IsPrivate() || ip.IsLinkLocalUnicast()
 }

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -2,14 +2,11 @@ package unifi
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
-	"net/http/cookiejar"
-	"sort"
 	"sync"
 	"time"
 
@@ -45,21 +42,14 @@ func New(baseURL, user, pass, site string, pollInterval time.Duration) *Client {
 	if site == "" {
 		site = "default"
 	}
-	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  baseURL,
-		user:     user,
-		pass:     pass,
-		site:     site,
-		interval: pollInterval,
-		httpClient: &http.Client{
-			Timeout: 15 * time.Second,
-			Jar:     jar,
-			Transport: httputil.WrapTransport(&http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}),
-		},
-		stopCh: make(chan struct{}),
+		baseURL:    baseURL,
+		user:       user,
+		pass:       pass,
+		site:       site,
+		interval:   pollInterval,
+		httpClient: httputil.NewInsecureClient(15 * time.Second),
+		stopCh:     make(chan struct{}),
 	}
 }
 
@@ -132,21 +122,10 @@ func (c *Client) poll() {
 		dt = 0
 	}
 
-	sum := c.buildSummary(devices, clients, dt)
+	sum := wifi.BuildSummary("UniFi", c.normalizeAPs(devices), c.normalizeClients(clients), dt, c.prevAP, c.prevSSID, c.prevCli)
 
 	// Store current counters for next delta
-	newAP := make(map[string]wifi.ByteSnap, len(sum.APs))
-	for _, ap := range sum.APs {
-		newAP[ap.MAC] = wifi.ByteSnap{Tx: ap.TxBytes, Rx: ap.RxBytes}
-	}
-	newSSID := make(map[string]wifi.ByteSnap, len(sum.SSIDs))
-	for _, s := range sum.SSIDs {
-		newSSID[s.Name] = wifi.ByteSnap{Tx: s.TxBytes, Rx: s.RxBytes}
-	}
-	newCli := make(map[string]wifi.ByteSnap, len(sum.Clients))
-	for _, cl := range sum.Clients {
-		newCli[cl.MAC] = wifi.ByteSnap{Tx: cl.TxBytes, Rx: cl.RxBytes}
-	}
+	newAP, newSSID, newCli := wifi.StoreSnapshots(sum)
 
 	c.mu.Lock()
 	c.summary = sum
@@ -318,8 +297,8 @@ func (c *Client) fetchClients() ([]rawClient, error) {
 	return cr.Data, nil
 }
 
-func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float64) *wifi.Summary {
-	var aps []wifi.APInfo
+func (c *Client) normalizeAPs(devices []rawDevice) []wifi.NormalizedAP {
+	var aps []wifi.NormalizedAP
 	for _, d := range devices {
 		if d.Type != "uap" {
 			continue
@@ -328,108 +307,26 @@ func (c *Client) buildSummary(devices []rawDevice, clients []rawClient, dt float
 		if d.State == 1 {
 			status = "connected"
 		}
-		ap := wifi.APInfo{
-			Name:       d.Name,
-			Model:      d.Model,
-			MAC:        d.MAC,
-			IP:         d.IP,
-			Version:    d.Version,
-			Status:     status,
-			NumClients: d.NumSta,
-			Uptime:     d.Uptime,
-			TxBytes:    d.TxBytes,
-			RxBytes:    d.RxBytes,
-		}
-		if dt > 0 {
-			if prev, ok := c.prevAP[d.MAC]; ok {
-				ap.TxRate, ap.RxRate = wifi.ComputeRates(d.TxBytes, d.RxBytes, prev, dt)
-			}
-		}
-		aps = append(aps, ap)
+		aps = append(aps, wifi.NormalizedAP{
+			Name: d.Name, Model: d.Model, MAC: d.MAC, IP: d.IP,
+			Version: d.Version, Status: status, NumClients: d.NumSta,
+			Uptime: d.Uptime, TxBytes: d.TxBytes, RxBytes: d.RxBytes,
+		})
 	}
-	sort.Slice(aps, func(i, j int) bool { return aps[i].Name < aps[j].Name })
+	return aps
+}
 
-	type ssidAgg struct {
-		count   int
-		txBytes int64
-		rxBytes int64
-	}
-	ssidMap := make(map[string]*ssidAgg)
-	totalWireless := 0
+func (c *Client) normalizeClients(clients []rawClient) []wifi.NormalizedClient {
+	var ncs []wifi.NormalizedClient
 	for _, cl := range clients {
-		if cl.IsWired {
-			continue
-		}
-		totalWireless++
-		if cl.ESSID != "" {
-			a, ok := ssidMap[cl.ESSID]
-			if !ok {
-				a = &ssidAgg{}
-				ssidMap[cl.ESSID] = a
-			}
-			a.count++
-			a.txBytes += cl.TxBytes
-			a.rxBytes += cl.RxBytes
-		}
+		ncs = append(ncs, wifi.NormalizedClient{
+			MAC: cl.MAC, Hostname: cl.Hostname, IP: cl.IP, SSID: cl.ESSID,
+			APMAC: cl.APMAC, Signal: cl.Signal, Channel: cl.Channel,
+			Radio: cl.Radio, TxBytes: cl.TxBytes, RxBytes: cl.RxBytes,
+			IsWireless: !cl.IsWired,
+		})
 	}
-
-	var ssids []wifi.SSIDStat
-	for name, a := range ssidMap {
-		s := wifi.SSIDStat{Name: name, NumClients: a.count, TxBytes: a.txBytes, RxBytes: a.rxBytes}
-		if dt > 0 {
-			if prev, ok := c.prevSSID[name]; ok {
-				s.TxRate, s.RxRate = wifi.ComputeRates(a.txBytes, a.rxBytes, prev, dt)
-			}
-		}
-		ssids = append(ssids, s)
-	}
-	sort.Slice(ssids, func(i, j int) bool { return ssids[i].NumClients > ssids[j].NumClients })
-
-	// Build AP MAC → name lookup
-	apNames := make(map[string]string)
-	for _, ap := range aps {
-		apNames[ap.MAC] = ap.Name
-	}
-
-	// Build per-client list (wireless only), sorted by total traffic descending
-	var clientInfos []wifi.ClientInfo
-	for _, cl := range clients {
-		if cl.IsWired {
-			continue
-		}
-		ci := wifi.ClientInfo{
-			MAC:      cl.MAC,
-			Hostname: cl.Hostname,
-			IP:       cl.IP,
-			SSID:     cl.ESSID,
-			APMAC:    cl.APMAC,
-			APName:   apNames[cl.APMAC],
-			Signal:   cl.Signal,
-			Channel:  cl.Channel,
-			Radio:    cl.Radio,
-			TxBytes:  cl.TxBytes,
-			RxBytes:  cl.RxBytes,
-		}
-		if dt > 0 {
-			if prev, ok := c.prevCli[cl.MAC]; ok {
-				ci.TxRate, ci.RxRate = wifi.ComputeRates(cl.TxBytes, cl.RxBytes, prev, dt)
-			}
-		}
-		clientInfos = append(clientInfos, ci)
-	}
-	sort.Slice(clientInfos, func(i, j int) bool {
-		return (clientInfos[i].TxBytes + clientInfos[i].RxBytes) >
-			(clientInfos[j].TxBytes + clientInfos[j].RxBytes)
-	})
-
-	return &wifi.Summary{
-		ProviderName: "UniFi",
-		TotalAPs:     len(aps),
-		TotalClients: totalWireless,
-		APs:          aps,
-		SSIDs:        ssids,
-		Clients:      clientInfos,
-	}
+	return ncs
 }
 
 func (c *Client) String() string {

--- a/wifi/wifi.go
+++ b/wifi/wifi.go
@@ -2,6 +2,8 @@
 // (UniFi, Omada, etc.), following the same pattern as the dns package.
 package wifi
 
+import "sort"
+
 // Provider is implemented by any WiFi controller stats backend.
 type Provider interface {
 	GetSummary() *Summary
@@ -86,4 +88,120 @@ func ComputeRates(curTx, curRx int64, prev ByteSnap, dt float64) (float64, float
 	txRate := Clamp(float64(curTx-prev.Tx) / dt)
 	rxRate := Clamp(float64(curRx-prev.Rx) / dt)
 	return txRate, rxRate
+}
+
+// NormalizedAP is a controller-agnostic AP representation for BuildSummary.
+type NormalizedAP struct {
+	Name, Model, MAC, IP, Version, Status string
+	NumClients                            int
+	Uptime, TxBytes, RxBytes              int64
+}
+
+// NormalizedClient is a controller-agnostic client for BuildSummary.
+type NormalizedClient struct {
+	MAC, Hostname, IP, SSID, APMAC, APName string
+	Signal, Channel                        int
+	Radio                                  string
+	TxBytes, RxBytes                       int64
+	IsWireless                             bool
+}
+
+// BuildSummary creates a Summary from normalized AP and client data.
+// It handles SSID aggregation, rate computation, and sorting.
+func BuildSummary(providerName string, rawAPs []NormalizedAP, rawClients []NormalizedClient, dt float64, prevAP, prevSSID, prevCli map[string]ByteSnap) *Summary {
+	// Build APs
+	var aps []APInfo
+	for _, d := range rawAPs {
+		ap := APInfo{Name: d.Name, Model: d.Model, MAC: d.MAC, IP: d.IP, Version: d.Version, Status: d.Status, NumClients: d.NumClients, Uptime: d.Uptime, TxBytes: d.TxBytes, RxBytes: d.RxBytes}
+		if dt > 0 {
+			if prev, ok := prevAP[d.MAC]; ok {
+				ap.TxRate, ap.RxRate = ComputeRates(d.TxBytes, d.RxBytes, prev, dt)
+			}
+		}
+		aps = append(aps, ap)
+	}
+	sort.Slice(aps, func(i, j int) bool { return aps[i].Name < aps[j].Name })
+
+	// SSID aggregation
+	type ssidAcc struct {
+		count int
+		tx    int64
+		rx    int64
+	}
+	ssidMap := make(map[string]*ssidAcc)
+	totalWireless := 0
+	for _, cl := range rawClients {
+		if !cl.IsWireless {
+			continue
+		}
+		totalWireless++
+		if cl.SSID != "" {
+			a, ok := ssidMap[cl.SSID]
+			if !ok {
+				a = &ssidAcc{}
+				ssidMap[cl.SSID] = a
+			}
+			a.count++
+			a.tx += cl.TxBytes
+			a.rx += cl.RxBytes
+		}
+	}
+	var ssids []SSIDStat
+	for name, a := range ssidMap {
+		s := SSIDStat{Name: name, NumClients: a.count, TxBytes: a.tx, RxBytes: a.rx}
+		if dt > 0 {
+			if prev, ok := prevSSID[name]; ok {
+				s.TxRate, s.RxRate = ComputeRates(a.tx, a.rx, prev, dt)
+			}
+		}
+		ssids = append(ssids, s)
+	}
+	sort.Slice(ssids, func(i, j int) bool { return ssids[i].NumClients > ssids[j].NumClients })
+
+	// AP name lookup
+	apNames := make(map[string]string, len(aps))
+	for _, ap := range aps {
+		apNames[ap.MAC] = ap.Name
+	}
+
+	// Clients
+	var clients []ClientInfo
+	for _, cl := range rawClients {
+		if !cl.IsWireless {
+			continue
+		}
+		apName := cl.APName
+		if apName == "" {
+			apName = apNames[cl.APMAC]
+		}
+		ci := ClientInfo{MAC: cl.MAC, Hostname: cl.Hostname, IP: cl.IP, SSID: cl.SSID, APMAC: cl.APMAC, APName: apName, Signal: cl.Signal, Channel: cl.Channel, Radio: cl.Radio, TxBytes: cl.TxBytes, RxBytes: cl.RxBytes}
+		if dt > 0 {
+			if prev, ok := prevCli[cl.MAC]; ok {
+				ci.TxRate, ci.RxRate = ComputeRates(cl.TxBytes, cl.RxBytes, prev, dt)
+			}
+		}
+		clients = append(clients, ci)
+	}
+	sort.Slice(clients, func(i, j int) bool {
+		return (clients[i].TxBytes + clients[i].RxBytes) > (clients[j].TxBytes + clients[j].RxBytes)
+	})
+
+	return &Summary{ProviderName: providerName, TotalAPs: len(aps), TotalClients: totalWireless, APs: aps, SSIDs: ssids, Clients: clients}
+}
+
+// StoreSnapshots returns prev-maps for the next delta cycle from a Summary.
+func StoreSnapshots(sum *Summary) (ap, ssid, cli map[string]ByteSnap) {
+	ap = make(map[string]ByteSnap, len(sum.APs))
+	for _, a := range sum.APs {
+		ap[a.MAC] = ByteSnap{Tx: a.TxBytes, Rx: a.RxBytes}
+	}
+	ssid = make(map[string]ByteSnap, len(sum.SSIDs))
+	for _, s := range sum.SSIDs {
+		ssid[s.Name] = ByteSnap{Tx: s.TxBytes, Rx: s.RxBytes}
+	}
+	cli = make(map[string]ByteSnap, len(sum.Clients))
+	for _, c := range sum.Clients {
+		cli[c.MAC] = ByteSnap{Tx: c.TxBytes, Rx: c.RxBytes}
+	}
+	return
 }


### PR DESCRIPTION
refactor: deduplicate and simplify Go backend code

High-impact changes (from previous work in this branch):
- New netutil package: shared IP classification (IsLocal, IsLocalStr,
  IsGlobalUnicast) and CGNAT constant, replacing 4 independent
  implementations across talkers, conntrack, topology, and handler
- New wifi.BuildSummary + StoreSnapshots: shared summary builder
  eliminates ~120 lines of duplicated SSID aggregation, rate delta
  computation, and client sorting between UniFi and Omada providers
- httputil additions: StreamChannel[T] generic SSE helper, SingleFlight
  guard, WriteJSON/WriteJSONOrNull response helpers — used in handler
  to eliminate 3 copies of SSE boilerplate and 2 mutex guards
- Merged readARPTable/readNDPTable into a single readNeighTable(family,
  sourceTag) in topology, removing ~40 lines of identical code
- Replaced containsStr with slices.Contains throughout topology

Medium-impact changes (this commit):
- speedtest: extracted measureThroughput() shared by measureDownload
  and measureUpload, eliminating ~70 lines of duplicated goroutine
  pool, ticker progress, and rate computation logic
- httputil.NewInsecureClient: fixed cookie jar creation, now used by
  unifi, omada, and pihole — removing 3 copies of TLS skip + transport
  + jar boilerplate
- geoip: added GeoFields interface and Enrich() method; talkers and
  conntrack implement SetGeo() and use geoDB.Enrich() instead of
  manual field-by-field assignment
- talkers: broke captureDevice (197 lines) into captureDevice +
  accountPacket + accountDirection, keeping the hot loop concise

Total across all changes: -179 lines net (595 added, 774 removed),
12 files modified, 2 new packages (netutil, geoip enrichment interface).
All existing tests pass, go vet clean.
