### PR TITLE
feat: enrich DNS tab clients with reverse DNS hostnames

### DIFF
--- a/dns/dns.go
+++ b/dns/dns.go
@@ -36,8 +36,9 @@ type DomainStat struct {
 
 // ClientStat is a single client IP + count entry.
 type ClientStat struct {
-	IP    string `json:"ip"`
-	Count int    `json:"count"`
+	IP       string `json:"ip"`
+	Hostname string `json:"hostname,omitempty"`
+	Count    int    `json:"count"`
 }
 
 // UpstreamStat is a single upstream server entry.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -52,13 +52,21 @@ func TopTalkersVolume(t *talkers.Tracker) http.HandlerFunc {
 	}
 }
 
-func DNSSummary(dp dns.Provider) http.HandlerFunc {
+func DNSSummary(dp dns.Provider, dnsRes *resolver.Resolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if dp == nil {
 			httputil.WriteJSONOrNull(w, nil)
 			return
 		}
-		httputil.WriteJSON(w, dp.GetSummary())
+		sum := dp.GetSummary()
+		if sum != nil && dnsRes != nil {
+			for i := range sum.TopClients {
+				if name := dnsRes.LookupAddrAsync(sum.TopClients[i].IP); name != "" && name != sum.TopClients[i].IP {
+					sum.TopClients[i].Hostname = name
+				}
+			}
+		}
+		httputil.WriteJSON(w, sum)
 	}
 }
 
@@ -565,7 +573,7 @@ func fetchExternalIP() string {
 }
 
 // buildPayload assembles the JSON payload sent over the SSE stream.
-func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, ts *topology.Scanner, origin *originResolver) map[string]interface{} {
+func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, ts *topology.Scanner, dnsRes *resolver.Resolver, origin *originResolver) map[string]interface{} {
 	geo := t.GetGeoBreakdown()
 	payload := map[string]interface{}{
 		"interfaces":    c.GetAll(),
@@ -592,7 +600,15 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 		}
 	}
 	if dp != nil {
-		payload["dns"] = dp.GetSummary()
+		sum := dp.GetSummary()
+		if sum != nil && dnsRes != nil {
+			for i := range sum.TopClients {
+				if name := dnsRes.LookupAddrAsync(sum.TopClients[i].IP); name != "" && name != sum.TopClients[i].IP {
+					sum.TopClients[i].Hostname = name
+				}
+			}
+		}
+		payload["dns"] = sum
 	}
 	if wp != nil {
 		payload["wifi"] = wp.GetSummary()
@@ -621,7 +637,7 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 // backed up (e.g. hibernating laptop, congested link), only the most recent
 // payload is kept — preventing kernel send-buffer buildup (same backpressure
 // logic that PR #18 added to the old WebSocket handler).
-func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, ts *topology.Scanner, geoDB *geoip.DB) http.HandlerFunc {
+func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, ts *topology.Scanner, dnsRes *resolver.Resolver, geoDB *geoip.DB) http.HandlerFunc {
 	origin := newOriginResolver(geoDB)
 	return func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
@@ -653,7 +669,7 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 		}()
 
 		// Send initial payload immediately.
-		data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, ts, origin))
+		data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, ts, dnsRes, origin))
 		if err != nil {
 			close(sendCh)
 			return
@@ -672,7 +688,7 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 			case <-writerDone:
 				return
 			case <-ticker.C:
-				data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, ts, origin))
+				data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, ts, dnsRes, origin))
 				if err != nil {
 					continue
 				}

--- a/main.go
+++ b/main.go
@@ -269,7 +269,7 @@ func main() {
 	mux.HandleFunc("/api/interfaces/history", handler.InterfaceHistory(statsCollector))
 	mux.HandleFunc("/api/talkers/bandwidth", handler.TopTalkersBandwidth(talkerTracker))
 	mux.HandleFunc("/api/talkers/volume", handler.TopTalkersVolume(talkerTracker))
-	mux.HandleFunc("/api/dns", handler.DNSSummary(dnsProvider))
+	mux.HandleFunc("/api/dns", handler.DNSSummary(dnsProvider, dnsResolver))
 	mux.HandleFunc("/api/wifi", handler.WiFiSummary(wifiProvider))
 	mux.HandleFunc("/api/conntrack", handler.ConntrackSummary(conntrackTracker))
 	mux.HandleFunc("/api/host", handler.HostDetail(talkerTracker, conntrackTracker, geoDB))
@@ -281,7 +281,7 @@ func main() {
 	mux.HandleFunc("/api/debug/mtu", handler.DebugMTU())
 	mux.HandleFunc("/api/summary", handler.MenuBarSummary(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker))
 	mux.HandleFunc("/api/topology", handler.TopologySummary(topoScanner))
-	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor, topoScanner, geoDB))
+	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor, topoScanner, dnsResolver, geoDB))
 	staticSub, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		log.Fatalf("Failed to create sub filesystem: %v", err)

--- a/static/js/tabs/dns.js
+++ b/static/js/tabs/dns.js
@@ -85,12 +85,12 @@
         // ── Top DNS Clients pie chart ──
         fillDoughnut(dnsClientsChart, document.getElementById('dnsClientsLegend'),
             dns.top_clients || [],
-            function(c) { return c.ip || 'Unknown'; },
+            function(c) { return c.hostname ? c.hostname + ' (' + c.ip + ')' : (c.ip || 'Unknown'); },
             function(c) { return c.count || 0; },
             function(v) { return v.toLocaleString() + ' queries'; }
         );
         fillDetailTable('dnsClientsTable', dns.top_clients || [],
-            function(c) { return c.ip || 'Unknown'; },
+            function(c) { return c.hostname ? c.hostname + ' <span style="color:var(--text-2);font-size:11px">(' + c.ip + ')</span>' : (c.ip || 'Unknown'); },
             function(c) { return c.count || 0; },
             function(v) { return v.toLocaleString(); }, 'bw'
         );


### PR DESCRIPTION
feat: enrich DNS tab clients with reverse DNS hostnames

Add hostname field to dns.ClientStat and resolve client IPs via the
shared reverse-DNS resolver. Hostnames are populated using the async
lookup (cache hits are cheap map reads, cache misses fire in the
background and resolve on the next tick).

Enrichment happens in the handler layer (buildPayload for SSE, and
DNSSummary for the REST endpoint) so no DNS provider code needs
changes. The resolver is passed through from main.go.

Frontend updated: DNS clients chart and table now display
"hostname (ip)" instead of bare IP addresses.
