### PR TITLE
refactor: extract shared poll runner and ICMP ping utility

### DIFF
--- a/adguard/adguard.go
+++ b/adguard/adguard.go
@@ -12,6 +12,7 @@ import (
 
 	"bandwidth-monitor/dns"
 	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/poller"
 )
 
 // Client polls ADGuard Home's REST API for DNS statistics.
@@ -25,7 +26,7 @@ type Client struct {
 	mu    sync.RWMutex
 	stats *Stats
 
-	stopCh chan struct{}
+	poller.Runner
 }
 
 // Stats holds the latest snapshot from AdGuard Home /control/stats.
@@ -54,39 +55,19 @@ type Stats struct {
 // New creates an AdGuard Home API client.
 // baseURL should be like "http://adguard.example.local" (no trailing slash).
 func New(baseURL, user, pass string, pollInterval time.Duration) *Client {
-	return &Client{
+	c := &Client{
 		baseURL:    baseURL,
 		user:       user,
 		pass:       pass,
 		interval:   pollInterval,
 		httpClient: &http.Client{Timeout: 10 * time.Second, Transport: httputil.WrapTransport(nil)},
-		stopCh:     make(chan struct{}),
 	}
+	c.Runner.Init()
+	return c
 }
 
 // Run starts the polling loop. Call in a goroutine.
-func (c *Client) Run() {
-	c.poll() // immediate first fetch
-	ticker := time.NewTicker(c.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.poll()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-// Stop terminates the polling loop.
-func (c *Client) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
-		close(c.stopCh)
-	}
-}
+func (c *Client) Run() { c.Runner.Run(c.interval, c.poll) }
 
 func (c *Client) poll() {
 	url := c.baseURL + "/control/stats"

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"bandwidth-monitor/poller"
+
 	vnl "github.com/vishvananda/netlink"
 )
 
@@ -68,7 +70,7 @@ type Collector struct {
 	spanPrevRx     uint64
 	spanPrevTx     uint64
 	spanHasPrev    bool
-	stopCh         chan struct{}
+	poller.Runner
 }
 
 type rawStat struct {
@@ -100,7 +102,7 @@ func New(vpnStatusFiles map[string]string, allowedIfaces []string) *Collector {
 	if err != nil {
 		log.Printf("collector: failed to create persistent netlink handle: %v (will use per-call sockets)", err)
 	}
-	return &Collector{
+	c := &Collector{
 		current:        make(map[string]*InterfaceStat),
 		previous:       make(map[string]*rawStat),
 		history:        make(map[string][]HistoryPoint),
@@ -109,8 +111,9 @@ func New(vpnStatusFiles map[string]string, allowedIfaces []string) *Collector {
 		allowedIfaces:  allowed,
 		nlHandle:       nlh,
 		addrCache:      make(map[int][]string),
-		stopCh:         make(chan struct{}),
 	}
+	c.Runner.Init()
+	return c
 }
 
 // EnableSPAN activates pcap-based direction detection on a SPAN/mirror port.
@@ -124,27 +127,17 @@ func (c *Collector) Run() {
 	if c.span != nil {
 		go c.span.run()
 	}
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
-	c.poll()
-	for {
-		select {
-		case <-ticker.C:
-			c.poll()
-		case <-c.stopCh:
-			return
-		}
-	}
+	c.Runner.Run(pollInterval, c.poll)
 }
 
 func (c *Collector) Stop() {
+	c.Runner.Stop()
 	if c.span != nil {
 		c.span.stop()
 	}
 	if c.nlHandle != nil {
 		c.nlHandle.Close()
 	}
-	close(c.stopCh)
 }
 
 func (c *Collector) GetAll() []InterfaceStat {

--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -14,6 +14,7 @@ import (
 
 	"bandwidth-monitor/geoip"
 	"bandwidth-monitor/netutil"
+	"bandwidth-monitor/poller"
 	"bandwidth-monitor/resolver"
 
 	ct "github.com/ti-mo/conntrack"
@@ -136,10 +137,10 @@ type Tracker struct {
 	available   bool
 	sockBufSize int // netlink socket receive buffer size
 	errCount    int // consecutive dump errors (for log rate-limiting)
-	stopCh      chan struct{}
-	geoDB       *geoip.DB
-	dns         *resolver.Resolver
-	conn        *ct.Conn // persistent netlink connection
+	poller.Runner
+	geoDB *geoip.DB
+	dns   *resolver.Resolver
+	conn  *ct.Conn // persistent netlink connection
 }
 
 // Default and maximum netlink socket buffer sizes.
@@ -152,13 +153,14 @@ const (
 // localNets defines which IPs are considered local/LAN (used to split
 // top sources vs top destinations into LAN clients vs remote hosts).
 func New(localNets []*net.IPNet, geoDB *geoip.DB, dns *resolver.Resolver) *Tracker {
-	return &Tracker{
+	t := &Tracker{
 		localNets:   localNets,
 		sockBufSize: defaultSockBuf,
-		stopCh:      make(chan struct{}),
 		geoDB:       geoDB,
 		dns:         dns,
 	}
+	t.Runner.Init()
+	return t
 }
 
 // Run opens a netlink connection to verify conntrack is available, then starts
@@ -192,22 +194,12 @@ func (t *Tracker) Run() {
 	t.available = true
 	log.Println("conntrack: netlink connection established")
 
-	t.poll()
-	ticker := time.NewTicker(pollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			t.poll()
-		case <-t.stopCh:
-			return
-		}
-	}
+	t.Runner.Run(pollInterval, t.poll)
 }
 
 // Stop terminates the polling loop.
 func (t *Tracker) Stop() {
-	close(t.stopCh)
+	t.Runner.Stop()
 	if t.conn != nil {
 		t.conn.Close()
 		t.conn = nil

--- a/geoip/geoip.go
+++ b/geoip/geoip.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"bandwidth-monitor/poller"
+
 	"github.com/oschwald/maxminddb-golang"
 )
 
@@ -27,7 +29,7 @@ type DB struct {
 	asn     *maxminddb.Reader
 	mu      sync.RWMutex
 	cache   map[string]*Result
-	stopCh  chan struct{}
+	poller.Runner
 }
 
 // cityRecord is the minimal struct for MMDB city/country lookups.
@@ -55,9 +57,9 @@ type asnRecord struct {
 // will gracefully return partial results.
 func Open(countryPath, asnPath string) (*DB, error) {
 	db := &DB{
-		cache:  make(map[string]*Result, 4096),
-		stopCh: make(chan struct{}),
+		cache: make(map[string]*Result, 4096),
 	}
+	db.Runner.Init()
 
 	if countryPath != "" {
 		if _, err := os.Stat(countryPath); err == nil {
@@ -93,29 +95,18 @@ const (
 // pruneLoop periodically clears the GeoIP cache to prevent unbounded growth.
 // MMDB lookups are fast (~1µs) so rebuilding the cache is cheap.
 func (db *DB) pruneLoop() {
-	ticker := time.NewTicker(geoCachePruneInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			db.mu.Lock()
-			if len(db.cache) > geoCacheMaxSize {
-				db.cache = make(map[string]*Result, 4096)
-			}
-			db.mu.Unlock()
-		case <-db.stopCh:
-			return
+	db.Runner.Run(geoCachePruneInterval, func() {
+		db.mu.Lock()
+		if len(db.cache) > geoCacheMaxSize {
+			db.cache = make(map[string]*Result, 4096)
 		}
-	}
+		db.mu.Unlock()
+	})
 }
 
 // Close releases the database readers and stops the pruning goroutine.
 func (db *DB) Close() {
-	select {
-	case <-db.stopCh:
-	default:
-		close(db.stopCh)
-	}
+	db.Runner.Stop()
 	if db.country != nil {
 		db.country.Close()
 	}

--- a/icmputil/icmputil.go
+++ b/icmputil/icmputil.go
@@ -1,0 +1,65 @@
+package icmputil
+
+import (
+"net"
+"time"
+
+"golang.org/x/net/icmp"
+"golang.org/x/net/ipv4"
+"golang.org/x/net/ipv6"
+)
+
+// PingOne sends a single ICMP echo and waits for the matching reply.
+// Returns RTT in ms, or -1 on timeout/error.
+// proto: 1 = ICMPv4, 58 = ICMPv6.
+func PingOne(conn *icmp.PacketConn, dest net.IP, id, seq uint16, proto int, timeout time.Duration) float64 {
+	var msgType, replyType icmp.Type
+	if proto == 1 {
+		msgType = ipv4.ICMPTypeEcho
+		replyType = ipv4.ICMPTypeEchoReply
+	} else {
+		msgType = ipv6.ICMPTypeEchoRequest
+		replyType = ipv6.ICMPTypeEchoReply
+	}
+
+	msg := icmp.Message{
+		Type: msgType, Code: 0,
+		Body: &icmp.Echo{ID: int(id), Seq: int(seq), Data: []byte("bwmon")},
+	}
+	wb, err := msg.Marshal(nil)
+	if err != nil {
+		return -1
+	}
+
+	dst := &net.IPAddr{IP: dest}
+	conn.SetDeadline(time.Now().Add(timeout))
+	start := time.Now()
+	if _, err := conn.WriteTo(wb, dst); err != nil {
+		return -1
+	}
+
+	rb := make([]byte, 1500)
+	for {
+		n, _, err := conn.ReadFrom(rb)
+		if err != nil {
+			return -1
+		}
+		rtt := RTTMs(start)
+		rm, err := icmp.ParseMessage(proto, rb[:n])
+		if err != nil {
+			continue
+		}
+		if rm.Type == replyType {
+			if echo, ok := rm.Body.(*icmp.Echo); ok {
+				if uint16(echo.ID) == id {
+					return rtt
+				}
+			}
+		}
+	}
+}
+
+// RTTMs returns milliseconds elapsed since start.
+func RTTMs(start time.Time) float64 {
+	return float64(time.Since(start).Microseconds()) / 1000.0
+}

--- a/latency/latency.go
+++ b/latency/latency.go
@@ -16,10 +16,10 @@ import (
 	"time"
 
 	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/icmputil"
+	"bandwidth-monitor/poller"
 
 	"golang.org/x/net/icmp"
-	"golang.org/x/net/ipv4"
-	"golang.org/x/net/ipv6"
 )
 
 const (
@@ -85,7 +85,7 @@ type Monitor struct {
 	targets []resolvedTarget
 	mu      sync.RWMutex
 	state   map[string]*targetState
-	stopCh  chan struct{}
+	poller.Runner
 }
 
 type resolvedTarget struct {
@@ -172,8 +172,8 @@ func New(targets []string) *Monitor {
 	m := &Monitor{
 		targets: resolved,
 		state:   make(map[string]*targetState, len(resolved)),
-		stopCh:  make(chan struct{}),
 	}
+	m.Runner.Init()
 	for _, t := range resolved {
 		st := &targetState{}
 		if t.ipv4 != nil {
@@ -204,27 +204,11 @@ func (m *Monitor) Run() {
 		log.Printf("  %s (v4=%s, v6=%s)", t.name, v4s, v6s)
 	}
 
-	ticker := time.NewTicker(probeInterval)
-	defer ticker.Stop()
-	m.probeAll()
-	for {
-		select {
-		case <-ticker.C:
-			m.probeAll()
-		case <-m.stopCh:
-			return
-		}
-	}
+	m.Runner.Run(probeInterval, m.probeAll)
 }
 
 // Stop terminates the probe loop.
-func (m *Monitor) Stop() {
-	select {
-	case <-m.stopCh:
-	default:
-		close(m.stopCh)
-	}
-}
+func (m *Monitor) Stop() { m.Runner.Stop() }
 
 // GetStatus returns the current status of all targets.
 func (m *Monitor) GetStatus() []TargetStatus {
@@ -449,77 +433,11 @@ var (
 )
 
 func pingOneV4(conn *icmp.PacketConn, dest net.IP, seq int) float64 {
-	id := uint16(os.Getpid() & 0xFFFF)
-	msg := icmp.Message{
-		Type: ipv4.ICMPTypeEcho, Code: 0,
-		Body: &icmp.Echo{ID: int(id), Seq: seq, Data: []byte("bwmon-lat")},
-	}
-	wb, err := msg.Marshal(nil)
-	if err != nil {
-		return -1
-	}
-	dst := &net.IPAddr{IP: dest}
-	conn.SetDeadline(time.Now().Add(icmpTimeout))
-	start := time.Now()
-	if _, err := conn.WriteTo(wb, dst); err != nil {
-		return -1
-	}
-	rb := make([]byte, 1500)
-	for {
-		n, _, err := conn.ReadFrom(rb)
-		if err != nil {
-			return -1
-		}
-		rtt := float64(time.Since(start).Microseconds()) / 1000.0
-		rm, err := icmp.ParseMessage(1, rb[:n])
-		if err != nil {
-			continue
-		}
-		if rm.Type == ipv4.ICMPTypeEchoReply {
-			if echo, ok := rm.Body.(*icmp.Echo); ok {
-				if uint16(echo.ID) == id {
-					return rtt
-				}
-			}
-		}
-	}
+	return icmputil.PingOne(conn, dest, uint16(os.Getpid()&0xFFFF), uint16(seq), 1, icmpTimeout)
 }
 
 func pingOneV6(conn *icmp.PacketConn, dest net.IP, seq int) float64 {
-	id := uint16(os.Getpid() & 0xFFFF)
-	msg := icmp.Message{
-		Type: ipv6.ICMPTypeEchoRequest, Code: 0,
-		Body: &icmp.Echo{ID: int(id), Seq: seq, Data: []byte("bwmon-lat")},
-	}
-	wb, err := msg.Marshal(nil)
-	if err != nil {
-		return -1
-	}
-	dst := &net.IPAddr{IP: dest}
-	conn.SetDeadline(time.Now().Add(icmpTimeout))
-	start := time.Now()
-	if _, err := conn.WriteTo(wb, dst); err != nil {
-		return -1
-	}
-	rb := make([]byte, 1500)
-	for {
-		n, _, err := conn.ReadFrom(rb)
-		if err != nil {
-			return -1
-		}
-		rtt := float64(time.Since(start).Microseconds()) / 1000.0
-		rm, err := icmp.ParseMessage(58, rb[:n])
-		if err != nil {
-			continue
-		}
-		if rm.Type == ipv6.ICMPTypeEchoReply {
-			if echo, ok := rm.Body.(*icmp.Echo); ok {
-				if uint16(echo.ID) == id {
-					return rtt
-				}
-			}
-		}
-	}
+	return icmputil.PingOne(conn, dest, uint16(os.Getpid()&0xFFFF), uint16(seq), 58, icmpTimeout)
 }
 
 func (m *Monitor) probeHTTPS(client *http.Client, hostname string) float64 {

--- a/nextdns/nextdns.go
+++ b/nextdns/nextdns.go
@@ -12,6 +12,7 @@ import (
 
 	"bandwidth-monitor/dns"
 	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/poller"
 )
 
 const apiBase = "https://api.nextdns.io"
@@ -26,7 +27,7 @@ type Client struct {
 	mu    sync.RWMutex
 	stats *snapshot
 
-	stopCh chan struct{}
+	poller.Runner
 }
 
 type snapshot struct {
@@ -59,38 +60,18 @@ type statusTSEntry struct {
 
 // New creates a NextDNS API client.
 func New(profile, apiKey string, pollInterval time.Duration) *Client {
-	return &Client{
+	c := &Client{
 		profile:  profile,
 		apiKey:   apiKey,
 		interval: pollInterval,
 		httpC:    &http.Client{Timeout: 15 * time.Second, Transport: httputil.WrapTransport(nil)},
-		stopCh:   make(chan struct{}),
 	}
+	c.Runner.Init()
+	return c
 }
 
 // Run starts the polling loop. Call in a goroutine.
-func (c *Client) Run() {
-	c.poll()
-	ticker := time.NewTicker(c.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.poll()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-// Stop terminates the polling loop.
-func (c *Client) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
-		close(c.stopCh)
-	}
-}
+func (c *Client) Run() { c.Runner.Run(c.interval, c.poll) }
 
 func (c *Client) poll() {
 	snap := &snapshot{}

--- a/omada/omada.go
+++ b/omada/omada.go
@@ -13,20 +13,21 @@ import (
 	"time"
 
 	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/poller"
 	"bandwidth-monitor/wifi"
 )
 
 // Client polls an Omada controller for WiFi stats.
 type Client struct {
-	baseURL   string
-	user      string
-	pass      string
-	siteName  string
-	interval  time.Duration
-	httpC     *http.Client
-	mu        sync.RWMutex
-	summary   *wifi.Summary
-	stopCh    chan struct{}
+	baseURL  string
+	user     string
+	pass     string
+	siteName string
+	interval time.Duration
+	httpC    *http.Client
+	mu       sync.RWMutex
+	summary  *wifi.Summary
+	poller.Runner
 	token     string
 	omadaCID  string
 	siteID    string
@@ -43,40 +44,20 @@ func New(baseURL, user, pass, siteName string, pollInterval time.Duration) *Clie
 	if siteName == "" {
 		siteName = "Default"
 	}
-	return &Client{
+	c := &Client{
 		baseURL:  strings.TrimRight(baseURL, "/"),
 		user:     user,
 		pass:     pass,
 		siteName: siteName,
 		interval: pollInterval,
 		httpC:    httputil.NewInsecureClient(15 * time.Second),
-		stopCh:   make(chan struct{}),
 	}
+	c.Runner.Init()
+	return c
 }
 
 // Run starts the polling loop. Call in a goroutine.
-func (c *Client) Run() {
-	c.poll()
-	ticker := time.NewTicker(c.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.poll()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-// Stop terminates the polling loop.
-func (c *Client) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
-		close(c.stopCh)
-	}
-}
+func (c *Client) Run() { c.Runner.Run(c.interval, c.poll) }
 
 // GetSummary returns the latest WiFi summary (nil if no data yet).
 func (c *Client) GetSummary() *wifi.Summary {

--- a/pihole/pihole.go
+++ b/pihole/pihole.go
@@ -13,6 +13,7 @@ import (
 
 	"bandwidth-monitor/dns"
 	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/poller"
 )
 
 // Client polls a Pi-hole v6 instance for DNS statistics.
@@ -29,7 +30,7 @@ type Client struct {
 	sid       string
 	sidExpiry time.Time
 
-	stopCh chan struct{}
+	poller.Runner
 }
 
 // snapshot holds the combined data from multiple Pi-hole API calls.
@@ -109,38 +110,18 @@ type historyResp struct {
 // New creates a Pi-hole v6 API client.
 // baseURL should be like "http://pi.hole" or "https://192.168.1.2" (no trailing slash).
 func New(baseURL, password string, pollInterval time.Duration) *Client {
-	return &Client{
+	c := &Client{
 		baseURL:    baseURL,
 		password:   password,
 		interval:   pollInterval,
 		httpClient: httputil.NewInsecureClient(15 * time.Second),
-		stopCh:     make(chan struct{}),
 	}
+	c.Runner.Init()
+	return c
 }
 
 // Run starts the polling loop. Call in a goroutine.
-func (c *Client) Run() {
-	c.poll()
-	ticker := time.NewTicker(c.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.poll()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-// Stop terminates the polling loop.
-func (c *Client) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
-		close(c.stopCh)
-	}
-}
+func (c *Client) Run() { c.Runner.Run(c.interval, c.poll) }
 
 // authenticate obtains (or reuses) a session ID from the Pi-hole API.
 func (c *Client) authenticate() (string, error) {

--- a/poller/poller.go
+++ b/poller/poller.go
@@ -1,0 +1,42 @@
+package poller
+
+import "time"
+
+// Runner manages a periodic poll loop with graceful shutdown.
+type Runner struct {
+	stopCh chan struct{}
+}
+
+// Init allocates the stop channel. Call in your constructor.
+func (r *Runner) Init() {
+	r.stopCh = make(chan struct{})
+}
+
+// Run calls fn immediately, then every interval until Stop. Blocks.
+func (r *Runner) Run(interval time.Duration, fn func()) {
+	fn()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			fn()
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+// Stop signals the loop to exit. Safe to call multiple times.
+func (r *Runner) Stop() {
+	select {
+	case <-r.stopCh:
+	default:
+		close(r.stopCh)
+	}
+}
+
+// StopCh returns the channel for custom select logic.
+func (r *Runner) StopCh() <-chan struct{} {
+	return r.stopCh
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"bandwidth-monitor/poller"
+
 	mdns "github.com/miekg/dns"
 )
 
@@ -45,7 +47,7 @@ type Resolver struct {
 	maxTTL  time.Duration
 	timeout time.Duration
 	server  string // DNS server address (host:port)
-	stopCh  chan struct{}
+	poller.Runner
 }
 
 // New creates a Resolver that reads /etc/resolv.conf for the system resolver.
@@ -66,42 +68,29 @@ func New() *Resolver {
 		maxTTL:  DefaultMaxTTL,
 		timeout: DefaultTimeout,
 		server:  server,
-		stopCh:  make(chan struct{}),
 	}
+	r.Runner.Init()
 	go r.pruneLoop()
 	return r
 }
 
 // Stop terminates the cache pruning goroutine.
-func (r *Resolver) Stop() {
-	select {
-	case <-r.stopCh:
-	default:
-		close(r.stopCh)
-	}
-}
+func (r *Resolver) Stop() { r.Runner.Stop() }
 
 const pruneInterval = 5 * time.Minute
 
 // pruneLoop periodically removes expired entries from the cache.
 func (r *Resolver) pruneLoop() {
-	ticker := time.NewTicker(pruneInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			now := time.Now()
-			r.mu.Lock()
-			for ip, entry := range r.cache {
-				if now.After(entry.expires) {
-					delete(r.cache, ip)
-				}
+	r.Runner.Run(pruneInterval, func() {
+		now := time.Now()
+		r.mu.Lock()
+		for ip, entry := range r.cache {
+			if now.After(entry.expires) {
+				delete(r.cache, ip)
 			}
-			r.mu.Unlock()
-		case <-r.stopCh:
-			return
 		}
-	}
+		r.mu.Unlock()
+	})
 }
 
 // LookupAddr performs a synchronous reverse-DNS lookup for ip, returning the

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -20,6 +20,7 @@ import (
 	"golang.zx2c4.com/wireguard/wgctrl"
 
 	"bandwidth-monitor/netutil"
+	"bandwidth-monitor/poller"
 	"bandwidth-monitor/resolver"
 	"bandwidth-monitor/wifi"
 )
@@ -91,9 +92,9 @@ type Scanner struct {
 	dns          *resolver.Resolver
 	wifiProvider wifi.Provider
 	localNets    []*net.IPNet
-	stopCh       chan struct{}
-	interval     time.Duration
-	wanIfaces    func() []string // returns names of WAN interfaces
+	poller.Runner
+	interval  time.Duration
+	wanIfaces func() []string // returns names of WAN interfaces
 }
 
 // New creates a topology scanner.
@@ -101,13 +102,14 @@ func New(dns *resolver.Resolver, wifiProvider wifi.Provider, localNets []*net.IP
 	if interval <= 0 {
 		interval = 30 * time.Second
 	}
-	return &Scanner{
+	s := &Scanner{
 		dns:          dns,
 		wifiProvider: wifiProvider,
 		localNets:    localNets,
-		stopCh:       make(chan struct{}),
 		interval:     interval,
 	}
+	s.Runner.Init()
+	return s
 }
 
 // SetWANInterfacesFunc sets the callback used to determine WAN interface names.
@@ -118,28 +120,7 @@ func (s *Scanner) SetWANInterfacesFunc(fn func() []string) {
 }
 
 // Run starts the periodic scan loop. Call in a goroutine.
-func (s *Scanner) Run() {
-	s.scan()
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			s.scan()
-		case <-s.stopCh:
-			return
-		}
-	}
-}
-
-// Stop terminates the scan loop.
-func (s *Scanner) Stop() {
-	select {
-	case <-s.stopCh:
-	default:
-		close(s.stopCh)
-	}
-}
+func (s *Scanner) Run() { s.Runner.Run(s.interval, s.scan) }
 
 // GetOverview returns the latest topology snapshot.
 func (s *Scanner) GetOverview() *Overview {

--- a/unifi/unifi.go
+++ b/unifi/unifi.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/poller"
 	"bandwidth-monitor/wifi"
 )
 
@@ -23,7 +24,7 @@ type Client struct {
 	httpClient *http.Client
 	mu         sync.RWMutex
 	summary    *wifi.Summary
-	stopCh     chan struct{}
+	poller.Runner
 
 	// API variant detection
 	unifiOS   bool   // true = UDM/UDR/CloudKey Gen2+, false = legacy controller
@@ -42,38 +43,19 @@ func New(baseURL, user, pass, site string, pollInterval time.Duration) *Client {
 	if site == "" {
 		site = "default"
 	}
-	return &Client{
+	c := &Client{
 		baseURL:    baseURL,
 		user:       user,
 		pass:       pass,
 		site:       site,
 		interval:   pollInterval,
 		httpClient: httputil.NewInsecureClient(15 * time.Second),
-		stopCh:     make(chan struct{}),
 	}
+	c.Runner.Init()
+	return c
 }
 
-func (c *Client) Run() {
-	c.poll()
-	ticker := time.NewTicker(c.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			c.poll()
-		case <-c.stopCh:
-			return
-		}
-	}
-}
-
-func (c *Client) Stop() {
-	select {
-	case <-c.stopCh:
-	default:
-		close(c.stopCh)
-	}
-}
+func (c *Client) Run() { c.Runner.Run(c.interval, c.poll) }
 
 func (c *Client) GetSummary() *wifi.Summary {
 	c.mu.RLock()


### PR DESCRIPTION
refactor: extract shared poll runner and ICMP ping utility

New packages:

- poller: embeddable Runner struct that replaces the identical
  ticker+stopCh poll loop pattern duplicated across 12 packages.
  Provides Run(interval, fn), Stop(), and StopCh() methods.

- icmputil: shared PingOne() function for ICMP echo request/reply,
  used by the latency monitor. Eliminates the duplicated pingOneV4
  and pingOneV6 implementations (~60 lines).

Packages updated to embed poller.Runner:
  adguard, nextdns, pihole, unifi, omada, topology (simple embed),
  conntrack, collector, latency (custom Run/Stop with extra logic),
  geoip, resolver (prune loops).

Skipped: talkers (multiple goroutines share a single stopCh).

Net: -123 lines (204 added, 327 removed), 13 files changed.
All existing tests pass, go vet clean.
