### PR TITLE
Fix OOM crash and add WAN_INTERFACE override

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -63,6 +63,7 @@ type Collector struct {
 	ifaceTypeCache map[string]string
 	vpnStatusFiles map[string]string // iface name → sentinel file path
 	allowedIfaces  map[string]bool   // nil = all; non-nil = whitelist
+	wanIfaces      map[string]bool   // nil = auto-detect; non-nil = explicit WAN interfaces
 	nlHandle       *vnl.Handle       // persistent netlink handle
 	addrCache      map[int][]string  // cached addresses by link index
 	addrCacheTime  time.Time         // last address refresh
@@ -85,7 +86,7 @@ type rawStat struct {
 	ts        time.Time
 }
 
-func New(vpnStatusFiles map[string]string, allowedIfaces []string) *Collector {
+func New(vpnStatusFiles map[string]string, allowedIfaces []string, wanIfaces []string) *Collector {
 	if vpnStatusFiles == nil {
 		vpnStatusFiles = make(map[string]string)
 	}
@@ -94,6 +95,13 @@ func New(vpnStatusFiles map[string]string, allowedIfaces []string) *Collector {
 		allowed = make(map[string]bool, len(allowedIfaces))
 		for _, name := range allowedIfaces {
 			allowed[name] = true
+		}
+	}
+	var wanSet map[string]bool
+	if len(wanIfaces) > 0 {
+		wanSet = make(map[string]bool, len(wanIfaces))
+		for _, name := range wanIfaces {
+			wanSet[name] = true
 		}
 	}
 	// Create a persistent netlink handle to avoid per-poll socket creation.
@@ -109,6 +117,7 @@ func New(vpnStatusFiles map[string]string, allowedIfaces []string) *Collector {
 		ifaceTypeCache: make(map[string]string),
 		vpnStatusFiles: vpnStatusFiles,
 		allowedIfaces:  allowed,
+		wanIfaces:      wanSet,
 		nlHandle:       nlh,
 		addrCache:      make(map[int][]string),
 	}
@@ -366,7 +375,7 @@ func (c *Collector) poll() {
 			TxDropped:       cur.txDropped,
 			Timestamp:       now.UnixMilli(),
 		}
-		iface.WAN = IsWAN(iface)
+		iface.WAN = c.isWAN(iface)
 
 		if hasPrev {
 			dt := now.Sub(prev.ts).Seconds()
@@ -513,17 +522,69 @@ func classifyLinkUncached(li *linkInfo) string {
 	return "physical"
 }
 
-// IsWAN reports whether the given interface looks like a WAN uplink.
-// It checks (in order): PPP type, then whether any assigned IPv4 address is
-// publicly-routable (not RFC1918, not link-local, not loopback).
+// isWAN reports whether the given interface looks like a WAN uplink.
+// It checks (in order):
+//  1. Explicit WAN_INTERFACE override (set via env var)
+//  2. PPP type
+//  3. Whether any assigned IPv4 address is publicly-routable
+//  4. Whether the interface carries the IPv4 default route (handles double-NAT)
+//
 // IPv6 is intentionally ignored: with prefix delegation, LAN interfaces
 // commonly carry globally-routable IPv6 addresses.
+func (c *Collector) isWAN(iface *InterfaceStat) bool {
+	// Explicit override takes priority
+	if c.wanIfaces != nil {
+		return c.wanIfaces[iface.Name]
+	}
+	if iface.IfaceType == "ppp" {
+		return true
+	}
+	for _, a := range iface.Addrs {
+		if isPublicIPv4(a) {
+			return true
+		}
+	}
+	if hasDefaultRoute(iface.Name) {
+		return true
+	}
+	return false
+}
+
+// IsWAN is a standalone version for use outside the Collector (no override).
 func IsWAN(iface *InterfaceStat) bool {
 	if iface.IfaceType == "ppp" {
 		return true
 	}
 	for _, a := range iface.Addrs {
 		if isPublicIPv4(a) {
+			return true
+		}
+	}
+	if hasDefaultRoute(iface.Name) {
+		return true
+	}
+	return false
+}
+
+// hasDefaultRoute reports whether the named interface carries an IPv4 default route.
+func hasDefaultRoute(ifaceName string) bool {
+	routes, err := vnl.RouteList(nil, vnl.FAMILY_V4)
+	if err != nil {
+		return false
+	}
+	for _, r := range routes {
+		// Default route: Dst is nil or 0.0.0.0/0
+		if r.Dst != nil {
+			ones, bits := r.Dst.Mask.Size()
+			if ones != 0 || bits == 0 {
+				continue
+			}
+		}
+		link, err := vnl.LinkByIndex(r.LinkIndex)
+		if err != nil {
+			continue
+		}
+		if link.Attrs().Name == ifaceName {
 			return true
 		}
 	}

--- a/env.example
+++ b/env.example
@@ -10,6 +10,11 @@ LISTEN=:8080
 # If not set, all interfaces (except loopback) are used.
 # INTERFACES=eth0,ppp0,wg0,br-lan
 
+# Explicitly mark interface(s) as WAN uplink.
+# Useful for double-NAT setups where the WAN interface has a private IP.
+# If not set, WAN is auto-detected (public IPv4, PPP type, or default route).
+# WAN_INTERFACE=eth0
+
 # GeoIP MMDB paths (relative to WorkingDirectory)
 # City DB includes country, city, and coordinates for map visualization.
 # Falls back to Country DB if City is unavailable.

--- a/main.go
+++ b/main.go
@@ -176,7 +176,20 @@ func main() {
 		log.Printf("INTERFACES: showing %d interface(s): %s", len(allowedIfaces), strings.Join(allowedIfaces, ", "))
 	}
 
-	statsCollector := collector.New(vpnStatusFiles, allowedIfaces)
+	// Parse WAN_INTERFACE: comma-separated list of interface names to treat as WAN.
+	// If not set, WAN is auto-detected (public IP, PPP, or default route).
+	var wanIfaces []string
+	if raw := os.Getenv("WAN_INTERFACE"); raw != "" {
+		for _, name := range strings.Split(raw, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				wanIfaces = append(wanIfaces, name)
+			}
+		}
+		log.Printf("WAN_INTERFACE: %s", strings.Join(wanIfaces, ", "))
+	}
+
+	statsCollector := collector.New(vpnStatusFiles, allowedIfaces, wanIfaces)
 
 	// Shared reverse-DNS resolver — used by talkers, conntrack, and debug.
 	dnsResolver := resolver.New()

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -438,6 +438,7 @@ func (t *Tracker) captureDevice(device string) {
 	// packet. At 10 MB/s there are ~7000 pps but only 10-100 unique IPs.
 	// The cache hits 99%+ of lookups, eliminating the main GC bottleneck.
 	ipStrCache := make(map[[16]byte]string, 256)
+	ipCacheResets := 0
 	ipStr := func(ip net.IP) string {
 		var k [16]byte
 		copy(k[:], ip.To16())
@@ -457,6 +458,16 @@ func (t *Tracker) captureDevice(device string) {
 		case <-t.stopCh:
 			return
 		default:
+		}
+
+		// Periodically reset the IP string cache to bound memory on
+		// routers that see a large number of unique IPs over time.
+		if len(ipStrCache) > 100000 {
+			ipStrCache = make(map[[16]byte]string, 256)
+			ipCacheResets++
+			if ipCacheResets == 1 {
+				log.Printf("talkers: reset IP string cache on %s (>100k entries)", device)
+			}
 		}
 
 		// Phase 1: Parse all packets in the block WITHOUT holding the lock.
@@ -662,6 +673,13 @@ func (t *Tracker) rotateBuckets() {
 				idx++
 			}
 			if idx > 0 {
+				// Nil out old entries so the backing array doesn't
+				// prevent GC of expired bucket data. Without this,
+				// the pointers stay alive until append reallocates
+				// the backing array — leaking up to 24h of buckets.
+				for i := 0; i < idx; i++ {
+					t.buckets[i] = nil
+				}
 				t.buckets = t.buckets[idx:]
 			}
 			t.current = &bucket{


### PR DESCRIPTION
## Memory leak fixes (OOM crash)

The service was being OOM-killed (SIGKILL/signal 9) after running for several hours.

**Root causes:**

1. **Bucket slice leak in `rotateBuckets()`** — old `*bucket` pointers remained in the backing array after `t.buckets = t.buckets[idx:]`, preventing GC from reclaiming expired bucket data. Over 24h this could leak up to 10k hosts × 1440 buckets worth of unreclaimable memory.

2. **Unbounded IP string cache in `captureDevice()`** — the `ipStrCache` map grew without limit on routers seeing many unique IPs. Now resets when it exceeds 100k entries.

## New feature: `WAN_INTERFACE` env var

Adds explicit WAN interface override via `WAN_INTERFACE` env var (comma-separated). Useful for double-NAT setups where the WAN interface has a private IP and auto-detection fails.

Also adds default-route detection as a fallback heuristic when no public IPv4 is found on the interface.