### PR TITLE
Backfill Live Traffic chart from stored history on browser (re)connect

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -127,6 +127,9 @@
         sse.onopen = function() {
             document.getElementById('statusDot').className = 'status-dot';
             document.getElementById('statusText').textContent = 'Live';
+            // Backfill the Live Traffic chart from stored history so a reload or
+            // a gap from a disconnect/hibernate is filled in, not lost.
+            if (BM._backfillLiveTraffic) BM._backfillLiveTraffic();
         };
         sse.onerror = function() {
             document.getElementById('statusDot').className = 'status-dot error';
@@ -177,7 +180,11 @@
             banner.className = 'vpn-banner inactive';
         }
 
-        var now = new Date();
+        // Use the server timestamp so live points share a clock with the
+        // backfilled history points (see BM._backfillLiveTraffic), keeping the
+        // Live Traffic chart contiguous across reloads/reconnects.
+        var ts = d.timestamp || Date.now();
+        var now = new Date(ts);
         for (var f of ifaces) {
             if (!BM.chartData[f.name]) BM.chartData[f.name] = { rx: [], tx: [] };
             if (!BM._emaState[f.name]) BM._emaState[f.name] = { rx: 0, tx: 0 };
@@ -186,9 +193,12 @@
             var rawTx = f.tx_rate || 0;
             em.rx = em.rx === 0 ? rawRx : BM.EMA_ALPHA * rawRx + (1 - BM.EMA_ALPHA) * em.rx;
             em.tx = em.tx === 0 ? rawTx : BM.EMA_ALPHA * rawTx + (1 - BM.EMA_ALPHA) * em.tx;
-            BM.chartData[f.name].rx.push({ x: now, y: em.rx });
-            BM.chartData[f.name].tx.push({ x: now, y: -(em.tx) });
-            if (BM.chartData[f.name].rx.length > BM.MAX_PTS) { BM.chartData[f.name].rx.shift(); BM.chartData[f.name].tx.shift(); }
+            var arr = BM.chartData[f.name];
+            var lastTs = arr.rx.length ? +arr.rx[arr.rx.length - 1].x : 0;
+            if (ts <= lastTs) continue; // already covered by backfill or a prior tick
+            arr.rx.push({ x: now, y: em.rx });
+            arr.tx.push({ x: now, y: -(em.tx) });
+            if (arr.rx.length > BM.MAX_PTS) { arr.rx.shift(); arr.tx.shift(); }
         }
 
         if (BM.renderIfaceCards) BM.renderIfaceCards(ifaces);

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -169,6 +169,36 @@
         _historyRefreshInterval = setInterval(_fetchInterfaceHistory, 60000);
     };
 
+    // Seed the Live Traffic chart's rolling buffer from server-stored history so
+    // a tab reload, disconnect, or hibernate doesn't blank it out — the backend
+    // keeps a 24h 1-sample/sec ring per interface. We take only the chart's
+    // window (last MAX_PTS seconds) and rebuild BM.chartData; live SSE ticks then
+    // continue appending from where history left off. Called on every (re)connect.
+    BM._backfillLiveTraffic = function() {
+        return fetch('/api/interfaces/history').then(function(r) { return r.json(); }).then(function(data) {
+            if (!data) return;
+            var cutoff = Date.now() - BM.MAX_PTS * 1000;
+            var names = Object.keys(data);
+            for (var ni = 0; ni < names.length; ni++) {
+                var name = names[ni];
+                var pts = data[name];
+                if (!pts || !pts.length) continue;
+                BM.knownIfaces.add(name);
+                var rx = [], tx = [];
+                for (var pi = 0; pi < pts.length; pi++) {
+                    if (pts[pi].t < cutoff) continue;
+                    var t = new Date(pts[pi].t);
+                    rx.push({ x: t, y: pts[pi].rx || 0 });
+                    tx.push({ x: t, y: -(pts[pi].tx || 0) });
+                }
+                if (rx.length > BM.MAX_PTS) { rx = rx.slice(-BM.MAX_PTS); tx = tx.slice(-BM.MAX_PTS); }
+                BM.chartData[name] = { rx: rx, tx: tx };
+            }
+            if (BM.renderIfaceTabs) BM.renderIfaceTabs();
+            if (BM.updateChart) BM.updateChart();
+        }).catch(function(e) { console.error('live backfill:', e); });
+    };
+
     // ── Doughnut chart instances ──
     function makeDoughnut(id) {
         return new Chart(document.getElementById(id).getContext('2d'), {


### PR DESCRIPTION
The Live Traffic chart (1h window) was fed only by live SSE ticks into the in-memory BM.chartData buffer, so a tab reload, disconnect, or hibernate blanked it — unlike the 24h history chart, which already rebuilds from the server's stored 24h ring via /api/interfaces/history.

Add BM._backfillLiveTraffic(), which seeds BM.chartData from that same endpoint (sliced to the chart's MAX_PTS window) and is invoked from the SSE onopen handler, so it runs on first load and every (re)connect — filling any gap left by a pause. Live ticks now key off the server timestamp and skip points already covered by backfill, keeping the history→live boundary contiguous and in order.