### PR TITLE
fix: correct rx/tx direction for local client IPs

### DIFF
--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -526,31 +526,38 @@ func (t *Tracker) accountDirection(p *parsedPkt, current *bucket, rSlot *rateSlo
 			}
 		}
 	} else if p.srcLocal && p.dstLocal {
+		// Both endpoints are local. Use selfIPs to determine direction.
+		// "srcSelf → dstClient" means the router is forwarding TO the client,
+		// so from the CLIENT's perspective this is download (rx).
+		// "srcClient → dstSelf" means the client is sending through the router,
+		// so from the CLIENT's perspective this is upload (tx).
 		if p.srcSelf && !p.dstSelf {
+			// Router → Client: client is downloading (rx)
 			if h, ok := current.hosts[p.dstStr]; ok {
-				h.txBytes += p.wireLen
+				h.rxBytes += p.wireLen
 			}
 			if h, ok := current.hosts[p.srcStr]; ok {
 				h.txBytes += p.wireLen
 			}
 			if rSlot != nil {
 				if h, ok := rSlot.hosts[p.dstStr]; ok {
-					h.txBytes += p.wireLen
+					h.rxBytes += p.wireLen
 				}
 				if h, ok := rSlot.hosts[p.srcStr]; ok {
 					h.txBytes += p.wireLen
 				}
 			}
 		} else if p.dstSelf && !p.srcSelf {
+			// Client → Router: client is uploading (tx)
 			if h, ok := current.hosts[p.srcStr]; ok {
-				h.rxBytes += p.wireLen
+				h.txBytes += p.wireLen
 			}
 			if h, ok := current.hosts[p.dstStr]; ok {
 				h.rxBytes += p.wireLen
 			}
 			if rSlot != nil {
 				if h, ok := rSlot.hosts[p.srcStr]; ok {
-					h.rxBytes += p.wireLen
+					h.txBytes += p.wireLen
 				}
 				if h, ok := rSlot.hosts[p.dstStr]; ok {
 					h.rxBytes += p.wireLen


### PR DESCRIPTION
fix: correct rx/tx direction for local client IPs

The direction detection in accountDirection() stored bytes from the
router's perspective: when the router forwarded data TO a local client,
it was recorded as txBytes on the client.

From the client's perspective this is a download (rx), not an upload.
This caused download rates to appear as upload and vice versa for all
local IPs in the topology view and bandwidth API.

Fix: when the router sends to a client (srcSelf, dstClient), the
client's bytes are now correctly accounted as rxBytes (download).
Conversely, when a client sends to the router, client bytes are
txBytes (upload).
