### PR TITLE
nixos flake fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, geolite2-country, geolite2-asn }:
+  outputs = { self, nixpkgs, flake-utils, geolite2-city, geolite2-asn }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,6 @@
           buildInputs = [ pkgs.libpcap ];
           nativeBuildInputs = [ pkgs.pkg-config ];
 
-          CGO_ENABLED = 1;
           ldflags = [
             "-s" "-w"
             "-X" "bandwidth-monitor/version.Version=${bandwidth-monitor.version}"


### PR DESCRIPTION
Fix wrong build input geoip2-country instead of correct geoip-city.

Not a Go expert and hence not sure about `CGO_ENABLED`. I think it should be `env.CGO_ENABLED`, but removing worked for me too. Feel free to drop this part.