### PR TITLE
Fix nil-pointer panic in SPAN rate calc on device flap

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -70,6 +70,7 @@ type Collector struct {
 	span           *spanOverlay      // nil when SPAN mode is disabled
 	spanPrevRx     uint64
 	spanPrevTx     uint64
+	spanPrevTs     time.Time // timestamp of the last SPAN snapshot (own baseline)
 	spanHasPrev    bool
 	poller.Runner
 }
@@ -339,6 +340,11 @@ func (c *Collector) poll() {
 		if _, exists := infos[name]; !exists {
 			delete(c.current, name)
 			delete(c.previous, name)
+			// Drop the SPAN baseline too, so a returning SPAN device
+			// re-baselines instead of reporting a rate spanning its downtime.
+			if c.span != nil && name == c.span.device {
+				c.spanHasPrev = false
+			}
 		}
 	}
 
@@ -413,8 +419,12 @@ func (c *Collector) poll() {
 			iface.RxPackets = rxP
 			iface.TxPackets = txP
 			iface.IfaceType = "span"
+			// Use the SPAN's own previous timestamp rather than the kernel
+			// rawStat's: prev is nil on the first poll and whenever the SPAN
+			// device has just (re)appeared after a flap (its entry is dropped
+			// from c.previous below), which would panic on prev.ts.
 			if c.spanHasPrev {
-				dt := now.Sub(prev.ts).Seconds()
+				dt := now.Sub(c.spanPrevTs).Seconds()
 				if dt > 0 {
 					iface.RxRate = float64(rxB-c.spanPrevRx) / dt
 					iface.TxRate = float64(txB-c.spanPrevTx) / dt
@@ -422,6 +432,7 @@ func (c *Collector) poll() {
 			}
 			c.spanPrevRx = rxB
 			c.spanPrevTx = txB
+			c.spanPrevTs = now
 			c.spanHasPrev = true
 		}
 


### PR DESCRIPTION
Claude found the below. Personally I've never had a problem with the SPAN, so it seems quite edge case, I can't imagine why the SPAN would 'disappear'.

The SPAN overlay computed its rate interval from the kernel rawStat's timestamp (prev.ts), but guarded that deref with c.spanHasPrev — a flag that is never cleared. prev is nil on the first poll and, more importantly, whenever the SPAN device disappears from netlink (its entry is deleted from c.previous) and then reappears: hasPrev is false but spanHasPrev is still true, so now.Sub(prev.ts) dereferences a nil *rawStat and panics.

Give the SPAN its own baseline timestamp (spanPrevTs) so the rate calc no longer touches the kernel prev, and clear spanHasPrev when the SPAN device is removed so a returning device re-baselines cleanly instead of emitting one rate averaged across its downtime.