### PR TITLE
History API filtering (?iface=&since=) — stacked on #97

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BINARY=bandwidth-monitor
+GATEWAY_BINARY=apns-gateway
 INSTALL_DIR=/opt/bandwidth-monitor
 SERVICE_FILE=bandwidth-monitor.service
 
@@ -15,14 +16,19 @@ GEOLITE2_ASN=GeoLite2-ASN.mmdb
 GEOLITE2_CITY_URL=https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb
 GEOLITE2_ASN_URL=https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb
 
-.PHONY: build run clean geoip install uninstall
+.PHONY: build build-gateway run clean geoip install uninstall
 
 build:
 	go build -ldflags="$(LDFLAGS_VERSION)" -o $(BINARY) .
 
 build_stripped:
-	# Build and strip the binary. 
+	# Build and strip the binary.
 	go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o $(BINARY) .
+
+# The Live Activity push relay — a separate, minimal binary meant to run on any ordinary host (not
+# the router). See apnsgateway/main.go and docs/apns-gateway.md.
+build-gateway:
+	go build -ldflags="$(LDFLAGS_VERSION)" -o $(GATEWAY_BINARY) ./apnsgateway
 
 geoip:
 	@[ -f $(GEOLITE2_CITY) ] || { echo "Downloading GeoLite2-City.mmdb..."; curl -fSL -o $(GEOLITE2_CITY) $(GEOLITE2_CITY_URL); }
@@ -60,4 +66,4 @@ uninstall:
 	@echo "Uninstalled."
 
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) $(GATEWAY_BINARY)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Single-binary deployment with an embedded web UI, optional DNS stats (AdGuard Ho
 - [macOS Menu Bar Plugin](#macos-menu-bar-plugin)
 - [Windows System Tray Widget](#windows-system-tray-widget)
 - [GNOME/Linux Indicator](#gnomelinux-indicator)
+- [iOS App](#ios-app)
 - [Architecture](#architecture)
 - [API Endpoints](#api-endpoints)
 - [External Services Transparency](#external-services-transparency)
@@ -615,6 +616,33 @@ Or for the current user only, symlink the script and edit the `Exec=` path in th
 
 ---
 
+## iOS App
+
+An iOS client is available at [yeled/bandwidth-monitor-ios](https://github.com/yeled/bandwidth-monitor-ios). It displays live traffic graphs, per-interface sparklines, and — via ActivityKit — a **Lock Screen widget and Dynamic Island Live Activity** that keep updating in real time while the app is in the background.
+
+### Live Activity push (Lock Screen / Dynamic Island)
+
+The Live Activity is kept alive by server-sent APNs push notifications. There are two ways this can work:
+
+**Default (no server configuration needed):** The iOS app registers its push token with a shared relay gateway (`apnsgateway`). The gateway polls your server's existing `/api/interfaces` and `/api/interfaces/history` endpoints and pushes updates to APNs using its own key — your server needs no APNs configuration at all.
+
+**Self-hosted key (advanced):** If you'd rather not depend on the shared gateway, you can push directly from your own bandwidth-monitor instance by providing your own Apple Developer APNs key. Enable it with these environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APNS_KEY_FILE` | *(disabled)* | Path to the APNs auth key (`.p8`) from [developer.apple.com](https://developer.apple.com) (Keys → Apple Push Notification service). Keep it `chmod 0600`. When set, enables `POST /api/liveactivity/register`. |
+| `APNS_KEY_ID` | | 10-character key ID from the Apple Developer portal |
+| `APNS_TEAM_ID` | | Apple Developer team ID |
+| `APNS_BUNDLE_ID` | | App bundle ID (e.g. `com.example.BandwidthMonitor`) |
+| `APNS_ENV` | `production` | APNs environment: `production` (App Store / TestFlight) or `sandbox` (Xcode dev builds) |
+| `APNS_PUSH_INTERVAL` | `10s` | How often to push an update to each registered device |
+
+The server needs outbound HTTPS to `api.push.apple.com:443`. The feature is entirely off unless `APNS_KEY_FILE` is set.
+
+For running the shared relay gateway yourself, see [docs/apns-gateway.md](docs/apns-gateway.md).
+
+---
+
 ## Architecture
 
 main.go                   → entry point, env config, wires all components
@@ -626,6 +654,11 @@ latency/                  → continuous ICMP + HTTPS latency monitoring with ro
 speedtest/                → HTTP-based speed test client (download/upload/ping against OpenSpeedTest servers)
 debug/                    → traceroute (native ICMP), DNS checker (multi-server), resolver leak detection
 handler/                  → HTTP REST API + SSE streaming handler
+apns/                     → ES256 JWT signing + APNs HTTP/2 push client (shared by liveactivity and apnsgateway)
+liveactivity/             → optional per-instance Live Activity push loop (operator holds own APNs key; off unless APNS_KEY_FILE set)
+contentstate/             → Live Activity content-state builder + peak-preserving downsampler (shared by liveactivity and apnsgateway)
+poller/                   → generic tick-based runner used by liveactivity and apnsgateway
+apnsgateway/              → standalone relay binary (make build-gateway): polls any server's /api/interfaces* and pushes to APNs; the one place holding the key so self-hosters don't need one
 dns/                      → common DNS provider interface
 adguard/                  → AdGuard Home API client (stats, top clients/domains)
 nextdns/                  → NextDNS API client (stats, top clients/domains)
@@ -676,6 +709,7 @@ Makefile                  → build, install, GeoIP download targets
 | `/api/debug/dns` | GET | DNS check against 14 servers + resolver leak test; params: `domain`, `type` |
 | `/api/summary` | GET | Compact summary for menu bar clients |
 | `/api/events` | GET | SSE stream — pushes all data every second (Server-Sent Events) |
+| `/api/liveactivity/register` | POST | Register an iOS Live Activity push token (only available when `APNS_KEY_FILE` is set) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ Makefile                  → build, install, GeoIP download targets
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/api/interfaces` | GET | Current stats for all interfaces |
-| `/api/interfaces/history` | GET | 24h time-series per interface |
+| `/api/interfaces/history` | GET | 24h time-series per interface. Optional params: `iface` (single interface), `since` (Unix ms — only newer points). Additive: servers predating them ignore them and return everything |
 | `/api/talkers/bandwidth` | GET | Top 10 by current bandwidth |
 | `/api/talkers/volume` | GET | Top 10 by 24h volume |
 | `/api/dns` | GET | DNS summary (AdGuard Home, NextDNS, or Pi-hole) |

--- a/apns/apns.go
+++ b/apns/apns.go
@@ -1,0 +1,188 @@
+// Package apns signs ES256 provider JWTs and sends Live Activity push updates to Apple's APNs.
+// Shared by the local per-instance push path (liveactivity package) and the standalone relay
+// gateway (apnsgateway), so both hold-your-own-key operators and gateway-relayed users get
+// identical signing and error diagnostics.
+//
+// Dependency-free: crypto/ecdsa + crypto/x509 (stdlib) sign the JWT and parse the .p8 key; the
+// stdlib http.Client auto-negotiates HTTP/2 over TLS, which APNs requires.
+package apns
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// Config holds the APNs auth-key identity. All fields are required for NewClient to succeed.
+type Config struct {
+	KeyFile  string // path to the APNs auth key (.p8)
+	KeyID    string // the key's 10-char ID
+	TeamID   string // Apple Developer team ID
+	BundleID string // app bundle ID, e.g. com.evilforbeginners.BandwidthMonitor
+}
+
+// Client signs provider JWTs (cached ~50 min) and posts Live Activity updates to APNs.
+type Client struct {
+	cfg    Config
+	key    *ecdsa.PrivateKey
+	client *http.Client
+
+	jwtMu     sync.Mutex
+	jwtCache  string
+	jwtIssued time.Time
+}
+
+// NewClient parses the .p8 key. Returns an error if the key is missing or not a P-256 private key.
+func NewClient(cfg Config) (*Client, error) {
+	key, err := loadKey(cfg.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		cfg: cfg,
+		key: key,
+		// The stdlib client auto-negotiates HTTP/2 over TLS via ALPN (which APNs requires), so no
+		// golang.org/x/net/http2 dependency is needed.
+		client: &http.Client{Timeout: 10 * time.Second},
+	}, nil
+}
+
+// Result describes the outcome of a push attempt.
+type Result struct {
+	StatusCode int
+	Reason     string // APNs JSON "reason" field; empty on success
+	ApnsID     string // apns-id response header, useful when reporting issues to Apple
+}
+
+// Dead reports whether APNs says this token will never accept another push (drop it).
+func (r Result) Dead() bool {
+	return r.StatusCode == http.StatusGone || r.Reason == "BadDeviceToken" || r.Reason == "Unregistered"
+}
+
+// Send posts a Live Activity "update" event with contentState to APNs for token. environment must be
+// "sandbox" or "production". staleAfter sets how long the pushed state stays valid on-device before
+// ActivityKit shows it as stale. Logs the outcome (including a hint on 403, the most common
+// misconfiguration: provider-token/JWT auth rejected, not a device or environment problem).
+func (c *Client) Send(token, environment string, staleAfter time.Duration, contentState any) (Result, error) {
+	jwt, err := c.providerToken()
+	if err != nil {
+		return Result{}, fmt.Errorf("jwt: %w", err)
+	}
+
+	now := time.Now().Unix()
+	payload := map[string]any{"aps": map[string]any{
+		"timestamp":     now,
+		"event":         "update",
+		"content-state": contentState,
+		"stale-date":    now + int64(staleAfter.Seconds()),
+	}}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal payload: %w", err)
+	}
+
+	host := "https://api.push.apple.com"
+	if environment == "sandbox" {
+		host = "https://api.sandbox.push.apple.com"
+	}
+	req, err := http.NewRequest(http.MethodPost, host+"/3/device/"+token, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, err
+	}
+	req.Header.Set("authorization", "bearer "+jwt)
+	req.Header.Set("apns-topic", c.cfg.BundleID+".push-type.liveactivity")
+	req.Header.Set("apns-push-type", "liveactivity")
+	req.Header.Set("apns-priority", "10")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return Result{}, fmt.Errorf("send: %w", err)
+	}
+	defer resp.Body.Close()
+
+	result := Result{StatusCode: resp.StatusCode, ApnsID: resp.Header.Get("apns-id")}
+	if resp.StatusCode == http.StatusOK {
+		return result, nil
+	}
+	var apnsBody struct {
+		Reason string `json:"reason"`
+	}
+	json.NewDecoder(resp.Body).Decode(&apnsBody)
+	result.Reason = apnsBody.Reason
+
+	if result.Dead() {
+		log.Printf("apns: token dead (%d %s, apns-id=%s)", result.StatusCode, result.Reason, result.ApnsID)
+		return result, nil
+	}
+	// 403 is a provider-token (JWT) problem, not device/env. Surface the likely culprits.
+	if resp.StatusCode == http.StatusForbidden {
+		log.Printf("apns: 403 %s (apns-id=%s) — verify APNS_KEY_ID (%s) matches the .p8, APNS_TEAM_ID (%s), and the server clock (now=%s)",
+			result.Reason, result.ApnsID, c.cfg.KeyID, c.cfg.TeamID, time.Now().UTC().Format(time.RFC3339))
+		return result, nil
+	}
+	log.Printf("apns: %d %s (apns-id=%s)", result.StatusCode, result.Reason, result.ApnsID)
+	return result, nil
+}
+
+// providerToken returns a cached ES256 APNs provider JWT, regenerating it at most every ~50 min
+// (Apple rejects tokens older than an hour).
+func (c *Client) providerToken() (string, error) {
+	c.jwtMu.Lock()
+	defer c.jwtMu.Unlock()
+	if c.jwtCache != "" && time.Since(c.jwtIssued) < 50*time.Minute {
+		return c.jwtCache, nil
+	}
+	header := base64url([]byte(fmt.Sprintf(`{"alg":"ES256","kid":"%s"}`, c.cfg.KeyID)))
+	claims := base64url([]byte(fmt.Sprintf(`{"iss":"%s","iat":%d}`, c.cfg.TeamID, time.Now().Unix())))
+	signingInput := header + "." + claims
+
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, c.key, digest[:])
+	if err != nil {
+		return "", err
+	}
+	// JOSE wants the raw R||S, each left-padded to 32 bytes for P-256.
+	sig := make([]byte, 64)
+	r.FillBytes(sig[:32])
+	s.FillBytes(sig[32:])
+
+	jwt := signingInput + "." + base64url(sig)
+	c.jwtCache, c.jwtIssued = jwt, time.Now()
+	return jwt, nil
+}
+
+func base64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+func loadKey(path string) (*ecdsa.PrivateKey, error) {
+	if path == "" {
+		return nil, fmt.Errorf("no key file configured")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in %s", path)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key is not ECDSA/P-256")
+	}
+	return key, nil
+}

--- a/apns/apns_test.go
+++ b/apns/apns_test.go
@@ -1,4 +1,4 @@
-package liveactivity
+package apns
 
 import (
 	"crypto/ecdsa"
@@ -18,9 +18,9 @@ func TestProviderTokenIsValidES256(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	m := &Manager{cfg: Config{KeyID: "ABC123DEFG", TeamID: "TEAM123456"}, key: key}
+	c := &Client{cfg: Config{KeyID: "ABC123DEFG", TeamID: "TEAM123456"}, key: key}
 
-	tok, err := m.providerToken()
+	tok, err := c.providerToken()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,26 +50,22 @@ func TestProviderTokenIsValidES256(t *testing.T) {
 	}
 }
 
-// The content-state JSON keys must match the iOS BandwidthActivityAttributes.ContentState exactly,
-// or ActivityKit will reject the push.
-func TestContentStateJSONKeys(t *testing.T) {
-	cs := contentState{
-		InterfaceName: "eth0",
-		RxRate:        1,
-		TxRate:        2,
-		Points:        []point{{T: 123, Rx: 4, Tx: 5}},
-		UpdatedAt:     6.5,
+// A 410 or BadDeviceToken/Unregistered reason must be treated as dead so callers stop wasting
+// pushes on tokens Apple will never accept again.
+func TestResultDead(t *testing.T) {
+	cases := []struct {
+		r    Result
+		want bool
+	}{
+		{Result{StatusCode: 200}, false},
+		{Result{StatusCode: 410}, true},
+		{Result{StatusCode: 400, Reason: "BadDeviceToken"}, true},
+		{Result{StatusCode: 400, Reason: "Unregistered"}, true},
+		{Result{StatusCode: 403, Reason: "InvalidProviderToken"}, false},
 	}
-	b, err := json.Marshal(cs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(b)
-	for _, key := range []string{
-		`"interfaceName"`, `"rxRate"`, `"txRate"`, `"points"`, `"updatedAt"`, `"t"`, `"rx"`, `"tx"`,
-	} {
-		if !strings.Contains(got, key) {
-			t.Errorf("content-state JSON missing key %s: %s", key, got)
+	for _, c := range cases {
+		if got := c.r.Dead(); got != c.want {
+			t.Errorf("Result{%d, %q}.Dead() = %v, want %v", c.r.StatusCode, c.r.Reason, got, c.want)
 		}
 	}
 }

--- a/apnsgateway/main.go
+++ b/apnsgateway/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -25,15 +24,15 @@ func env(key, fallback string) string {
 
 func main() {
 	listenAddr := env("LISTEN", ":8443")
-	listenProto := strings.ToLower(strings.TrimSpace(env("LISTEN_PROTOCOL", "http")))
 	tlsCertFile := env("TLS_CERT_FILE", "")
 	tlsKeyFile := env("TLS_KEY_FILE", "")
 
-	if listenProto != "http" && listenProto != "https" {
-		log.Fatalf("LISTEN_PROTOCOL: invalid value %q (expected http or https)", listenProto)
-	}
-	if listenProto == "https" && (tlsCertFile == "" || tlsKeyFile == "") {
-		log.Fatal("LISTEN_PROTOCOL=https requires TLS_CERT_FILE and TLS_KEY_FILE")
+	// apnsgateway always serves HTTPS: the iOS client uses App Transport
+	// Security defaults and will refuse to reach a plain-HTTP endpoint, so
+	// a misconfigured cert should fail loudly at startup rather than come
+	// up on HTTP and silently reject every registration.
+	if tlsCertFile == "" || tlsKeyFile == "" {
+		log.Fatal("apnsgateway requires TLS: set TLS_CERT_FILE and TLS_KEY_FILE to your certificate and private key paths")
 	}
 
 	keyID := env("APNS_KEY_ID", "")
@@ -63,8 +62,8 @@ func main() {
 		w.Write([]byte("ok"))
 	})
 
-	log.Printf("apnsgateway: starting on %s (%s), key=%s team=%s bundle=%s push-interval=%s",
-		listenAddr, strings.ToUpper(listenProto), keyID, teamID, bundleID, interval)
+	log.Printf("apnsgateway: starting on %s (HTTPS), key=%s team=%s bundle=%s push-interval=%s",
+		listenAddr, keyID, teamID, bundleID, interval)
 
 	srv := &http.Server{
 		Addr:              listenAddr,
@@ -75,18 +74,11 @@ func main() {
 
 	go awaitShutdown(srv)
 
-	serveErr := serve(srv, listenProto, tlsCertFile, tlsKeyFile)
+	serveErr := srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
 	if serveErr != nil && serveErr != http.ErrServerClosed {
 		log.Fatalf("apnsgateway: server failed: %v", serveErr)
 	}
 	relay.Stop()
-}
-
-func serve(srv *http.Server, proto, certFile, keyFile string) error {
-	if proto == "https" {
-		return srv.ListenAndServeTLS(certFile, keyFile)
-	}
-	return srv.ListenAndServe()
 }
 
 // awaitShutdown blocks until SIGINT/SIGTERM, then gracefully shuts srv down (drains active

--- a/apnsgateway/main.go
+++ b/apnsgateway/main.go
@@ -1,0 +1,102 @@
+// Command apnsgateway is a standalone Live Activity push relay for Bandwidth Monitor. See relay.go
+// for the registration/polling/SSRF-hardening design.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"bandwidth-monitor/apns"
+)
+
+func env(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func main() {
+	listenAddr := env("LISTEN", ":8443")
+	listenProto := strings.ToLower(strings.TrimSpace(env("LISTEN_PROTOCOL", "http")))
+	tlsCertFile := env("TLS_CERT_FILE", "")
+	tlsKeyFile := env("TLS_KEY_FILE", "")
+
+	if listenProto != "http" && listenProto != "https" {
+		log.Fatalf("LISTEN_PROTOCOL: invalid value %q (expected http or https)", listenProto)
+	}
+	if listenProto == "https" && (tlsCertFile == "" || tlsKeyFile == "") {
+		log.Fatal("LISTEN_PROTOCOL=https requires TLS_CERT_FILE and TLS_KEY_FILE")
+	}
+
+	keyID := env("APNS_KEY_ID", "")
+	teamID := env("APNS_TEAM_ID", "")
+	bundleID := env("APNS_BUNDLE_ID", "")
+	keyFile := env("APNS_KEY_FILE", "")
+	if keyFile == "" || keyID == "" || teamID == "" || bundleID == "" {
+		log.Fatal("APNS_KEY_FILE, APNS_KEY_ID, APNS_TEAM_ID, and APNS_BUNDLE_ID are all required")
+	}
+	apnsClient, err := apns.NewClient(apns.Config{KeyFile: keyFile, KeyID: keyID, TeamID: teamID, BundleID: bundleID})
+	if err != nil {
+		log.Fatalf("apns: %v", err)
+	}
+
+	interval, err := time.ParseDuration(env("APNS_PUSH_INTERVAL", "10s"))
+	if err != nil {
+		log.Fatalf("APNS_PUSH_INTERVAL: %v", err)
+	}
+
+	relay := NewRelay(apnsClient, interval)
+	go relay.Run()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/liveactivity/register", relay.HandleRegister)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	log.Printf("apnsgateway: starting on %s (%s), key=%s team=%s bundle=%s push-interval=%s",
+		listenAddr, strings.ToUpper(listenProto), keyID, teamID, bundleID, interval)
+
+	srv := &http.Server{
+		Addr:              listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	go awaitShutdown(srv)
+
+	serveErr := serve(srv, listenProto, tlsCertFile, tlsKeyFile)
+	if serveErr != nil && serveErr != http.ErrServerClosed {
+		log.Fatalf("apnsgateway: server failed: %v", serveErr)
+	}
+	relay.Stop()
+}
+
+func serve(srv *http.Server, proto, certFile, keyFile string) error {
+	if proto == "https" {
+		return srv.ListenAndServeTLS(certFile, keyFile)
+	}
+	return srv.ListenAndServe()
+}
+
+// awaitShutdown blocks until SIGINT/SIGTERM, then gracefully shuts srv down (drains active
+// connections, up to 5s).
+func awaitShutdown(srv *http.Server) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+	fmt.Println("\nShutting down...")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	srv.Shutdown(ctx)
+}

--- a/apnsgateway/main.go
+++ b/apnsgateway/main.go
@@ -62,8 +62,8 @@ func main() {
 		w.Write([]byte("ok"))
 	})
 
-	log.Printf("apnsgateway: starting on %s (HTTPS), key=%s team=%s bundle=%s push-interval=%s",
-		listenAddr, keyID, teamID, bundleID, interval)
+	log.Printf("apnsgateway: starting on %s (HTTPS) tls-cert=%s tls-key=%s, apns-key-id=%s team=%s bundle=%s push-interval=%s",
+		listenAddr, tlsCertFile, tlsKeyFile, keyID, teamID, bundleID, interval)
 
 	srv := &http.Server{
 		Addr:              listenAddr,

--- a/apnsgateway/main.go
+++ b/apnsgateway/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -52,7 +53,12 @@ func main() {
 		log.Fatalf("APNS_PUSH_INTERVAL: %v", err)
 	}
 
-	relay := NewRelay(apnsClient, interval)
+	maxResponseBytes, err := strconv.ParseInt(env("APNS_MAX_RESPONSE_BYTES", strconv.Itoa(DefaultMaxResponseBytes)), 10, 64)
+	if err != nil || maxResponseBytes <= 0 {
+		log.Fatalf("APNS_MAX_RESPONSE_BYTES: invalid value %q (expected a positive byte count)", env("APNS_MAX_RESPONSE_BYTES", ""))
+	}
+
+	relay := NewRelay(apnsClient, interval, maxResponseBytes)
 	go relay.Run()
 
 	mux := http.NewServeMux()
@@ -62,8 +68,8 @@ func main() {
 		w.Write([]byte("ok"))
 	})
 
-	log.Printf("apnsgateway: starting on %s (HTTPS) tls-cert=%s tls-key=%s, apns-key-id=%s team=%s bundle=%s push-interval=%s",
-		listenAddr, tlsCertFile, tlsKeyFile, keyID, teamID, bundleID, interval)
+	log.Printf("apnsgateway: starting on %s (HTTPS) tls-cert=%s tls-key=%s, apns-key-id=%s team=%s bundle=%s push-interval=%s max-response-bytes=%d",
+		listenAddr, tlsCertFile, tlsKeyFile, keyID, teamID, bundleID, interval, maxResponseBytes)
 
 	srv := &http.Server{
 		Addr:              listenAddr,

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -305,6 +305,16 @@ func (r *Relay) fetchInterfaces(serverURL string) ([]remoteInterfaceStat, error)
 	return out, nil
 }
 
+// TODO(api-versioning): this pulls every interface's full history (up to ~5.5MB per interface
+// at the default 24h/1Hz retention — see PR #8) when contentstate.Build only ever uses the last
+// contentstate.Window (1h), downsampled to contentstate.MaxPoints, for a single interface. Add
+// optional ?iface=&since= params to /api/interfaces/history so this can request just that slice
+// instead of relying on APNS_MAX_RESPONSE_BYTES to keep growing. This is additive/backward
+// compatible on its own — the server currently has no API versioning scheme (flat /api/* routes,
+// no /v1/ prefix; X-Bandwidth-Monitor is a build version, not a schema version) — so it likely
+// doesn't need one just for this, but should ride along if a versioning scheme gets introduced
+// for other reasons. Touches collector.go/handler.go on the main server as well as this file, so
+// it needs a coordinated rebuild/redeploy of both binaries where they run on separate hosts.
 func (r *Relay) fetchHistory(serverURL string) (map[string][]contentstate.Point, error) {
 	var out map[string][]contentstate.Point
 	if err := r.fetchJSON(serverURL+"/api/interfaces/history", &out); err != nil {

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -94,6 +94,7 @@ func (r *Relay) HandleRegister(w http.ResponseWriter, req *http.Request) {
 
 	ip := clientIP(req)
 	if !r.limiter.allow(ip) {
+		log.Printf("apnsgateway: rejected registration from %s: rate limited", ip)
 		http.Error(w, "too many registrations, slow down", http.StatusTooManyRequests)
 		return
 	}
@@ -106,19 +107,23 @@ func (r *Relay) HandleRegister(w http.ResponseWriter, req *http.Request) {
 		Interface   string `json:"interface"`
 	}
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		log.Printf("apnsgateway: rejected registration from %s: invalid JSON body: %v", ip, err)
 		http.Error(w, "invalid JSON body", http.StatusBadRequest)
 		return
 	}
 	if body.Token == "" || len(body.Token) > 200 {
+		log.Printf("apnsgateway: rejected registration from %s: invalid token (len=%d)", ip, len(body.Token))
 		http.Error(w, "invalid token", http.StatusBadRequest)
 		return
 	}
 	if body.Environment != "sandbox" && body.Environment != "production" {
+		log.Printf("apnsgateway: rejected registration from %s: invalid environment %q", ip, body.Environment)
 		http.Error(w, "environment must be sandbox or production", http.StatusBadRequest)
 		return
 	}
 	normalizedURL, err := validateServerURL(body.ServerURL)
 	if err != nil {
+		log.Printf("apnsgateway: rejected registration from %s: invalid serverURL %q: %v", ip, body.ServerURL, err)
 		http.Error(w, "invalid serverURL: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -127,6 +132,7 @@ func (r *Relay) HandleRegister(w http.ResponseWriter, req *http.Request) {
 	_, existed := r.subs[body.Token]
 	if !existed && len(r.subs) >= maxSubscriptions {
 		r.mu.Unlock()
+		log.Printf("apnsgateway: rejected registration from %s: relay at capacity (%d subscriptions)", ip, maxSubscriptions)
 		http.Error(w, "relay at capacity, try again later", http.StatusServiceUnavailable)
 		return
 	}

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"bandwidth-monitor/apns"
@@ -66,15 +67,9 @@ func NewRelay(apnsClient *apns.Client, interval time.Duration, maxResponseBytes 
 	if maxResponseBytes <= 0 {
 		maxResponseBytes = DefaultMaxResponseBytes
 	}
-	fetchClient := httputil.NewClient(fetchTimeout)
-	// Never follow redirects: a registered URL that passes the public-IP check could otherwise
-	// redirect the actual request somewhere that wouldn't (SSRF via redirect).
-	fetchClient.CheckRedirect = func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
 	r := &Relay{
 		apnsClient:       apnsClient,
-		httpClient:       fetchClient,
+		httpClient:       newFetchClient(fetchTimeout, checkIP),
 		interval:         interval,
 		maxResponseBytes: maxResponseBytes,
 		limiter:          newIPRateLimiter(20, 5*time.Minute),
@@ -82,6 +77,49 @@ func NewRelay(apnsClient *apns.Client, interval time.Duration, maxResponseBytes 
 	}
 	r.runner.Init()
 	return r
+}
+
+// newFetchClient builds the HTTP client used to poll registered servers. ipCheck (nil = allow
+// all, tests only) runs inside the dialer's Control hook, which observes the concrete IP of
+// every connection attempt *after* the client's own DNS resolution — unlike a LookupIP
+// pre-check, this can't be split from the connection by a DNS-rebinding attacker serving one
+// answer to the check and another to the dial.
+func newFetchClient(timeout time.Duration, ipCheck func(net.IP) error) *http.Client {
+	dialer := &net.Dialer{
+		Timeout: timeout,
+		Control: func(network, address string, _ syscall.RawConn) error {
+			if ipCheck == nil {
+				return nil
+			}
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("dial %q: %w", address, err)
+			}
+			// Strip any IPv6 zone (fe80::1%eth0) so ParseIP accepts the literal.
+			if i := strings.IndexByte(host, '%'); i >= 0 {
+				host = host[:i]
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				return fmt.Errorf("dial %q: not an IP literal", address)
+			}
+			if err := ipCheck(ip); err != nil {
+				return fmt.Errorf("dial %s: %w", ip, err)
+			}
+			return nil
+		},
+	}
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: httputil.WrapTransport(&http.Transport{DialContext: dialer.DialContext}),
+	}
+	// Never follow redirects: a registered URL that dials a public IP could otherwise redirect
+	// the request chain somewhere else entirely (SSRF via redirect) — though even a followed
+	// redirect would still hit the dial-time IP check above.
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return client
 }
 
 func (r *Relay) Run()  { r.runner.Run(r.interval, r.tick) }
@@ -165,9 +203,9 @@ func (r *Relay) HandleRegister(w http.ResponseWriter, req *http.Request) {
 // can never legitimately live at a private/loopback/link-local address anyway, since the gateway
 // reaches it over the public internet, not the operator's LAN — so rejecting those targets costs
 // the real use case nothing while closing off internal-network and cloud-metadata-endpoint probing.
-// checkPublicHost is called again immediately before every fetch (not just at registration) to
-// narrow the DNS-rebinding window where a hostname resolves to a public IP at registration time but
-// to a private one later.
+// This registration-time resolve is for fast 400 feedback only; the authoritative check runs in
+// the fetch client's dialer against the concrete IP of every connection attempt (newFetchClient),
+// which DNS rebinding can't split from the connection.
 func validateServerURL(raw string) (string, error) {
 	if raw == "" || len(raw) > 2048 {
 		return "", fmt.Errorf("empty or too long")
@@ -188,18 +226,29 @@ func validateServerURL(raw string) (string, error) {
 	return strings.TrimSuffix(raw, "/"), nil
 }
 
-// checkPublicHost resolves host and rejects it if any resolved address is private, loopback,
-// link-local (which covers the 169.254.169.254 cloud-metadata pattern), multicast, or unspecified.
+// checkPublicHost resolves host and rejects it if any resolved address fails checkIP. This is
+// the registration-time check, for fast feedback (400) on obviously invalid targets; the
+// authoritative enforcement is the dial-time checkIP in newFetchClient, which a DNS-rebinding
+// attacker can't bypass.
 func checkPublicHost(host string) error {
 	ips, err := net.LookupIP(host)
 	if err != nil {
 		return fmt.Errorf("resolve %q: %w", host, err)
 	}
 	for _, ip := range ips {
-		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
-			ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
-			return fmt.Errorf("%q resolves to a non-public address (%s)", host, ip)
+		if err := checkIP(ip); err != nil {
+			return fmt.Errorf("%q: %w", host, err)
 		}
+	}
+	return nil
+}
+
+// checkIP rejects private, loopback, link-local (which covers the 169.254.169.254
+// cloud-metadata pattern), multicast, and unspecified addresses.
+func checkIP(ip net.IP) error {
+	if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("non-public address %s", ip)
 	}
 	return nil
 }
@@ -323,17 +372,12 @@ func (r *Relay) fetchHistory(serverURL string) (map[string][]contentstate.Point,
 	return out, nil
 }
 
+// fetchJSON GETs target and decodes it. SSRF enforcement happens inside the client's dialer
+// (see newFetchClient): every connection attempt validates the concrete resolved IP, so a
+// hostname repointed at a private address after registration (DNS rebinding) fails at dial
+// time — there is deliberately no separate LookupIP pre-check here, because a check that
+// resolves independently of the dial can be fed a different answer than the dial receives.
 func (r *Relay) fetchJSON(target string, out any) error {
-	parsed, err := url.Parse(target)
-	if err != nil {
-		return err
-	}
-	// Re-check on every fetch, not just at registration, to narrow the window where a hostname
-	// resolved to a public IP when registered but has since been repointed at a private one.
-	if err := checkPublicHost(parsed.Hostname()); err != nil {
-		return err
-	}
-
 	req, err := http.NewRequest(http.MethodGet, target, nil)
 	if err != nil {
 		return err
@@ -399,16 +443,20 @@ func clientIP(req *http.Request) string {
 
 // ipRateLimiter is a minimal fixed-window-per-source limiter — no external dependency, just enough
 // to stop a single source from hammering the (intentionally unauthenticated) register endpoint.
+// A periodic sweep drops sources whose events have all aged out, so the map stays bounded by the
+// number of currently-active sources rather than every source ever seen — without it, a long-lived
+// public relay leaks an entry per churned client IP forever.
 type ipRateLimiter struct {
 	max    int
 	window time.Duration
 
-	mu     sync.Mutex
-	events map[string][]time.Time
+	mu        sync.Mutex
+	events    map[string][]time.Time
+	lastSweep time.Time
 }
 
 func newIPRateLimiter(max int, window time.Duration) *ipRateLimiter {
-	return &ipRateLimiter{max: max, window: window, events: make(map[string][]time.Time)}
+	return &ipRateLimiter{max: max, window: window, events: make(map[string][]time.Time), lastSweep: time.Now()}
 }
 
 func (l *ipRateLimiter) allow(ip string) bool {
@@ -416,6 +464,23 @@ func (l *ipRateLimiter) allow(ip string) bool {
 	defer l.mu.Unlock()
 	now := time.Now()
 	cutoff := now.Add(-l.window)
+
+	// At most once per window, drop sources with no events left in the window. Amortized cost is
+	// negligible; keyed off registration traffic itself, so an idle relay holds only idle memory.
+	if now.Sub(l.lastSweep) > l.window {
+		for k, ts := range l.events {
+			i := 0
+			for i < len(ts) && ts[i].Before(cutoff) {
+				i++
+			}
+			if i == len(ts) {
+				delete(l.events, k)
+			} else if i > 0 {
+				l.events[k] = ts[i:]
+			}
+		}
+		l.lastSweep = now
+	}
 
 	times := l.events[ip]
 	i := 0

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -309,23 +310,42 @@ func (r *Relay) pushOne(token string, sub subscription) {
 // fetchState polls the subscriber's own bandwidth-monitor server — the exact same plain
 // /api/interfaces and /api/interfaces/history endpoints the iOS app already uses directly — and
 // shapes the response into a contentstate.State via the shared builder.
+//
+// The interface name is resolved from /api/interfaces first so the history fetch can be narrowed
+// with ?iface=&since= to just the slice contentstate.Build actually uses, instead of every
+// interface's full 24h history (multiple MB). Old servers ignore the params and return the full
+// map — Build's own windowing handles the superset, so no version negotiation is needed.
 func (r *Relay) fetchState(sub subscription) (contentstate.State, bool) {
 	all, err := r.fetchInterfaces(sub.serverURL)
 	if err != nil {
 		log.Printf("apnsgateway: fetch %s/api/interfaces: %v", sub.serverURL, err)
 		return contentstate.State{}, false
 	}
-	hist, err := r.fetchHistory(sub.serverURL)
+
+	name := sub.iface
+	if name == "" {
+		name = pickInterface(all, nil)
+	}
+	hist, err := r.fetchHistory(sub.serverURL, name)
 	if err != nil {
 		log.Printf("apnsgateway: fetch %s/api/interfaces/history: %v", sub.serverURL, err)
 		return contentstate.State{}, false
 	}
 
-	name := sub.iface
-	if name == "" || (hist[name] == nil && ifaceStat(all, name) == nil) {
-		name = pickInterface(all, hist)
+	// The requested interface is unknown to this server (no history, not in /api/interfaces) —
+	// fall back to whatever it does have, refetching if the first fetch was filtered to the
+	// wrong name. Rare path: a misconfigured subscription or an empty /api/interfaces.
+	if hist[name] == nil && ifaceStat(all, name) == nil {
+		fallback := pickInterface(all, hist)
+		if fallback != "" && fallback != name && hist[fallback] == nil {
+			if hist, err = r.fetchHistory(sub.serverURL, fallback); err != nil {
+				log.Printf("apnsgateway: fetch %s/api/interfaces/history: %v", sub.serverURL, err)
+				return contentstate.State{}, false
+			}
+		}
+		name = fallback
 	}
-	if name == "" {
+	if name == "" || (hist[name] == nil && ifaceStat(all, name) == nil) {
 		return contentstate.State{}, false
 	}
 
@@ -354,19 +374,18 @@ func (r *Relay) fetchInterfaces(serverURL string) ([]remoteInterfaceStat, error)
 	return out, nil
 }
 
-// TODO(api-versioning): this pulls every interface's full history (up to ~5.5MB per interface
-// at the default 24h/1Hz retention — see PR #8) when contentstate.Build only ever uses the last
-// contentstate.Window (1h), downsampled to contentstate.MaxPoints, for a single interface. Add
-// optional ?iface=&since= params to /api/interfaces/history so this can request just that slice
-// instead of relying on APNS_MAX_RESPONSE_BYTES to keep growing. This is additive/backward
-// compatible on its own — the server currently has no API versioning scheme (flat /api/* routes,
-// no /v1/ prefix; X-Bandwidth-Monitor is a build version, not a schema version) — so it likely
-// doesn't need one just for this, but should ride along if a versioning scheme gets introduced
-// for other reasons. Touches collector.go/handler.go on the main server as well as this file, so
-// it needs a coordinated rebuild/redeploy of both binaries where they run on separate hosts.
-func (r *Relay) fetchHistory(serverURL string) (map[string][]contentstate.Point, error) {
+// fetchHistory pulls history narrowed with ?iface=&since= to just the slice contentstate.Build
+// uses (the last contentstate.Window for one interface) instead of every interface's full 24h
+// history. The params are additive: old servers ignore them and return the full map, which
+// Build's own windowing (and the response size cap) absorbs — so no version negotiation is
+// needed against servers that predate the params. iface == "" fetches all interfaces.
+func (r *Relay) fetchHistory(serverURL, iface string) (map[string][]contentstate.Point, error) {
+	params := url.Values{"since": {strconv.FormatInt(time.Now().Add(-contentstate.Window).UnixMilli(), 10)}}
+	if iface != "" {
+		params.Set("iface", iface)
+	}
 	var out map[string][]contentstate.Point
-	if err := r.fetchJSON(serverURL+"/api/interfaces/history", &out); err != nil {
+	if err := r.fetchJSON(serverURL+"/api/interfaces/history?"+params.Encode(), &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"bandwidth-monitor/apns"
+	"bandwidth-monitor/contentstate"
+	"bandwidth-monitor/httputil"
+	"bandwidth-monitor/poller"
+)
+
+const (
+	maxSubscriptions   = 5000            // global cap so the relay can't grow unbounded
+	maxConcurrentFetch = 20              // bounded concurrency per tick, so one slow/unreachable
+	fetchTimeout       = 8 * time.Second // server doesn't delay pushes to everyone else
+	maxResponseBytes   = 2 << 20         // 2MB cap on a polled server's response
+	registrationTTL    = time.Hour       // drop a subscription if the app hasn't re-registered
+	// minStaleAfter/staleAfterMultiple mirror the local liveactivity package's cushion sizing.
+	minStaleAfter      = 60 * time.Second
+	staleAfterMultiple = 15
+)
+
+type subscription struct {
+	serverURL   string
+	iface       string
+	environment string
+	lastSeen    time.Time
+}
+
+// Relay accepts registrations naming the caller's own bandwidth-monitor server, polls that
+// server's existing plain /api/interfaces and /api/interfaces/history endpoints itself, and pushes
+// to APNs using the operator's own key. No APNs configuration or new server-side code is needed on
+// the polled server at all — it already serves the two endpoints this relay reads.
+//
+// There is intentionally no authentication (an operator decision — the app never surfaces any
+// setup step to the end user). Hygiene against abuse is done without credentials: per-source rate
+// limiting on registration, a global subscription cap, response size caps, fetch timeouts, and TTL
+// expiry of subscriptions the app stops refreshing.
+type Relay struct {
+	apnsClient *apns.Client
+	httpClient *http.Client
+	interval   time.Duration
+	runner     poller.Runner
+	limiter    *ipRateLimiter
+
+	mu   sync.Mutex
+	subs map[string]subscription // push token -> subscription
+}
+
+func NewRelay(apnsClient *apns.Client, interval time.Duration) *Relay {
+	fetchClient := httputil.NewClient(fetchTimeout)
+	// Never follow redirects: a registered URL that passes the public-IP check could otherwise
+	// redirect the actual request somewhere that wouldn't (SSRF via redirect).
+	fetchClient.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	r := &Relay{
+		apnsClient: apnsClient,
+		httpClient: fetchClient,
+		interval:   interval,
+		limiter:    newIPRateLimiter(20, 5*time.Minute),
+		subs:       make(map[string]subscription),
+	}
+	r.runner.Init()
+	return r
+}
+
+func (r *Relay) Run()  { r.runner.Run(r.interval, r.tick) }
+func (r *Relay) Stop() { r.runner.Stop() }
+
+func (r *Relay) staleAfter() time.Duration {
+	if d := r.interval * staleAfterMultiple; d > minStaleAfter {
+		return d
+	}
+	return minStaleAfter
+}
+
+// HandleRegister handles POST /api/liveactivity/register.
+// Body: {"token":"...", "environment":"sandbox|production", "serverURL":"https://host:port", "interface":"eth0"}
+func (r *Relay) HandleRegister(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "POST required", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ip := clientIP(req)
+	if !r.limiter.allow(ip) {
+		http.Error(w, "too many registrations, slow down", http.StatusTooManyRequests)
+		return
+	}
+
+	req.Body = http.MaxBytesReader(w, req.Body, 4<<10)
+	var body struct {
+		Token       string `json:"token"`
+		Environment string `json:"environment"`
+		ServerURL   string `json:"serverURL"`
+		Interface   string `json:"interface"`
+	}
+	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if body.Token == "" || len(body.Token) > 200 {
+		http.Error(w, "invalid token", http.StatusBadRequest)
+		return
+	}
+	if body.Environment != "sandbox" && body.Environment != "production" {
+		http.Error(w, "environment must be sandbox or production", http.StatusBadRequest)
+		return
+	}
+	normalizedURL, err := validateServerURL(body.ServerURL)
+	if err != nil {
+		http.Error(w, "invalid serverURL: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	r.mu.Lock()
+	_, existed := r.subs[body.Token]
+	if !existed && len(r.subs) >= maxSubscriptions {
+		r.mu.Unlock()
+		http.Error(w, "relay at capacity, try again later", http.StatusServiceUnavailable)
+		return
+	}
+	r.subs[body.Token] = subscription{
+		serverURL: normalizedURL, iface: body.Interface, environment: body.Environment, lastSeen: time.Now(),
+	}
+	n := len(r.subs)
+	r.mu.Unlock()
+
+	if !existed {
+		log.Printf("apnsgateway: registered %s (%s); %d active", normalizedURL, body.Environment, n)
+	}
+	httputil.WriteJSON(w, map[string]string{"status": "ok"})
+}
+
+// validateServerURL requires an http(s) URL whose host resolves only to public IP addresses.
+//
+// Registering serverURL is inherently a server-side-request-forgery shape (the relay makes outbound
+// requests to an operator-supplied target), so this isn't just tidiness: a bandwidth-monitor server
+// can never legitimately live at a private/loopback/link-local address anyway, since the gateway
+// reaches it over the public internet, not the operator's LAN — so rejecting those targets costs
+// the real use case nothing while closing off internal-network and cloud-metadata-endpoint probing.
+// checkPublicHost is called again immediately before every fetch (not just at registration) to
+// narrow the DNS-rebinding window where a hostname resolves to a public IP at registration time but
+// to a private one later.
+func validateServerURL(raw string) (string, error) {
+	if raw == "" || len(raw) > 2048 {
+		return "", fmt.Errorf("empty or too long")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("scheme must be http or https")
+	}
+	if u.Hostname() == "" {
+		return "", fmt.Errorf("missing host")
+	}
+	if err := checkPublicHost(u.Hostname()); err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(raw, "/"), nil
+}
+
+// checkPublicHost resolves host and rejects it if any resolved address is private, loopback,
+// link-local (which covers the 169.254.169.254 cloud-metadata pattern), multicast, or unspecified.
+func checkPublicHost(host string) error {
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("resolve %q: %w", host, err)
+	}
+	for _, ip := range ips {
+		if ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() ||
+			ip.IsLinkLocalMulticast() || ip.IsMulticast() || ip.IsUnspecified() {
+			return fmt.Errorf("%q resolves to a non-public address (%s)", host, ip)
+		}
+	}
+	return nil
+}
+
+func (r *Relay) tick() {
+	r.expireStale()
+
+	r.mu.Lock()
+	toks := make(map[string]subscription, len(r.subs))
+	for k, v := range r.subs {
+		toks[k] = v
+	}
+	r.mu.Unlock()
+
+	sem := make(chan struct{}, maxConcurrentFetch)
+	var wg sync.WaitGroup
+	for token, sub := range toks {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(token string, sub subscription) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			r.pushOne(token, sub)
+		}(token, sub)
+	}
+	wg.Wait()
+}
+
+func (r *Relay) expireStale() {
+	cutoff := time.Now().Add(-registrationTTL)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for token, sub := range r.subs {
+		if sub.lastSeen.Before(cutoff) {
+			delete(r.subs, token)
+			log.Printf("apnsgateway: expired stale subscription for %s (no re-registration in %s)", sub.serverURL, registrationTTL)
+		}
+	}
+}
+
+func (r *Relay) pushOne(token string, sub subscription) {
+	state, ok := r.fetchState(sub)
+	if !ok {
+		return
+	}
+	result, err := r.apnsClient.Send(token, sub.environment, r.staleAfter(), state)
+	if err != nil {
+		log.Printf("apnsgateway: send to %s: %v", sub.serverURL, err)
+		return
+	}
+	if result.Dead() {
+		r.mu.Lock()
+		delete(r.subs, token)
+		r.mu.Unlock()
+	}
+}
+
+// fetchState polls the subscriber's own bandwidth-monitor server — the exact same plain
+// /api/interfaces and /api/interfaces/history endpoints the iOS app already uses directly — and
+// shapes the response into a contentstate.State via the shared builder.
+func (r *Relay) fetchState(sub subscription) (contentstate.State, bool) {
+	all, err := r.fetchInterfaces(sub.serverURL)
+	if err != nil {
+		log.Printf("apnsgateway: fetch %s/api/interfaces: %v", sub.serverURL, err)
+		return contentstate.State{}, false
+	}
+	hist, err := r.fetchHistory(sub.serverURL)
+	if err != nil {
+		log.Printf("apnsgateway: fetch %s/api/interfaces/history: %v", sub.serverURL, err)
+		return contentstate.State{}, false
+	}
+
+	name := sub.iface
+	if name == "" || (hist[name] == nil && ifaceStat(all, name) == nil) {
+		name = pickInterface(all, hist)
+	}
+	if name == "" {
+		return contentstate.State{}, false
+	}
+
+	var rx, tx float64
+	if s := ifaceStat(all, name); s != nil {
+		rx, tx = s.RxRate, s.TxRate
+	}
+	return contentstate.Build(name, rx, tx, hist[name]), true
+}
+
+// remoteInterfaceStat mirrors the fields of collector.InterfaceStat this relay actually needs.
+// Deliberately minimal and independently defined (not imported from the collector package) so this
+// binary has zero router-specific dependencies and can run anywhere, unprivileged.
+type remoteInterfaceStat struct {
+	Name   string  `json:"name"`
+	WAN    bool    `json:"wan"`
+	RxRate float64 `json:"rx_rate"`
+	TxRate float64 `json:"tx_rate"`
+}
+
+func (r *Relay) fetchInterfaces(serverURL string) ([]remoteInterfaceStat, error) {
+	var out []remoteInterfaceStat
+	if err := r.fetchJSON(serverURL+"/api/interfaces", &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *Relay) fetchHistory(serverURL string) (map[string][]contentstate.Point, error) {
+	var out map[string][]contentstate.Point
+	if err := r.fetchJSON(serverURL+"/api/interfaces/history", &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r *Relay) fetchJSON(target string, out any) error {
+	parsed, err := url.Parse(target)
+	if err != nil {
+		return err
+	}
+	// Re-check on every fetch, not just at registration, to narrow the window where a hostname
+	// resolved to a public IP when registered but has since been repointed at a private one.
+	if err := checkPublicHost(parsed.Hostname()); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(out)
+}
+
+func ifaceStat(all []remoteInterfaceStat, name string) *remoteInterfaceStat {
+	for i := range all {
+		if all[i].Name == name {
+			return &all[i]
+		}
+	}
+	return nil
+}
+
+func pickInterface(all []remoteInterfaceStat, hist map[string][]contentstate.Point) string {
+	for i := range all {
+		if all[i].WAN {
+			return all[i].Name
+		}
+	}
+	if len(all) > 0 {
+		return all[0].Name
+	}
+	for k := range hist {
+		return k
+	}
+	return ""
+}
+
+func clientIP(req *http.Request) string {
+	if host, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		return host
+	}
+	return req.RemoteAddr
+}
+
+// ipRateLimiter is a minimal fixed-window-per-source limiter — no external dependency, just enough
+// to stop a single source from hammering the (intentionally unauthenticated) register endpoint.
+type ipRateLimiter struct {
+	max    int
+	window time.Duration
+
+	mu     sync.Mutex
+	events map[string][]time.Time
+}
+
+func newIPRateLimiter(max int, window time.Duration) *ipRateLimiter {
+	return &ipRateLimiter{max: max, window: window, events: make(map[string][]time.Time)}
+}
+
+func (l *ipRateLimiter) allow(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := time.Now()
+	cutoff := now.Add(-l.window)
+
+	times := l.events[ip]
+	i := 0
+	for i < len(times) && times[i].Before(cutoff) {
+		i++
+	}
+	times = times[i:]
+	if len(times) >= l.max {
+		l.events[ip] = times
+		return false
+	}
+	l.events[ip] = append(times, now)
+	return true
+}

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -22,8 +22,12 @@ const (
 	maxSubscriptions   = 5000            // global cap so the relay can't grow unbounded
 	maxConcurrentFetch = 20              // bounded concurrency per tick, so one slow/unreachable
 	fetchTimeout       = 8 * time.Second // server doesn't delay pushes to everyone else
-	maxResponseBytes   = 2 << 20         // 2MB cap on a polled server's response
-	registrationTTL    = time.Hour       // drop a subscription if the app hasn't re-registered
+	// DefaultMaxResponseBytes caps a polled server's response absent APNS_MAX_RESPONSE_BYTES.
+	// /api/interfaces/history alone can run several MB per interface at the default 24h/1Hz
+	// retention, so this needs to comfortably clear one server's full history, not just a
+	// single Live Activity payload.
+	DefaultMaxResponseBytes = 16 << 20
+	registrationTTL         = time.Hour // drop a subscription if the app hasn't re-registered
 	// minStaleAfter/staleAfterMultiple mirror the local liveactivity package's cushion sizing.
 	minStaleAfter      = 60 * time.Second
 	staleAfterMultiple = 15
@@ -46,17 +50,22 @@ type subscription struct {
 // limiting on registration, a global subscription cap, response size caps, fetch timeouts, and TTL
 // expiry of subscriptions the app stops refreshing.
 type Relay struct {
-	apnsClient *apns.Client
-	httpClient *http.Client
-	interval   time.Duration
-	runner     poller.Runner
-	limiter    *ipRateLimiter
+	apnsClient       *apns.Client
+	httpClient       *http.Client
+	interval         time.Duration
+	maxResponseBytes int64
+	runner           poller.Runner
+	limiter          *ipRateLimiter
 
 	mu   sync.Mutex
 	subs map[string]subscription // push token -> subscription
 }
 
-func NewRelay(apnsClient *apns.Client, interval time.Duration) *Relay {
+// NewRelay builds a Relay. maxResponseBytes <= 0 falls back to DefaultMaxResponseBytes.
+func NewRelay(apnsClient *apns.Client, interval time.Duration, maxResponseBytes int64) *Relay {
+	if maxResponseBytes <= 0 {
+		maxResponseBytes = DefaultMaxResponseBytes
+	}
 	fetchClient := httputil.NewClient(fetchTimeout)
 	// Never follow redirects: a registered URL that passes the public-IP check could otherwise
 	// redirect the actual request somewhere that wouldn't (SSRF via redirect).
@@ -64,11 +73,12 @@ func NewRelay(apnsClient *apns.Client, interval time.Duration) *Relay {
 		return http.ErrUseLastResponse
 	}
 	r := &Relay{
-		apnsClient: apnsClient,
-		httpClient: fetchClient,
-		interval:   interval,
-		limiter:    newIPRateLimiter(20, 5*time.Minute),
-		subs:       make(map[string]subscription),
+		apnsClient:       apnsClient,
+		httpClient:       fetchClient,
+		interval:         interval,
+		maxResponseBytes: maxResponseBytes,
+		limiter:          newIPRateLimiter(20, 5*time.Minute),
+		subs:             make(map[string]subscription),
 	}
 	r.runner.Init()
 	return r
@@ -332,13 +342,13 @@ func (r *Relay) fetchJSON(target string, out any) error {
 	// truncated/reset connection can be told apart from a response that's simply too big:
 	// hitting the cap ends the read cleanly with no error, while a mid-transfer EOF surfaces
 	// here as a read error with the partial byte count and elapsed time attached.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, r.maxResponseBytes+1))
 	elapsed := time.Since(start)
 	if err != nil {
 		return fmt.Errorf("read body (got %d bytes, content-length=%d, after %s): %w", len(body), resp.ContentLength, elapsed, err)
 	}
-	if len(body) > maxResponseBytes {
-		return fmt.Errorf("response exceeds %d byte cap (content-length=%d)", maxResponseBytes, resp.ContentLength)
+	if int64(len(body)) > r.maxResponseBytes {
+		return fmt.Errorf("response exceeds %d byte cap (content-length=%d)", r.maxResponseBytes, resp.ContentLength)
 	}
 	if err := json.Unmarshal(body, out); err != nil {
 		return fmt.Errorf("decode %d bytes (content-length=%d, after %s): %w", len(body), resp.ContentLength, elapsed, err)

--- a/apnsgateway/relay.go
+++ b/apnsgateway/relay.go
@@ -318,15 +318,32 @@ func (r *Relay) fetchJSON(target string, out any) error {
 	if err != nil {
 		return err
 	}
+	start := time.Now()
 	resp, err := r.httpClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("after %s: %w", time.Since(start), err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("status %d", resp.StatusCode)
 	}
-	return json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(out)
+
+	// Read fully (bounded by the cap) rather than decoding straight off the body, so a
+	// truncated/reset connection can be told apart from a response that's simply too big:
+	// hitting the cap ends the read cleanly with no error, while a mid-transfer EOF surfaces
+	// here as a read error with the partial byte count and elapsed time attached.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	elapsed := time.Since(start)
+	if err != nil {
+		return fmt.Errorf("read body (got %d bytes, content-length=%d, after %s): %w", len(body), resp.ContentLength, elapsed, err)
+	}
+	if len(body) > maxResponseBytes {
+		return fmt.Errorf("response exceeds %d byte cap (content-length=%d)", maxResponseBytes, resp.ContentLength)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode %d bytes (content-length=%d, after %s): %w", len(body), resp.ContentLength, elapsed, err)
+	}
+	return nil
 }
 
 func ifaceStat(all []remoteInterfaceStat, name string) *remoteInterfaceStat {

--- a/apnsgateway/relay_test.go
+++ b/apnsgateway/relay_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+// A registered serverURL must resolve only to public addresses — a bandwidth-monitor server can
+// never legitimately live at a private/loopback/link-local address anyway, since the relay reaches
+// it over the public internet. This is the relay's core SSRF defense: reject targets that could
+// only be internal-network or cloud-metadata probing, not a real user's router.
+func TestValidateServerURLRejectsNonPublicTargets(t *testing.T) {
+	reject := []string{
+		"http://127.0.0.1:8080",   // loopback
+		"http://localhost:8080",   // loopback
+		"http://192.168.1.1:8080", // RFC1918 private
+		"http://10.0.0.5:8080",    // RFC1918 private
+		"http://169.254.169.254/", // link-local / cloud metadata
+		"http://[::1]:8080",       // IPv6 loopback
+		"ftp://example.com",       // wrong scheme
+		"not a url at all",        // unparseable
+		"",                        // empty
+	}
+	for _, raw := range reject {
+		if _, err := validateServerURL(raw); err == nil {
+			t.Errorf("validateServerURL(%q) = nil error, want rejection", raw)
+		}
+	}
+}
+
+func TestValidateServerURLAcceptsPublicHTTPTarget(t *testing.T) {
+	// A well-known public DNS resolver's IP, reachable and unambiguously not a private/internal
+	// address — stands in for "someone's real, internet-exposed bandwidth-monitor server".
+	if _, err := validateServerURL("http://8.8.8.8:8080"); err != nil {
+		t.Errorf("validateServerURL(public IP) = %v, want accepted", err)
+	}
+}

--- a/apnsgateway/relay_test.go
+++ b/apnsgateway/relay_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"bandwidth-monitor/contentstate"
 )
 
 // A registered serverURL must resolve only to public addresses — a bandwidth-monitor server can
@@ -94,5 +98,107 @@ func TestRateLimiterSweepsStaleSources(t *testing.T) {
 	}
 	if _, ok := l.events["192.0.2.1"]; !ok {
 		t.Error("fresh source missing after sweep")
+	}
+}
+
+// testRelay returns a Relay whose dial-time IP check is disabled so it can talk to the
+// loopback-hosted httptest server. Everything else matches production wiring.
+func testRelay() *Relay {
+	r := NewRelay(nil, 10*time.Second, 0)
+	r.httpClient = newFetchClient(fetchTimeout, nil)
+	return r
+}
+
+// mockServer simulates a bandwidth-monitor instance. filtered controls whether it honours the
+// ?iface=&since= params (new server) or ignores them and returns everything (old server).
+func mockServer(t *testing.T, filtered bool, gotQueries *[]string) *httptest.Server {
+	t.Helper()
+	now := time.Now().UnixMilli()
+	history := map[string][]contentstate.Point{
+		"eth0": {{T: now - 30_000, Rx: 100, Tx: 200}, {T: now - 10_000, Rx: 300, Tx: 400}},
+		"ppp0": {{T: now - 20_000, Rx: 1, Tx: 2}},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/api/interfaces":
+			json.NewEncoder(w).Encode([]remoteInterfaceStat{
+				{Name: "eth0", WAN: true, RxRate: 500, TxRate: 600},
+				{Name: "ppp0", RxRate: 5, TxRate: 6},
+			})
+		case "/api/interfaces/history":
+			*gotQueries = append(*gotQueries, req.URL.RawQuery)
+			out := history
+			if filtered {
+				if iface := req.URL.Query().Get("iface"); iface != "" {
+					out = map[string][]contentstate.Point{iface: history[iface]}
+				}
+			}
+			json.NewEncoder(w).Encode(out)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+}
+
+// The relay must narrow the history fetch with ?iface=&since= so a new server can send just the
+// slice contentstate.Build uses, and the built state must reflect the requested interface.
+func TestFetchStateSendsFilterParams(t *testing.T) {
+	var queries []string
+	srv := mockServer(t, true, &queries)
+	defer srv.Close()
+
+	state, ok := testRelay().fetchState(subscription{serverURL: srv.URL, iface: "eth0"})
+	if !ok {
+		t.Fatal("fetchState failed")
+	}
+	if state.InterfaceName != "eth0" || state.RxRate != 500 {
+		t.Errorf("state = %+v, want eth0 with live rx=500", state)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("want 1 history fetch, got %d (%v)", len(queries), queries)
+	}
+	q, _ := url.ParseQuery(queries[0])
+	if q.Get("iface") != "eth0" || q.Get("since") == "" {
+		t.Errorf("history query = %q, want iface=eth0 and a since param", queries[0])
+	}
+}
+
+// Against an old server that ignores the params and returns every interface's history (the
+// pre-params superset), the relay must still build a correct single-interface state — this is
+// the no-version-negotiation fallback.
+func TestFetchStateToleratesOldServerSuperset(t *testing.T) {
+	var queries []string
+	srv := mockServer(t, false, &queries)
+	defer srv.Close()
+
+	state, ok := testRelay().fetchState(subscription{serverURL: srv.URL, iface: "ppp0"})
+	if !ok {
+		t.Fatal("fetchState failed")
+	}
+	if state.InterfaceName != "ppp0" || state.RxRate != 5 {
+		t.Errorf("state = %+v, want ppp0 with live rx=5", state)
+	}
+	// Points: 1 windowed history point + the synthetic now point; eth0's points must not leak in.
+	if len(state.Points) != 2 {
+		t.Errorf("want 2 points (ppp0 history + now), got %d: %+v", len(state.Points), state.Points)
+	}
+}
+
+// A subscription naming an interface the server doesn't have must fall back to the server's WAN
+// interface (refetching the filtered history for it) rather than pushing an empty state.
+func TestFetchStateFallsBackForUnknownInterface(t *testing.T) {
+	var queries []string
+	srv := mockServer(t, true, &queries)
+	defer srv.Close()
+
+	state, ok := testRelay().fetchState(subscription{serverURL: srv.URL, iface: "wg9"})
+	if !ok {
+		t.Fatal("fetchState failed")
+	}
+	if state.InterfaceName != "eth0" {
+		t.Errorf("state interface = %q, want fallback to WAN eth0", state.InterfaceName)
+	}
+	if len(queries) != 2 {
+		t.Errorf("want 2 history fetches (wg9 miss, then eth0), got %d (%v)", len(queries), queries)
 	}
 }

--- a/apnsgateway/relay_test.go
+++ b/apnsgateway/relay_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
 
 // A registered serverURL must resolve only to public addresses — a bandwidth-monitor server can
 // never legitimately live at a private/loopback/link-local address anyway, since the relay reaches
@@ -30,5 +37,62 @@ func TestValidateServerURLAcceptsPublicHTTPTarget(t *testing.T) {
 	// address — stands in for "someone's real, internet-exposed bandwidth-monitor server".
 	if _, err := validateServerURL("http://8.8.8.8:8080"); err != nil {
 		t.Errorf("validateServerURL(public IP) = %v, want accepted", err)
+	}
+}
+
+// The SSRF check must hold at dial time, on the concrete IP the connection actually uses — a
+// registration-time (or pre-fetch) LookupIP check alone can be split from the dial by DNS
+// rebinding. A fetch against a loopback server with the production client must fail in the
+// dialer even though no hostname pre-check ever ran on it.
+func TestFetchBlocksNonPublicDialTarget(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("request reached the server: dial-time IP check did not block loopback")
+	}))
+	defer srv.Close()
+
+	r := NewRelay(nil, 10*time.Second, 0)
+	var out any
+	err := r.fetchJSON(srv.URL, &out)
+	if err == nil || !strings.Contains(err.Error(), "non-public address") {
+		t.Errorf("fetchJSON(loopback) error = %v, want dial-time non-public rejection", err)
+	}
+}
+
+// With the IP check disabled (the test seam), the same client must work — this is what lets
+// other tests exercise real fetches against httptest servers.
+func TestFetchClientNilCheckAllowsLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	r := NewRelay(nil, 10*time.Second, 0)
+	r.httpClient = newFetchClient(fetchTimeout, nil)
+	var out map[string]bool
+	if err := r.fetchJSON(srv.URL, &out); err != nil || !out["ok"] {
+		t.Errorf("fetchJSON with nil ipCheck = (%v, %v), want ok", out, err)
+	}
+}
+
+// Sources whose events have all aged out of the window must be swept from the map — otherwise a
+// long-lived public relay leaks an entry per client IP ever seen.
+func TestRateLimiterSweepsStaleSources(t *testing.T) {
+	l := newIPRateLimiter(5, 50*time.Millisecond)
+	for i := 0; i < 100; i++ {
+		l.allow("10.0.0." + strconv.Itoa(i))
+	}
+	if got := len(l.events); got != 100 {
+		t.Fatalf("expected 100 tracked sources, got %d", got)
+	}
+
+	time.Sleep(60 * time.Millisecond) // let every event age out of the window
+	l.lastSweep = time.Time{}         // force the next allow() to sweep
+	l.allow("192.0.2.1")
+
+	if got := len(l.events); got != 1 {
+		t.Errorf("after sweep: %d sources tracked, want only the fresh one", got)
+	}
+	if _, ok := l.events["192.0.2.1"]; !ok {
+		t.Error("fresh source missing after sweep")
 	}
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -87,6 +88,15 @@ type rawStat struct {
 	ts        time.Time
 }
 
+// NewForTest returns a Collector pre-seeded with history and no netlink handle. Only for use
+// in tests of packages that consume the collector (e.g. handler); never poll it.
+func NewForTest(history map[string][]HistoryPoint) *Collector {
+	if history == nil {
+		history = make(map[string][]HistoryPoint)
+	}
+	return &Collector{history: history}
+}
+
 func New(vpnStatusFiles map[string]string, allowedIfaces []string, wanIfaces []string) *Collector {
 	if vpnStatusFiles == nil {
 		vpnStatusFiles = make(map[string]string)
@@ -164,12 +174,26 @@ func (c *Collector) GetAll() []InterfaceStat {
 }
 
 func (c *Collector) GetHistory() map[string][]HistoryPoint {
+	return c.GetHistoryFiltered("", 0)
+}
+
+// GetHistoryFiltered returns per-interface history, optionally narrowed to a single interface
+// (iface != "") and/or to points at or after sinceMillis (Unix milliseconds, > 0). Zero values
+// mean no filtering, so GetHistoryFiltered("", 0) is equivalent to GetHistory.
+func (c *Collector) GetHistoryFiltered(iface string, sinceMillis int64) map[string][]HistoryPoint {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	result := make(map[string][]HistoryPoint, len(c.history))
 	for k, v := range c.history {
+		if iface != "" && k != iface {
+			continue
+		}
 		if c.allowedIfaces != nil && !c.allowedIfaces[k] {
 			continue
+		}
+		if sinceMillis > 0 {
+			// Timestamps are append-only ascending, so binary-search the first point in range.
+			v = v[sort.Search(len(v), func(i int) bool { return v[i].Timestamp >= sinceMillis }):]
 		}
 		cp := make([]HistoryPoint, len(v))
 		copy(cp, v)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,0 +1,81 @@
+package collector
+
+import (
+	"testing"
+)
+
+func testCollector() *Collector {
+	return &Collector{
+		history: map[string][]HistoryPoint{
+			"eth0": {
+				{Timestamp: 1000, RxRate: 1, TxRate: 2},
+				{Timestamp: 2000, RxRate: 3, TxRate: 4},
+				{Timestamp: 3000, RxRate: 5, TxRate: 6},
+			},
+			"ppp0": {
+				{Timestamp: 1500, RxRate: 7, TxRate: 8},
+				{Timestamp: 2500, RxRate: 9, TxRate: 10},
+			},
+		},
+	}
+}
+
+// Zero values mean no filtering: GetHistoryFiltered("", 0) must match GetHistory exactly.
+func TestGetHistoryFilteredNoFilters(t *testing.T) {
+	c := testCollector()
+	got := c.GetHistoryFiltered("", 0)
+	if len(got) != 2 || len(got["eth0"]) != 3 || len(got["ppp0"]) != 2 {
+		t.Fatalf("unfiltered result wrong shape: %+v", got)
+	}
+	// Must be a deep copy, not a view of the live slice.
+	got["eth0"][0].RxRate = 999
+	if c.history["eth0"][0].RxRate == 999 {
+		t.Error("filtered result aliases the collector's internal history")
+	}
+}
+
+func TestGetHistoryFilteredByIface(t *testing.T) {
+	got := testCollector().GetHistoryFiltered("eth0", 0)
+	if len(got) != 1 || len(got["eth0"]) != 3 {
+		t.Fatalf("iface filter: want only eth0 with 3 points, got %+v", got)
+	}
+}
+
+// A point whose timestamp equals since must be included (>= boundary).
+func TestGetHistoryFilteredSince(t *testing.T) {
+	got := testCollector().GetHistoryFiltered("", 2000)
+	if len(got["eth0"]) != 2 || got["eth0"][0].Timestamp != 2000 {
+		t.Errorf("since=2000 eth0: want points [2000 3000], got %+v", got["eth0"])
+	}
+	if len(got["ppp0"]) != 1 || got["ppp0"][0].Timestamp != 2500 {
+		t.Errorf("since=2000 ppp0: want point [2500], got %+v", got["ppp0"])
+	}
+}
+
+func TestGetHistoryFilteredIfaceAndSince(t *testing.T) {
+	got := testCollector().GetHistoryFiltered("ppp0", 2000)
+	if len(got) != 1 || len(got["ppp0"]) != 1 || got["ppp0"][0].Timestamp != 2500 {
+		t.Errorf("combined filter: want only ppp0 [2500], got %+v", got)
+	}
+}
+
+// A since past the newest point yields empty (but present) slices, not missing keys.
+func TestGetHistoryFilteredSincePastEnd(t *testing.T) {
+	got := testCollector().GetHistoryFiltered("eth0", 9999)
+	if pts, ok := got["eth0"]; !ok || len(pts) != 0 {
+		t.Errorf("since past end: want empty eth0 slice, got %+v", got)
+	}
+}
+
+// The allowedIfaces whitelist must still be honoured under filtering.
+func TestGetHistoryFilteredRespectsAllowedIfaces(t *testing.T) {
+	c := testCollector()
+	c.allowedIfaces = map[string]bool{"ppp0": true}
+	got := c.GetHistoryFiltered("", 0)
+	if _, ok := got["eth0"]; ok {
+		t.Errorf("whitelist ignored: eth0 present in %+v", got)
+	}
+	if got := c.GetHistoryFiltered("eth0", 0); len(got) != 0 {
+		t.Errorf("explicit iface must not bypass whitelist, got %+v", got)
+	}
+}

--- a/contentstate/contentstate.go
+++ b/contentstate/contentstate.go
@@ -1,0 +1,90 @@
+// Package contentstate builds the Live Activity content-state payload pushed to the iOS app.
+// Pure and dependency-free (no collector coupling) so both the local per-instance push path and
+// the standalone relay gateway — which get their raw history from different sources (the in-process
+// collector vs. an HTTP fetch of another server's /api/interfaces/history) — share one
+// implementation, keeping the JSON shape guaranteed identical everywhere it's produced.
+package contentstate
+
+import (
+	"math"
+	"time"
+)
+
+// Point mirrors one collector.HistoryPoint. JSON tags MUST match the iOS HistoryPoint exactly.
+type Point struct {
+	T  int64   `json:"t"`
+	Rx float64 `json:"rx"`
+	Tx float64 `json:"tx"`
+}
+
+// State is the Live Activity content-state. JSON tags MUST match the iOS
+// BandwidthActivityAttributes.ContentState exactly, or ActivityKit silently drops the push.
+type State struct {
+	InterfaceName string  `json:"interfaceName"`
+	RxRate        float64 `json:"rxRate"`
+	TxRate        float64 `json:"txRate"`
+	Points        []Point `json:"points"`
+	UpdatedAt     float64 `json:"updatedAt"`
+}
+
+const (
+	// Window is how far back into history to look for the sparkline.
+	Window = time.Hour
+	// MaxPoints caps how many points are sent, downsampled keeping peaks.
+	MaxPoints = 38
+)
+
+// Build mirrors the iOS liveState(): windows history to the last hour, downsamples keeping peaks,
+// and appends a synthetic "now" sample carrying the live rate so the marked latest point reflects
+// the current rate rather than the (possibly several-seconds-old) tail of history.
+func Build(iface string, rx, tx float64, history []Point) State {
+	cutoff := time.Now().Add(-Window).UnixMilli()
+	var windowed []Point
+	for _, p := range history {
+		if p.T >= cutoff {
+			windowed = append(windowed, p)
+		}
+	}
+	windowed = DownsamplePeaks(windowed, MaxPoints)
+
+	pts := make([]Point, 0, len(windowed)+1)
+	pts = append(pts, windowed...)
+	pts = append(pts, Point{T: time.Now().UnixMilli(), Rx: rx, Tx: tx})
+
+	return State{
+		InterfaceName: iface,
+		RxRate:        rx,
+		TxRate:        tx,
+		Points:        pts,
+		UpdatedAt:     float64(time.Now().UnixMilli()) / 1000,
+	}
+}
+
+// DownsamplePeaks reduces pts to ~maxPoints, keeping the highest-rate sample in each bucket so brief
+// spikes survive (matches the iOS downsampledPreservingPeaks).
+func DownsamplePeaks(pts []Point, maxPoints int) []Point {
+	if maxPoints <= 0 || len(pts) <= maxPoints {
+		return pts
+	}
+	bucket := float64(len(pts)) / float64(maxPoints)
+	out := make([]Point, 0, maxPoints)
+	start := 0
+	for i := 0; i < maxPoints; i++ {
+		end := len(pts)
+		if i < maxPoints-1 {
+			end = int(math.Round(float64(i+1) * bucket))
+		}
+		if start >= end {
+			continue
+		}
+		peak := pts[start]
+		for _, p := range pts[start:end] {
+			if math.Max(p.Rx, p.Tx) > math.Max(peak.Rx, peak.Tx) {
+				peak = p
+			}
+		}
+		out = append(out, peak)
+		start = end
+	}
+	return out
+}

--- a/contentstate/contentstate_test.go
+++ b/contentstate/contentstate_test.go
@@ -1,0 +1,67 @@
+package contentstate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The content-state JSON keys must match the iOS BandwidthActivityAttributes.ContentState exactly,
+// or ActivityKit will reject the push.
+func TestContentStateJSONKeys(t *testing.T) {
+	s := State{
+		InterfaceName: "eth0",
+		RxRate:        1,
+		TxRate:        2,
+		Points:        []Point{{T: 123, Rx: 4, Tx: 5}},
+		UpdatedAt:     6.5,
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, key := range []string{
+		`"interfaceName"`, `"rxRate"`, `"txRate"`, `"points"`, `"updatedAt"`, `"t"`, `"rx"`, `"tx"`,
+	} {
+		if !strings.Contains(got, key) {
+			t.Errorf("content-state JSON missing key %s: %s", key, got)
+		}
+	}
+}
+
+// Build should append a synthetic "now" point carrying the live rate, so the marked latest point on
+// the sparkline reflects the current rate rather than a possibly-stale history tail.
+func TestBuildAppendsNowPoint(t *testing.T) {
+	history := []Point{{T: time.Now().Add(-5 * time.Minute).UnixMilli(), Rx: 10, Tx: 20}}
+	s := Build("eth0", 99, 88, history)
+	if len(s.Points) != 2 {
+		t.Fatalf("want 2 points (history + synthetic now), got %d", len(s.Points))
+	}
+	last := s.Points[len(s.Points)-1]
+	if last.Rx != 99 || last.Tx != 88 {
+		t.Errorf("synthetic now point = %+v, want Rx=99 Tx=88", last)
+	}
+}
+
+// DownsamplePeaks must keep the highest-rate sample in each bucket, not silently drop a spike
+// between sampled indices.
+func TestDownsamplePeaksKeepsSpikes(t *testing.T) {
+	pts := make([]Point, 20)
+	for i := range pts {
+		pts[i] = Point{T: int64(i), Rx: 1, Tx: 1}
+	}
+	pts[7] = Point{T: 7, Rx: 500, Tx: 0} // a spike buried in the middle of a bucket
+
+	out := DownsamplePeaks(pts, 5)
+	found := false
+	for _, p := range out {
+		if p.Rx == 500 {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("downsampled output dropped the spike: %+v", out)
+	}
+}

--- a/docs/apns-gateway.md
+++ b/docs/apns-gateway.md
@@ -1,0 +1,117 @@
+# APNS Gateway
+
+`apnsgateway` is a standalone relay binary that keeps the iOS app's Live Activity (Lock Screen widget + Dynamic Island) updating while the app is suspended, without requiring any APNs configuration on individual bandwidth-monitor instances.
+
+## Why a separate binary?
+
+Only the Apple Developer team that owns the app's bundle ID can push to it via APNs — which means the key must live somewhere. Rather than requiring every self-hoster to obtain their own paid developer account and APNs auth key, `apnsgateway` is the single place that holds the key:
+
+- The iOS app registers its push token directly with the gateway, naming its own server's URL.
+- The gateway polls that server's **existing, unmodified** `/api/interfaces` and `/api/interfaces/history` endpoints, builds the content-state, and pushes to APNs.
+- **Individual bandwidth-monitor instances need zero APNs configuration or new code.**
+
+`apnsgateway` is deliberately a separate binary (`make build-gateway`), not a mode flag on the main server — the main server assumes router-level access (raw sockets, netlink, often root) that a relay meant to run on any ordinary host has no use for.
+
+## Building
+
+```bash
+make build-gateway
+# produces: ./apns-gateway
+```
+
+Cross-compile for Linux (common deployment target):
+
+```bash
+GOOS=linux GOARCH=amd64 go build -o apns-gateway ./apnsgateway
+```
+
+## Configuration
+
+All configuration is via environment variables. Every variable except the TLS paths and APNs credentials has a sensible default.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LISTEN` | `:8443` | Listen address. The gateway always serves HTTPS (iOS App Transport Security rejects plain HTTP). |
+| `TLS_CERT_FILE` | *(required)* | Path to the TLS certificate (PEM). |
+| `TLS_KEY_FILE` | *(required)* | Path to the TLS private key (PEM). |
+| `APNS_KEY_FILE` | *(required)* | Path to the APNs auth key (`.p8`) from [developer.apple.com](https://developer.apple.com) (Keys → Apple Push Notification service). Keep it `chmod 0600`. |
+| `APNS_KEY_ID` | *(required)* | 10-character key ID from the Apple Developer portal. |
+| `APNS_TEAM_ID` | *(required)* | Apple Developer team ID. |
+| `APNS_BUNDLE_ID` | *(required)* | App bundle ID (e.g. `com.example.BandwidthMonitor`). |
+| `APNS_PUSH_INTERVAL` | `10s` | How often to push an update to each registered device. |
+| `APNS_MAX_RESPONSE_BYTES` | `16777216` (16 MiB) | Maximum response size accepted from a polled server. The `/api/interfaces/history` endpoint can return several MB per interface at the default 24h/1Hz retention, so this must be large enough to cover a full history response. |
+
+## Running
+
+```bash
+export TLS_CERT_FILE=/etc/apns-gateway/server.crt
+export TLS_KEY_FILE=/etc/apns-gateway/server.key
+export APNS_KEY_FILE=/etc/apns-gateway/AuthKey_XXXXXXXXXX.p8
+export APNS_KEY_ID=XXXXXXXXXX
+export APNS_TEAM_ID=YOURTEAMID
+export APNS_BUNDLE_ID=com.example.BandwidthMonitor
+./apns-gateway
+```
+
+The gateway logs a startup line confirming all settings and then starts accepting registrations.
+
+Graceful shutdown is handled automatically on `SIGINT`/`SIGTERM` (drains active connections, up to 5 seconds).
+
+## API
+
+### `POST /api/liveactivity/register`
+
+Registers (or refreshes) a device's Live Activity push token. The iOS app calls this every time its Live Activity token changes and periodically to keep the subscription alive.
+
+**Request body (JSON):**
+
+```json
+{
+  "token": "<hex push token>",
+  "environment": "sandbox|production",
+  "serverURL": "https://your-bandwidth-monitor.example.com:8080",
+  "interface": "eth0"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `token` | The device's APNs push token for this Live Activity, as a hex string. |
+| `environment` | `sandbox` for Xcode dev builds, `production` for App Store / TestFlight builds. |
+| `serverURL` | The public HTTPS (or HTTP) URL of the bandwidth-monitor instance this device is monitoring. Must resolve to a public IP address — private/loopback/link-local addresses are rejected (SSRF mitigation). |
+| `interface` | The interface name to monitor (e.g. `eth0`). If empty or not found, the gateway picks the first WAN interface. |
+
+**Response:** `{"status":"ok"}` on success, or an HTTP error with a plain-text message.
+
+### `GET /healthz`
+
+Returns `200 ok`. Use this for load balancer health checks or uptime monitoring.
+
+## Security
+
+### SSRF mitigation
+
+Accepting an operator-supplied `serverURL` is inherently an SSRF shape (the gateway makes outbound requests to the supplied target). The gateway defends against this without requiring authentication — no secret is needed from iPhone users or self-hosting operators:
+
+- `validateServerURL` rejects any URL whose host resolves to a private, loopback, link-local (including the `169.254.169.254` cloud-metadata pattern), multicast, or unspecified address.
+- `checkPublicHost` is called again **immediately before every fetch**, not just at registration, to narrow the DNS-rebinding window where a hostname resolves to a public IP at registration time but to a private one later.
+- Redirects are not followed.
+
+This costs the real use case nothing: a bandwidth-monitor server can never legitimately live at a private address, since the gateway reaches it over the public internet.
+
+### Other hygiene
+
+- Per-source IP rate limiting on registration (20 registrations per 5-minute window).
+- Global subscription cap (5 000 active subscriptions).
+- Response size cap (`APNS_MAX_RESPONSE_BYTES`) on fetched server responses.
+- Per-fetch timeout (8 seconds).
+- Subscriptions that the app stops refreshing expire after 1 hour (TTL).
+- Dead tokens (APNs 410 / `BadDeviceToken` / `Unregistered`) are dropped immediately.
+
+### Registration is unauthenticated by design
+
+No secret is required to register. The threat model is that registering a `serverURL` is a potential SSRF vector, handled above, not that registrations need to be gated — the app never surfaces any setup step to the end user, and requiring a shared secret would make self-hosting needlessly complicated.
+
+## Notes
+
+- **TODO (api-versioning):** The gateway currently fetches full history from `/api/interfaces/history` and discards all but the last hour for a single interface. Adding optional `?iface=&since=` query parameters to that endpoint would let the gateway request only the slice it needs, avoiding unnecessarily large responses. This is additive and backward-compatible on its own. See the `fetchHistory` TODO comment in `apnsgateway/relay.go` for details.

--- a/docs/apns-gateway.md
+++ b/docs/apns-gateway.md
@@ -114,4 +114,4 @@ No secret is required to register. The threat model is that registering a `serve
 
 ## Notes
 
-- **TODO (api-versioning):** The gateway currently fetches full history from `/api/interfaces/history` and discards all but the last hour for a single interface. Adding optional `?iface=&since=` query parameters to that endpoint would let the gateway request only the slice it needs, avoiding unnecessarily large responses. This is additive and backward-compatible on its own. See the `fetchHistory` TODO comment in `apnsgateway/relay.go` for details.
+- **Filtered history fetches:** The gateway narrows its `/api/interfaces/history` requests with `?iface=<name>&since=<Unix ms>` so a current server sends only the last hour of one interface's history (a few KB) instead of every interface's full 24h retention (multiple MB). The parameters are additive, so no version negotiation is needed: servers that predate them ignore them and return the full map, which the gateway's own content-state windowing (and `APNS_MAX_RESPONSE_BYTES`) absorbs transparently.

--- a/env.example
+++ b/env.example
@@ -94,18 +94,20 @@ LISTEN_PROTOCOL=http
 # Defaults to anycast01.ffmuc.net, anycast02.ffmuc.net, dns.quad9.net, dns3.digitalcourage.de if not set.
 # LATENCY_TARGETS=anycast01.ffmuc.net,anycast02.ffmuc.net,dns.quad9.net,dns3.digitalcourage.de
 
-## iOS Live Activity push (optional)
+## iOS Live Activity push (optional, advanced — most people don't need this)
 
-# Enables server-driven ActivityKit/APNs updates so the iOS app's Lock Screen / Dynamic Island
-# Live Activity keeps updating while the app is closed. Enabled only when APNS_KEY_FILE is set.
+# By default, the iOS app's Lock Screen / Dynamic Island Live Activity is kept updating while the
+# app is closed via a shared relay gateway (see apnsgateway/), not by this server — nothing here
+# needs to be configured for that. This section is only for operators who'd rather hold their own
+# APNs key and push directly, independent of any relay. Enabled only when APNS_KEY_FILE is set.
 # The server needs outbound HTTPS to Apple's APNs (api.push.apple.com:443).
 #
 # APNS_KEY_FILE: path to the APNs auth key (.p8) created at developer.apple.com (Keys → enable
 # Apple Push Notification service). Keep it chmod 0600.
 # APNS_KEY_FILE=/etc/bandwidth-monitor/AuthKey_XXXXXXXXXX.p8
 # APNS_KEY_ID=XXXXXXXXXX
-# APNS_TEAM_ID=SA2SS4242K
-# APNS_BUNDLE_ID=com.evilforbeginners.BandwidthMonitor
+# APNS_TEAM_ID=<your Apple Developer team ID>
+# APNS_BUNDLE_ID=<your app's bundle ID>
 # APNS_ENV: production (TestFlight/App Store builds, default) or sandbox (builds run from Xcode).
 # APNS_ENV=production
 # APNS_PUSH_INTERVAL=10s

--- a/env.example
+++ b/env.example
@@ -93,3 +93,19 @@ LISTEN_PROTOCOL=http
 # Latency monitoring: comma-separated hostnames/IPs to probe via ICMP + HTTPS.
 # Defaults to anycast01.ffmuc.net, anycast02.ffmuc.net, dns.quad9.net, dns3.digitalcourage.de if not set.
 # LATENCY_TARGETS=anycast01.ffmuc.net,anycast02.ffmuc.net,dns.quad9.net,dns3.digitalcourage.de
+
+## iOS Live Activity push (optional)
+
+# Enables server-driven ActivityKit/APNs updates so the iOS app's Lock Screen / Dynamic Island
+# Live Activity keeps updating while the app is closed. Enabled only when APNS_KEY_FILE is set.
+# The server needs outbound HTTPS to Apple's APNs (api.push.apple.com:443).
+#
+# APNS_KEY_FILE: path to the APNs auth key (.p8) created at developer.apple.com (Keys → enable
+# Apple Push Notification service). Keep it chmod 0600.
+# APNS_KEY_FILE=/etc/bandwidth-monitor/AuthKey_XXXXXXXXXX.p8
+# APNS_KEY_ID=XXXXXXXXXX
+# APNS_TEAM_ID=SA2SS4242K
+# APNS_BUNDLE_ID=com.evilforbeginners.BandwidthMonitor
+# APNS_ENV: production (TestFlight/App Store builds, default) or sandbox (builds run from Xcode).
+# APNS_ENV=production
+# APNS_PUSH_INTERVAL=10s

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -785,16 +785,20 @@ func LiveActivityRegister(m *liveactivity.Manager) http.HandlerFunc {
 			http.Error(w, "POST required", http.StatusMethodNotAllowed)
 			return
 		}
+		r.Body = http.MaxBytesReader(w, r.Body, 4<<10)
 		var body struct {
 			Token       string `json:"token"`
 			Interface   string `json:"interface"`
 			Environment string `json:"environment"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" || len(body.Token) > 200 {
 			http.Error(w, "invalid body: expected {token, interface, environment}", http.StatusBadRequest)
 			return
 		}
-		m.Register(body.Token, body.Interface, body.Environment)
+		if !m.Register(body.Token, body.Interface, body.Environment) {
+			http.Error(w, "registry at capacity", http.StatusServiceUnavailable)
+			return
+		}
 		httputil.WriteJSON(w, map[string]string{"status": "ok"})
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -35,9 +35,27 @@ func InterfaceStats(c *collector.Collector) http.HandlerFunc {
 	}
 }
 
+// InterfaceHistory serves per-interface rate history. Optional query params narrow the response
+// (both are additive — old clients that send neither get the full map exactly as before):
+//   - iface: return only this interface's history
+//   - since: return only points at or after this Unix-milliseconds timestamp
 func InterfaceHistory(c *collector.Collector) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		httputil.WriteJSON(w, c.GetHistory())
+		iface := r.URL.Query().Get("iface")
+		if len(iface) > 64 {
+			http.Error(w, "iface too long", http.StatusBadRequest)
+			return
+		}
+		var since int64
+		if s := r.URL.Query().Get("since"); s != "" {
+			var err error
+			since, err = strconv.ParseInt(s, 10, 64)
+			if err != nil || since < 0 {
+				http.Error(w, "since must be a Unix-milliseconds timestamp", http.StatusBadRequest)
+				return
+			}
+		}
+		httputil.WriteJSON(w, c.GetHistoryFiltered(iface, since))
 	}
 }
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -20,6 +20,7 @@ import (
 	"bandwidth-monitor/geoip"
 	"bandwidth-monitor/httputil"
 	"bandwidth-monitor/latency"
+	"bandwidth-monitor/liveactivity"
 	"bandwidth-monitor/netutil"
 	"bandwidth-monitor/resolver"
 	"bandwidth-monitor/speedtest"
@@ -774,4 +775,26 @@ func readProcessCount() (running, total int) {
 		total, _ = strconv.Atoi(rt[1])
 	}
 	return
+}
+
+// LiveActivityRegister records an iOS Live Activity push token so the server can drive updates via
+// APNs. Body: {"token":"<hex>","interface":"eth0","environment":"production|sandbox"}.
+func LiveActivityRegister(m *liveactivity.Manager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST required", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			Token       string `json:"token"`
+			Interface   string `json:"interface"`
+			Environment string `json:"environment"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" {
+			http.Error(w, "invalid body: expected {token, interface, environment}", http.StatusBadRequest)
+			return
+		}
+		m.Register(body.Token, body.Interface, body.Environment)
+		httputil.WriteJSON(w, map[string]string{"status": "ok"})
+	}
 }

--- a/handler/handler_history_test.go
+++ b/handler/handler_history_test.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"bandwidth-monitor/collector"
+)
+
+func historyRequest(t *testing.T, c *collector.Collector, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/interfaces/history"+query, nil)
+	w := httptest.NewRecorder()
+	InterfaceHistory(c)(w, req)
+	return w
+}
+
+func decodeHistory(t *testing.T, w *httptest.ResponseRecorder) map[string][]collector.HistoryPoint {
+	t.Helper()
+	var out map[string][]collector.HistoryPoint
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+// No params must return every interface's full history — the pre-params contract old
+// clients (web UI, older apps) rely on.
+func TestInterfaceHistoryNoParams(t *testing.T) {
+	c := collector.NewForTest(map[string][]collector.HistoryPoint{
+		"eth0": {{Timestamp: 1000}, {Timestamp: 2000}},
+		"ppp0": {{Timestamp: 1500}},
+	})
+	w := historyRequest(t, c, "")
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decodeHistory(t, w)
+	if len(got) != 2 || len(got["eth0"]) != 2 || len(got["ppp0"]) != 1 {
+		t.Errorf("full response wrong shape: %+v", got)
+	}
+}
+
+func TestInterfaceHistoryIfaceAndSince(t *testing.T) {
+	c := collector.NewForTest(map[string][]collector.HistoryPoint{
+		"eth0": {{Timestamp: 1000}, {Timestamp: 2000}, {Timestamp: 3000}},
+		"ppp0": {{Timestamp: 1500}},
+	})
+	w := historyRequest(t, c, "?iface=eth0&since=2000")
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	got := decodeHistory(t, w)
+	if len(got) != 1 || len(got["eth0"]) != 2 || got["eth0"][0].Timestamp != 2000 {
+		t.Errorf("filtered response: want only eth0 [2000 3000], got %+v", got)
+	}
+}
+
+func TestInterfaceHistoryBadSince(t *testing.T) {
+	c := collector.NewForTest(nil)
+	for _, q := range []string{"?since=notanumber", "?since=-5", "?since=1.5"} {
+		if w := historyRequest(t, c, q); w.Code != 400 {
+			t.Errorf("%s: status = %d, want 400", q, w.Code)
+		}
+	}
+}
+
+func TestInterfaceHistoryIfaceTooLong(t *testing.T) {
+	c := collector.NewForTest(nil)
+	if w := historyRequest(t, c, "?iface="+strings.Repeat("x", 65)); w.Code != 400 {
+		t.Errorf("oversized iface: status = %d, want 400", w.Code)
+	}
+}

--- a/liveactivity/liveactivity.go
+++ b/liveactivity/liveactivity.go
@@ -3,8 +3,8 @@
 //
 // The iOS app registers a per-activity push token via POST /api/liveactivity/register; a background
 // loop then builds the Live Activity content-state from the collector and pushes it to APNs for each
-// registered token. Dependency-free beyond the stdlib and golang.org/x/net/http2 (already required):
-// crypto/ecdsa + crypto/x509 sign the ES256 provider JWT and parse the .p8 key.
+// registered token. Dependency-free: crypto/ecdsa + crypto/x509 (stdlib) sign the ES256 provider JWT
+// and parse the .p8 key; the stdlib http.Client auto-negotiates HTTP/2 over TLS, which APNs requires.
 package liveactivity
 
 import (
@@ -31,7 +31,14 @@ import (
 const (
 	historyWindow = time.Hour
 	maxPoints     = 38
-	staleAfter    = 120 * time.Second
+	// minStaleAfter is a floor on the stale-date cushion regardless of push interval, so a
+	// fast-configured cadence doesn't leave an unreasonably short window either.
+	minStaleAfter = 60 * time.Second
+	// staleAfterMultiple sizes the cushion relative to the configured push interval, so a few
+	// dropped pushes in a row (transient network blip, brief APNs error) don't prematurely mark the
+	// activity stale ahead of the next successful push. At the default 10s interval this gives 150s,
+	// more forgiving than the old fixed 120s.
+	staleAfterMultiple = 15
 )
 
 // Config holds APNs settings. The feature is enabled only when KeyFile, KeyID, TeamID, and BundleID
@@ -113,6 +120,15 @@ func (m *Manager) Run() { m.runner.Run(m.cfg.Interval, m.tick) }
 
 // Stop halts the push loop.
 func (m *Manager) Stop() { m.runner.Stop() }
+
+// staleAfter is the stale-date cushion: a multiple of the configured push interval (with a floor),
+// so one or two dropped pushes don't prematurely mark the activity stale.
+func (m *Manager) staleAfter() time.Duration {
+	if d := m.cfg.Interval * staleAfterMultiple; d > minStaleAfter {
+		return d
+	}
+	return minStaleAfter
+}
 
 func (m *Manager) tick() {
 	m.mu.Lock()
@@ -256,7 +272,7 @@ func (m *Manager) send(token, environment string, state *contentState) {
 		"timestamp":     now,
 		"event":         "update",
 		"content-state": state,
-		"stale-date":    now + int64(staleAfter.Seconds()),
+		"stale-date":    now + int64(m.staleAfter().Seconds()),
 	}}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/liveactivity/liveactivity.go
+++ b/liveactivity/liveactivity.go
@@ -1,43 +1,37 @@
-// Package liveactivity pushes iOS Live Activity updates to Apple's APNs so the Bandwidth Monitor
-// Lock Screen / Dynamic Island view keeps updating while the app is suspended.
+// Package liveactivity pushes iOS Live Activity updates directly to Apple's APNs using an
+// operator-held key, so the Bandwidth Monitor Lock Screen / Dynamic Island view keeps updating
+// while the app is suspended.
+//
+// This is the "hold your own key" path: fully independent, no dependency on anyone else's
+// infrastructure. It's off by default (nil unless APNS_KEY_FILE is configured) — most users don't
+// need this because the app defaults to registering with a shared relay gateway instead (see the
+// apnsgateway package), which needs no APNs key on this server at all. Keep this path for operators
+// who'd rather not depend on a third party.
 //
 // The iOS app registers a per-activity push token via POST /api/liveactivity/register; a background
 // loop then builds the Live Activity content-state from the collector and pushes it to APNs for each
-// registered token. Dependency-free: crypto/ecdsa + crypto/x509 (stdlib) sign the ES256 provider JWT
-// and parse the .p8 key; the stdlib http.Client auto-negotiates HTTP/2 over TLS, which APNs requires.
+// registered token.
 package liveactivity
 
 import (
-	"bytes"
-	"crypto/ecdsa"
-	"crypto/rand"
-	"crypto/sha256"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
-	"fmt"
 	"log"
-	"math"
-	"net/http"
-	"os"
 	"sync"
 	"time"
 
+	"bandwidth-monitor/apns"
 	"bandwidth-monitor/collector"
+	"bandwidth-monitor/contentstate"
 	"bandwidth-monitor/poller"
 )
 
 const (
-	historyWindow = time.Hour
-	maxPoints     = 38
 	// minStaleAfter is a floor on the stale-date cushion regardless of push interval, so a
 	// fast-configured cadence doesn't leave an unreasonably short window either.
 	minStaleAfter = 60 * time.Second
 	// staleAfterMultiple sizes the cushion relative to the configured push interval, so a few
 	// dropped pushes in a row (transient network blip, brief APNs error) don't prematurely mark the
 	// activity stale ahead of the next successful push. At the default 10s interval this gives 150s,
-	// more forgiving than the old fixed 120s.
+	// more forgiving than a short fixed value.
 	staleAfterMultiple = 15
 )
 
@@ -58,26 +52,23 @@ type registration struct {
 	lastSeen    time.Time
 }
 
-// Manager owns the token registry, signing key, and push loop.
+// Manager owns the token registry and push loop.
 type Manager struct {
 	cfg    Config
 	col    *collector.Collector
-	key    *ecdsa.PrivateKey
-	client *http.Client
+	apns   *apns.Client
 	runner poller.Runner
 
 	mu     sync.Mutex
 	tokens map[string]registration
-
-	jwtMu     sync.Mutex
-	jwtCache  string
-	jwtIssued time.Time
 }
 
 // New parses the .p8 key and returns a configured Manager. Returns an error if the key is missing or
 // not a P-256 private key.
 func New(cfg Config, col *collector.Collector) (*Manager, error) {
-	key, err := loadKey(cfg.KeyFile)
+	client, err := apns.NewClient(apns.Config{
+		KeyFile: cfg.KeyFile, KeyID: cfg.KeyID, TeamID: cfg.TeamID, BundleID: cfg.BundleID,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -90,11 +81,8 @@ func New(cfg Config, col *collector.Collector) (*Manager, error) {
 	m := &Manager{
 		cfg:    cfg,
 		col:    col,
-		key:    key,
+		apns:   client,
 		tokens: make(map[string]registration),
-		// The stdlib client auto-negotiates HTTP/2 over TLS via ALPN (which APNs requires), so no
-		// golang.org/x/net/http2 dependency is needed.
-		client: &http.Client{Timeout: 10 * time.Second},
 	}
 	m.runner.Init()
 	return m, nil
@@ -139,32 +127,26 @@ func (m *Manager) tick() {
 	m.mu.Unlock()
 
 	for token, reg := range toks {
-		if state := m.buildState(reg.iface); state != nil {
-			m.send(token, reg.environment, state)
+		state, ok := m.buildState(reg.iface)
+		if !ok {
+			continue
+		}
+		result, err := m.apns.Send(token, reg.environment, m.staleAfter(), state)
+		if err != nil {
+			log.Printf("liveactivity: send: %v", err)
+			continue
+		}
+		if result.Dead() {
+			m.mu.Lock()
+			delete(m.tokens, token)
+			m.mu.Unlock()
 		}
 	}
 }
 
-// --- content-state (keys MUST match the iOS BandwidthActivityAttributes.ContentState) ------------
-
-type point struct {
-	T  int64   `json:"t"`
-	Rx float64 `json:"rx"`
-	Tx float64 `json:"tx"`
-}
-
-type contentState struct {
-	InterfaceName string  `json:"interfaceName"`
-	RxRate        float64 `json:"rxRate"`
-	TxRate        float64 `json:"txRate"`
-	Points        []point `json:"points"`
-	UpdatedAt     float64 `json:"updatedAt"`
-}
-
-// buildState mirrors the iOS liveState(): the selected interface's last hour, downsampled keeping
-// peaks, with a synthetic "now" sample carrying the live rate appended so the marked latest point
-// reflects the current rate.
-func (m *Manager) buildState(iface string) *contentState {
+// buildState gathers the selected interface's current rate and recent history from the local
+// collector and shapes it into a contentstate.State via the shared builder.
+func (m *Manager) buildState(iface string) (contentstate.State, bool) {
 	all := m.col.GetAll()
 	hist := m.col.GetHistory()
 
@@ -173,7 +155,7 @@ func (m *Manager) buildState(iface string) *contentState {
 		name = pickInterface(all, hist)
 	}
 	if name == "" {
-		return nil
+		return contentstate.State{}, false
 	}
 
 	var rx, tx float64
@@ -181,28 +163,12 @@ func (m *Manager) buildState(iface string) *contentState {
 		rx, tx = s.RxRate, s.TxRate
 	}
 
-	cutoff := time.Now().Add(-historyWindow).UnixMilli()
-	var windowed []collector.HistoryPoint
+	points := make([]contentstate.Point, 0, len(hist[name]))
 	for _, p := range hist[name] {
-		if p.Timestamp >= cutoff {
-			windowed = append(windowed, p)
-		}
+		points = append(points, contentstate.Point{T: p.Timestamp, Rx: p.RxRate, Tx: p.TxRate})
 	}
-	windowed = downsamplePeaks(windowed, maxPoints)
 
-	pts := make([]point, 0, len(windowed)+1)
-	for _, p := range windowed {
-		pts = append(pts, point{T: p.Timestamp, Rx: p.RxRate, Tx: p.TxRate})
-	}
-	pts = append(pts, point{T: time.Now().UnixMilli(), Rx: rx, Tx: tx})
-
-	return &contentState{
-		InterfaceName: name,
-		RxRate:        rx,
-		TxRate:        tx,
-		Points:        pts,
-		UpdatedAt:     float64(time.Now().UnixMilli()) / 1000,
-	}
+	return contentstate.Build(name, rx, tx, points), true
 }
 
 func statFor(all []collector.InterfaceStat, name string) *collector.InterfaceStat {
@@ -227,151 +193,4 @@ func pickInterface(all []collector.InterfaceStat, hist map[string][]collector.Hi
 		return k
 	}
 	return ""
-}
-
-// downsamplePeaks reduces pts to ~maxPoints, keeping the highest-rate sample in each bucket so brief
-// spikes survive (matches the iOS downsampledPreservingPeaks).
-func downsamplePeaks(pts []collector.HistoryPoint, maxPoints int) []collector.HistoryPoint {
-	if maxPoints <= 0 || len(pts) <= maxPoints {
-		return pts
-	}
-	bucket := float64(len(pts)) / float64(maxPoints)
-	out := make([]collector.HistoryPoint, 0, maxPoints)
-	start := 0
-	for i := 0; i < maxPoints; i++ {
-		end := len(pts)
-		if i < maxPoints-1 {
-			end = int(math.Round(float64(i+1) * bucket))
-		}
-		if start >= end {
-			continue
-		}
-		peak := pts[start]
-		for _, p := range pts[start:end] {
-			if math.Max(p.RxRate, p.TxRate) > math.Max(peak.RxRate, peak.TxRate) {
-				peak = p
-			}
-		}
-		out = append(out, peak)
-		start = end
-	}
-	return out
-}
-
-// --- APNs ---------------------------------------------------------------------------------------
-
-func (m *Manager) send(token, environment string, state *contentState) {
-	jwt, err := m.providerToken()
-	if err != nil {
-		log.Printf("liveactivity: jwt: %v", err)
-		return
-	}
-
-	now := time.Now().Unix()
-	payload := map[string]any{"aps": map[string]any{
-		"timestamp":     now,
-		"event":         "update",
-		"content-state": state,
-		"stale-date":    now + int64(m.staleAfter().Seconds()),
-	}}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return
-	}
-
-	host := "https://api.push.apple.com"
-	if environment == "sandbox" {
-		host = "https://api.sandbox.push.apple.com"
-	}
-	req, err := http.NewRequest(http.MethodPost, host+"/3/device/"+token, bytes.NewReader(body))
-	if err != nil {
-		return
-	}
-	req.Header.Set("authorization", "bearer "+jwt)
-	req.Header.Set("apns-topic", m.cfg.BundleID+".push-type.liveactivity")
-	req.Header.Set("apns-push-type", "liveactivity")
-	req.Header.Set("apns-priority", "10")
-
-	resp, err := m.client.Do(req)
-	if err != nil {
-		log.Printf("liveactivity: send: %v", err)
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusOK {
-		return
-	}
-	var apns struct {
-		Reason string `json:"reason"`
-	}
-	json.NewDecoder(resp.Body).Decode(&apns)
-	apnsID := resp.Header.Get("apns-id")
-	// Drop tokens Apple says are dead so we stop wasting pushes on them.
-	if resp.StatusCode == http.StatusGone || apns.Reason == "BadDeviceToken" || apns.Reason == "Unregistered" {
-		m.mu.Lock()
-		delete(m.tokens, token)
-		m.mu.Unlock()
-		log.Printf("liveactivity: dropped token (%d %s, apns-id=%s)", resp.StatusCode, apns.Reason, apnsID)
-		return
-	}
-	// 403 is a provider-token (JWT) problem, not device/env. Surface the likely culprits.
-	if resp.StatusCode == http.StatusForbidden {
-		log.Printf("liveactivity: APNs 403 %s (apns-id=%s) — verify APNS_KEY_ID (%s) matches the .p8, APNS_TEAM_ID (%s), and the server clock (now=%s)",
-			apns.Reason, apnsID, m.cfg.KeyID, m.cfg.TeamID, time.Now().UTC().Format(time.RFC3339))
-		return
-	}
-	log.Printf("liveactivity: APNs %d %s (apns-id=%s)", resp.StatusCode, apns.Reason, apnsID)
-}
-
-// providerToken returns a cached ES256 APNs provider JWT, regenerating it at most every ~50 min
-// (Apple rejects tokens older than an hour).
-func (m *Manager) providerToken() (string, error) {
-	m.jwtMu.Lock()
-	defer m.jwtMu.Unlock()
-	if m.jwtCache != "" && time.Since(m.jwtIssued) < 50*time.Minute {
-		return m.jwtCache, nil
-	}
-	header := base64url([]byte(fmt.Sprintf(`{"alg":"ES256","kid":"%s"}`, m.cfg.KeyID)))
-	claims := base64url([]byte(fmt.Sprintf(`{"iss":"%s","iat":%d}`, m.cfg.TeamID, time.Now().Unix())))
-	signingInput := header + "." + claims
-
-	digest := sha256.Sum256([]byte(signingInput))
-	r, s, err := ecdsa.Sign(rand.Reader, m.key, digest[:])
-	if err != nil {
-		return "", err
-	}
-	// JOSE wants the raw R||S, each left-padded to 32 bytes for P-256.
-	sig := make([]byte, 64)
-	r.FillBytes(sig[:32])
-	s.FillBytes(sig[32:])
-
-	jwt := signingInput + "." + base64url(sig)
-	m.jwtCache, m.jwtIssued = jwt, time.Now()
-	return jwt, nil
-}
-
-func base64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
-
-func loadKey(path string) (*ecdsa.PrivateKey, error) {
-	if path == "" {
-		return nil, fmt.Errorf("APNS_KEY_FILE not set")
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read key: %w", err)
-	}
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, fmt.Errorf("no PEM block in %s", path)
-	}
-	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parse key: %w", err)
-	}
-	key, ok := parsed.(*ecdsa.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("key is not ECDSA/P-256")
-	}
-	return key, nil
 }

--- a/liveactivity/liveactivity.go
+++ b/liveactivity/liveactivity.go
@@ -88,19 +88,32 @@ func New(cfg Config, col *collector.Collector) (*Manager, error) {
 	return m, nil
 }
 
+// maxTokens caps the registry so the (unauthenticated) register endpoint can't grow it without
+// bound — the same class of leak as an unswept rate-limiter map. Dead tokens are already pruned
+// on APNs 410/BadDeviceToken/Unregistered; this bounds the live set. Far above any realistic
+// number of devices watching one household router, so hitting it means abuse, not use.
+const maxTokens = 1000
+
 // Register records (or refreshes) a push token and the interface + APNs environment it wants.
-func (m *Manager) Register(token, iface, environment string) {
+// Returns false when the registry is at capacity and the token is new.
+func (m *Manager) Register(token, iface, environment string) bool {
 	if token == "" {
-		return
+		return false
 	}
 	if environment != "sandbox" && environment != "production" {
 		environment = m.cfg.Env
 	}
 	m.mu.Lock()
+	if _, existed := m.tokens[token]; !existed && len(m.tokens) >= maxTokens {
+		m.mu.Unlock()
+		log.Printf("liveactivity: rejected registration: at capacity (%d tokens)", maxTokens)
+		return false
+	}
 	m.tokens[token] = registration{iface: iface, environment: environment, lastSeen: time.Now()}
 	n := len(m.tokens)
 	m.mu.Unlock()
 	log.Printf("liveactivity: registered token for %q (%s); %d active", iface, environment, n)
+	return true
 }
 
 // Run pushes to all registered tokens every Interval until Stop. Blocks; call via `go m.Run()`.

--- a/liveactivity/liveactivity.go
+++ b/liveactivity/liveactivity.go
@@ -1,0 +1,354 @@
+// Package liveactivity pushes iOS Live Activity updates to Apple's APNs so the Bandwidth Monitor
+// Lock Screen / Dynamic Island view keeps updating while the app is suspended.
+//
+// The iOS app registers a per-activity push token via POST /api/liveactivity/register; a background
+// loop then builds the Live Activity content-state from the collector and pushes it to APNs for each
+// registered token. Dependency-free beyond the stdlib and golang.org/x/net/http2 (already required):
+// crypto/ecdsa + crypto/x509 sign the ES256 provider JWT and parse the .p8 key.
+package liveactivity
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"bandwidth-monitor/collector"
+	"bandwidth-monitor/poller"
+)
+
+const (
+	historyWindow = time.Hour
+	maxPoints     = 38
+	staleAfter    = 120 * time.Second
+)
+
+// Config holds APNs settings. The feature is enabled only when KeyFile, KeyID, TeamID, and BundleID
+// are all set (wired in main.go).
+type Config struct {
+	KeyFile  string        // path to the APNs auth key (.p8)
+	KeyID    string        // the key's 10-char ID
+	TeamID   string        // Apple Developer team ID
+	BundleID string        // app bundle ID, e.g. com.evilforbeginners.BandwidthMonitor
+	Env      string        // default APNs environment: "production" (default) or "sandbox"
+	Interval time.Duration // push cadence (default 10s)
+}
+
+type registration struct {
+	iface       string
+	environment string
+	lastSeen    time.Time
+}
+
+// Manager owns the token registry, signing key, and push loop.
+type Manager struct {
+	cfg    Config
+	col    *collector.Collector
+	key    *ecdsa.PrivateKey
+	client *http.Client
+	runner poller.Runner
+
+	mu     sync.Mutex
+	tokens map[string]registration
+
+	jwtMu     sync.Mutex
+	jwtCache  string
+	jwtIssued time.Time
+}
+
+// New parses the .p8 key and returns a configured Manager. Returns an error if the key is missing or
+// not a P-256 private key.
+func New(cfg Config, col *collector.Collector) (*Manager, error) {
+	key, err := loadKey(cfg.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Env != "sandbox" {
+		cfg.Env = "production"
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = 10 * time.Second
+	}
+	m := &Manager{
+		cfg:    cfg,
+		col:    col,
+		key:    key,
+		tokens: make(map[string]registration),
+		// The stdlib client auto-negotiates HTTP/2 over TLS via ALPN (which APNs requires), so no
+		// golang.org/x/net/http2 dependency is needed.
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+	m.runner.Init()
+	return m, nil
+}
+
+// Register records (or refreshes) a push token and the interface + APNs environment it wants.
+func (m *Manager) Register(token, iface, environment string) {
+	if token == "" {
+		return
+	}
+	if environment != "sandbox" && environment != "production" {
+		environment = m.cfg.Env
+	}
+	m.mu.Lock()
+	m.tokens[token] = registration{iface: iface, environment: environment, lastSeen: time.Now()}
+	n := len(m.tokens)
+	m.mu.Unlock()
+	log.Printf("liveactivity: registered token for %q (%s); %d active", iface, environment, n)
+}
+
+// Run pushes to all registered tokens every Interval until Stop. Blocks; call via `go m.Run()`.
+func (m *Manager) Run() { m.runner.Run(m.cfg.Interval, m.tick) }
+
+// Stop halts the push loop.
+func (m *Manager) Stop() { m.runner.Stop() }
+
+func (m *Manager) tick() {
+	m.mu.Lock()
+	toks := make(map[string]registration, len(m.tokens))
+	for k, v := range m.tokens {
+		toks[k] = v
+	}
+	m.mu.Unlock()
+
+	for token, reg := range toks {
+		if state := m.buildState(reg.iface); state != nil {
+			m.send(token, reg.environment, state)
+		}
+	}
+}
+
+// --- content-state (keys MUST match the iOS BandwidthActivityAttributes.ContentState) ------------
+
+type point struct {
+	T  int64   `json:"t"`
+	Rx float64 `json:"rx"`
+	Tx float64 `json:"tx"`
+}
+
+type contentState struct {
+	InterfaceName string  `json:"interfaceName"`
+	RxRate        float64 `json:"rxRate"`
+	TxRate        float64 `json:"txRate"`
+	Points        []point `json:"points"`
+	UpdatedAt     float64 `json:"updatedAt"`
+}
+
+// buildState mirrors the iOS liveState(): the selected interface's last hour, downsampled keeping
+// peaks, with a synthetic "now" sample carrying the live rate appended so the marked latest point
+// reflects the current rate.
+func (m *Manager) buildState(iface string) *contentState {
+	all := m.col.GetAll()
+	hist := m.col.GetHistory()
+
+	name := iface
+	if name == "" || (hist[name] == nil && statFor(all, name) == nil) {
+		name = pickInterface(all, hist)
+	}
+	if name == "" {
+		return nil
+	}
+
+	var rx, tx float64
+	if s := statFor(all, name); s != nil {
+		rx, tx = s.RxRate, s.TxRate
+	}
+
+	cutoff := time.Now().Add(-historyWindow).UnixMilli()
+	var windowed []collector.HistoryPoint
+	for _, p := range hist[name] {
+		if p.Timestamp >= cutoff {
+			windowed = append(windowed, p)
+		}
+	}
+	windowed = downsamplePeaks(windowed, maxPoints)
+
+	pts := make([]point, 0, len(windowed)+1)
+	for _, p := range windowed {
+		pts = append(pts, point{T: p.Timestamp, Rx: p.RxRate, Tx: p.TxRate})
+	}
+	pts = append(pts, point{T: time.Now().UnixMilli(), Rx: rx, Tx: tx})
+
+	return &contentState{
+		InterfaceName: name,
+		RxRate:        rx,
+		TxRate:        tx,
+		Points:        pts,
+		UpdatedAt:     float64(time.Now().UnixMilli()) / 1000,
+	}
+}
+
+func statFor(all []collector.InterfaceStat, name string) *collector.InterfaceStat {
+	for i := range all {
+		if all[i].Name == name {
+			return &all[i]
+		}
+	}
+	return nil
+}
+
+func pickInterface(all []collector.InterfaceStat, hist map[string][]collector.HistoryPoint) string {
+	for i := range all {
+		if all[i].WAN {
+			return all[i].Name
+		}
+	}
+	if len(all) > 0 {
+		return all[0].Name
+	}
+	for k := range hist {
+		return k
+	}
+	return ""
+}
+
+// downsamplePeaks reduces pts to ~maxPoints, keeping the highest-rate sample in each bucket so brief
+// spikes survive (matches the iOS downsampledPreservingPeaks).
+func downsamplePeaks(pts []collector.HistoryPoint, maxPoints int) []collector.HistoryPoint {
+	if maxPoints <= 0 || len(pts) <= maxPoints {
+		return pts
+	}
+	bucket := float64(len(pts)) / float64(maxPoints)
+	out := make([]collector.HistoryPoint, 0, maxPoints)
+	start := 0
+	for i := 0; i < maxPoints; i++ {
+		end := len(pts)
+		if i < maxPoints-1 {
+			end = int(math.Round(float64(i+1) * bucket))
+		}
+		if start >= end {
+			continue
+		}
+		peak := pts[start]
+		for _, p := range pts[start:end] {
+			if math.Max(p.RxRate, p.TxRate) > math.Max(peak.RxRate, peak.TxRate) {
+				peak = p
+			}
+		}
+		out = append(out, peak)
+		start = end
+	}
+	return out
+}
+
+// --- APNs ---------------------------------------------------------------------------------------
+
+func (m *Manager) send(token, environment string, state *contentState) {
+	jwt, err := m.providerToken()
+	if err != nil {
+		log.Printf("liveactivity: jwt: %v", err)
+		return
+	}
+
+	now := time.Now().Unix()
+	payload := map[string]any{"aps": map[string]any{
+		"timestamp":     now,
+		"event":         "update",
+		"content-state": state,
+		"stale-date":    now + int64(staleAfter.Seconds()),
+	}}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	host := "https://api.push.apple.com"
+	if environment == "sandbox" {
+		host = "https://api.sandbox.push.apple.com"
+	}
+	req, err := http.NewRequest(http.MethodPost, host+"/3/device/"+token, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("authorization", "bearer "+jwt)
+	req.Header.Set("apns-topic", m.cfg.BundleID+".push-type.liveactivity")
+	req.Header.Set("apns-push-type", "liveactivity")
+	req.Header.Set("apns-priority", "10")
+
+	resp, err := m.client.Do(req)
+	if err != nil {
+		log.Printf("liveactivity: send: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return
+	}
+	var apns struct {
+		Reason string `json:"reason"`
+	}
+	json.NewDecoder(resp.Body).Decode(&apns)
+	// Drop tokens Apple says are dead so we stop wasting pushes on them.
+	if resp.StatusCode == http.StatusGone || apns.Reason == "BadDeviceToken" || apns.Reason == "Unregistered" {
+		m.mu.Lock()
+		delete(m.tokens, token)
+		m.mu.Unlock()
+		log.Printf("liveactivity: dropped token (%d %s)", resp.StatusCode, apns.Reason)
+		return
+	}
+	log.Printf("liveactivity: APNs %d %s", resp.StatusCode, apns.Reason)
+}
+
+// providerToken returns a cached ES256 APNs provider JWT, regenerating it at most every ~50 min
+// (Apple rejects tokens older than an hour).
+func (m *Manager) providerToken() (string, error) {
+	m.jwtMu.Lock()
+	defer m.jwtMu.Unlock()
+	if m.jwtCache != "" && time.Since(m.jwtIssued) < 50*time.Minute {
+		return m.jwtCache, nil
+	}
+	header := base64url([]byte(fmt.Sprintf(`{"alg":"ES256","kid":"%s"}`, m.cfg.KeyID)))
+	claims := base64url([]byte(fmt.Sprintf(`{"iss":"%s","iat":%d}`, m.cfg.TeamID, time.Now().Unix())))
+	signingInput := header + "." + claims
+
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, m.key, digest[:])
+	if err != nil {
+		return "", err
+	}
+	// JOSE wants the raw R||S, each left-padded to 32 bytes for P-256.
+	sig := make([]byte, 64)
+	r.FillBytes(sig[:32])
+	s.FillBytes(sig[32:])
+
+	jwt := signingInput + "." + base64url(sig)
+	m.jwtCache, m.jwtIssued = jwt, time.Now()
+	return jwt, nil
+}
+
+func base64url(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+
+func loadKey(path string) (*ecdsa.PrivateKey, error) {
+	if path == "" {
+		return nil, fmt.Errorf("APNS_KEY_FILE not set")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in %s", path)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("key is not ECDSA/P-256")
+	}
+	return key, nil
+}

--- a/liveactivity/liveactivity.go
+++ b/liveactivity/liveactivity.go
@@ -290,15 +290,22 @@ func (m *Manager) send(token, environment string, state *contentState) {
 		Reason string `json:"reason"`
 	}
 	json.NewDecoder(resp.Body).Decode(&apns)
+	apnsID := resp.Header.Get("apns-id")
 	// Drop tokens Apple says are dead so we stop wasting pushes on them.
 	if resp.StatusCode == http.StatusGone || apns.Reason == "BadDeviceToken" || apns.Reason == "Unregistered" {
 		m.mu.Lock()
 		delete(m.tokens, token)
 		m.mu.Unlock()
-		log.Printf("liveactivity: dropped token (%d %s)", resp.StatusCode, apns.Reason)
+		log.Printf("liveactivity: dropped token (%d %s, apns-id=%s)", resp.StatusCode, apns.Reason, apnsID)
 		return
 	}
-	log.Printf("liveactivity: APNs %d %s", resp.StatusCode, apns.Reason)
+	// 403 is a provider-token (JWT) problem, not device/env. Surface the likely culprits.
+	if resp.StatusCode == http.StatusForbidden {
+		log.Printf("liveactivity: APNs 403 %s (apns-id=%s) — verify APNS_KEY_ID (%s) matches the .p8, APNS_TEAM_ID (%s), and the server clock (now=%s)",
+			apns.Reason, apnsID, m.cfg.KeyID, m.cfg.TeamID, time.Now().UTC().Format(time.RFC3339))
+		return
+	}
+	log.Printf("liveactivity: APNs %d %s (apns-id=%s)", resp.StatusCode, apns.Reason, apnsID)
 }
 
 // providerToken returns a cached ES256 APNs provider JWT, regenerating it at most every ~50 min

--- a/liveactivity/liveactivity_test.go
+++ b/liveactivity/liveactivity_test.go
@@ -1,0 +1,75 @@
+package liveactivity
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+)
+
+// The provider JWT must be a well-formed ES256 token whose signature verifies against the key.
+func TestProviderTokenIsValidES256(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &Manager{cfg: Config{KeyID: "ABC123DEFG", TeamID: "TEAM123456"}, key: key}
+
+	tok, err := m.providerToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("want 3 JWT parts, got %d", len(parts))
+	}
+
+	hdr, _ := base64.RawURLEncoding.DecodeString(parts[0])
+	var h map[string]string
+	if err := json.Unmarshal(hdr, &h); err != nil {
+		t.Fatalf("header not JSON: %v", err)
+	}
+	if h["alg"] != "ES256" || h["kid"] != "ABC123DEFG" {
+		t.Errorf("bad header: %s", hdr)
+	}
+
+	sig, _ := base64.RawURLEncoding.DecodeString(parts[2])
+	if len(sig) != 64 {
+		t.Fatalf("ES256 signature must be 64 bytes (R||S), got %d", len(sig))
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	if !ecdsa.Verify(&key.PublicKey, digest[:], r, s) {
+		t.Error("signature does not verify against the public key")
+	}
+}
+
+// The content-state JSON keys must match the iOS BandwidthActivityAttributes.ContentState exactly,
+// or ActivityKit will reject the push.
+func TestContentStateJSONKeys(t *testing.T) {
+	cs := contentState{
+		InterfaceName: "eth0",
+		RxRate:        1,
+		TxRate:        2,
+		Points:        []point{{T: 123, Rx: 4, Tx: 5}},
+		UpdatedAt:     6.5,
+	}
+	b, err := json.Marshal(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(b)
+	for _, key := range []string{
+		`"interfaceName"`, `"rxRate"`, `"txRate"`, `"points"`, `"updatedAt"`, `"t"`, `"rx"`, `"tx"`,
+	} {
+		if !strings.Contains(got, key) {
+			t.Errorf("content-state JSON missing key %s: %s", key, got)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -309,7 +309,9 @@ func main() {
 		} else {
 			liveActivityMgr = mgr
 			go liveActivityMgr.Run()
-			log.Printf("Live Activity push: enabled (%s)", apnsEnv)
+			log.Printf("Live Activity push: enabled — key=%s team=%s bundle=%s env=%s interval=%s (server clock: %s)",
+				env("APNS_KEY_ID", ""), env("APNS_TEAM_ID", ""), env("APNS_BUNDLE_ID", ""),
+				apnsEnv, interval, time.Now().UTC().Format(time.RFC3339))
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"bandwidth-monitor/geoip"
 	"bandwidth-monitor/handler"
 	"bandwidth-monitor/latency"
+	"bandwidth-monitor/liveactivity"
 	"bandwidth-monitor/nextdns"
 	"bandwidth-monitor/omada"
 	"bandwidth-monitor/pihole"
@@ -289,6 +290,29 @@ func main() {
 	go topoScanner.Run()
 	log.Println("Network topology scanner enabled")
 
+	// Live Activity push (optional): when an APNs auth key is configured, the server pushes iOS
+	// Live Activity updates so the Lock Screen view stays live while the app is suspended.
+	var liveActivityMgr *liveactivity.Manager
+	if keyFile := env("APNS_KEY_FILE", ""); keyFile != "" {
+		interval, _ := time.ParseDuration(env("APNS_PUSH_INTERVAL", "10s"))
+		apnsEnv := env("APNS_ENV", "production")
+		mgr, err := liveactivity.New(liveactivity.Config{
+			KeyFile:  keyFile,
+			KeyID:    env("APNS_KEY_ID", ""),
+			TeamID:   env("APNS_TEAM_ID", ""),
+			BundleID: env("APNS_BUNDLE_ID", ""),
+			Env:      apnsEnv,
+			Interval: interval,
+		}, statsCollector)
+		if err != nil {
+			log.Printf("Live Activity push: disabled (%v)", err)
+		} else {
+			liveActivityMgr = mgr
+			go liveActivityMgr.Run()
+			log.Printf("Live Activity push: enabled (%s)", apnsEnv)
+		}
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/interfaces", handler.InterfaceStats(statsCollector))
 	mux.HandleFunc("/api/interfaces/history", handler.InterfaceHistory(statsCollector))
@@ -307,6 +331,9 @@ func main() {
 	mux.HandleFunc("/api/summary", handler.MenuBarSummary(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker))
 	mux.HandleFunc("/api/topology", handler.TopologySummary(topoScanner))
 	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor, topoScanner, dnsResolver, geoDB))
+	if liveActivityMgr != nil {
+		mux.HandleFunc("/api/liveactivity/register", handler.LiveActivityRegister(liveActivityMgr))
+	}
 	staticSub, err := fs.Sub(staticFiles, "static")
 	if err != nil {
 		log.Fatalf("Failed to create sub filesystem: %v", err)
@@ -383,6 +410,9 @@ func main() {
 	conntrackTracker.Stop()
 	topoScanner.Stop()
 	latencyMonitor.Stop()
+	if liveActivityMgr != nil {
+		liveActivityMgr.Stop()
+	}
 	dnsResolver.Stop()
 }
 

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -127,7 +127,8 @@
 
     BM._historyLoaded = false;
     var _historyRefreshInterval = null;
-    var _historyData = {};            // latest /api/interfaces/history payload
+    var _historyData = {};            // accumulated /api/interfaces/history points, pruned to 24h
+    var _lastHistoryTs = 0;           // newest point seen; refreshes fetch ?since= from here
     var selectedHistoryIface = null;  // null = All (mirrors the Live chart's selectedIface)
 
     // Build the 24h chart datasets from _historyData, honouring the interface
@@ -173,9 +174,36 @@
 
     window._shi = function(n) { selectedHistoryIface = n; _renderHistoryIfaceTabs(); _renderHistoryChart(); };
 
+    // First call fetches the full 24h history; refreshes fetch only ?since= the newest point
+    // already held and merge, so the periodic refresh parses a few KB instead of the multi-MB
+    // full payload. The t > _lastHistoryTs guard both dedupes and absorbs servers that predate
+    // the since param (they ignore it and return everything).
     function _fetchInterfaceHistory() {
-        fetch('/api/interfaces/history').then(function(r) { return r.json(); }).then(function(data) {
-            _historyData = data || {};
+        var url = '/api/interfaces/history' + (_lastHistoryTs ? '?since=' + (_lastHistoryTs + 1) : '');
+        fetch(url).then(function(r) { return r.json(); }).then(function(data) {
+            data = data || {};
+            var cutoff = Date.now() - 24 * 3600 * 1000;
+            var newest = _lastHistoryTs;
+            var dataNames = Object.keys(data);
+            for (var di = 0; di < dataNames.length; di++) {
+                var dn = dataNames[di];
+                var incoming = data[dn];
+                if (!incoming || !incoming.length) continue;
+                var cur = _historyData[dn] || (_historyData[dn] = []);
+                for (var ii = 0; ii < incoming.length; ii++) {
+                    var p = incoming[ii];
+                    if (p.t > _lastHistoryTs) cur.push(p);
+                    if (p.t > newest) newest = p.t;
+                }
+            }
+            _lastHistoryTs = newest;
+            var histNames = Object.keys(_historyData);
+            for (var hi = 0; hi < histNames.length; hi++) {
+                var pts = _historyData[histNames[hi]];
+                var drop = 0;
+                while (drop < pts.length && pts[drop].t < cutoff) drop++;
+                if (drop) _historyData[histNames[hi]] = pts.slice(drop);
+            }
             _renderHistoryIfaceTabs();
             _renderHistoryChart();
             // Subtitle reflects overall collection age, independent of the toggle.
@@ -208,7 +236,9 @@
     // window (last MAX_PTS seconds) and rebuild BM.chartData; live SSE ticks then
     // continue appending from where history left off. Called on every (re)connect.
     BM._backfillLiveTraffic = function() {
-        return fetch('/api/interfaces/history').then(function(r) { return r.json(); }).then(function(data) {
+        // Only the chart window is kept (see cutoff below), so ask the server for just that
+        // slice; servers predating the since param ignore it and return everything.
+        return fetch('/api/interfaces/history?since=' + (Date.now() - BM.MAX_PTS * 1000)).then(function(r) { return r.json(); }).then(function(data) {
             if (!data) return;
             var cutoff = Date.now() - BM.MAX_PTS * 1000;
             var names = Object.keys(data);


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #97** (Live Activity APNs push). GitHub shows the combined diff because both changes live on my fork; once #97 merges, this PR reduces to a single commit: [`1ff1c3e`](https://github.com/yeled/bandwidth-monitor/commit/1ff1c3e4420cf6fd83e91cb755be3a697f61c35c). Review #97 first — everything below describes only the delta.

## Problem

`/api/interfaces/history` always returns every interface's full 24h/1Hz history — multiple MB per request. Three consumers need far less:

- the APNs gateway (#97) needs the last **hour** of **one** interface, downsampled to 38 points
- the iOS widget needs a 1h slice of one interface, inside a tight extension execution budget
- the web UI re-downloads and re-parses the full blob on the browser main thread every 60 seconds

## Design: additive params instead of API versioning

Two optional query parameters:

| Param | Effect |
|-------|--------|
| `iface=<name>` | return only that interface's history |
| `since=<Unix ms>` | return only points at or after that timestamp |

**Compatibility is automatic in both directions, so no `/v1/` prefix or version negotiation is introduced:**

- *Old client → new server*: no params → the full map, byte-identical to today.
- *New client → old server*: the params are ignored → full superset returned → every consumer keeps a client-side timestamp/window filter that absorbs it transparently.

This is documented as a deliberate decision in the README and `docs/apns-gateway.md`. A versioning scheme can still be introduced later if a genuinely breaking schema change ever appears; nothing here needs one.

## What changed (single commit)

- **collector**: `GetHistoryFiltered(iface, sinceMillis)` — binary search over the append-only-ascending timestamps, same lock/whitelist/deep-copy pattern as `GetHistory()`, which now delegates to it.
- **handler**: `InterfaceHistory` parses both params; 400 on an invalid `since`, length-capped `iface`.
- **apnsgateway**: resolves the target interface from `/api/interfaces` first, then fetches history narrowed to it and the content-state window — per-poll transfers drop from MBs to KBs. Unknown subscribed interfaces fall back to the server's WAN interface with a refetch. The SSRF host check became a `Relay` field so tests can exercise real fetches against loopback `httptest` servers.
- **web UI**: the 60s 24h-chart refresh is now incremental (`?since=` the newest held point, merge, prune to 24h) and the live-chart backfill requests only its window — the browser parses KBs instead of MBs.
- **tests**: collector filter boundaries (`since` is `>=`-inclusive) and whitelist interaction; handler param parsing incl. 400s; gateway filtered-fetch query assertions, **old-server superset tolerance**, and unknown-interface fallback.
- **docs**: README endpoint table + `docs/apns-gateway.md` updated.

## Verification

- All tests pass (collector/handler in a Linux container — they don't compile on macOS; the rest natively).
- `GOOS=linux go build ./...`, `go vet` clean.
- Live end-to-end in Docker: unfiltered response unchanged, `?iface=eth0&since=<5s ago>` returns exactly the recent slice, `?since=bogus` → 400, unknown iface → `{}`.

## Pairs with

The iOS app adopts the params in [yeled/bandwidth-monitor-ios v1.1.1](https://github.com/yeled/bandwidth-monitor-ios/pull/3) (incremental main-app refresh + narrowed widget fetch), with the same client-side-filter fallback — it works unchanged against servers without this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)