### PR TITLE
ui: sort interface tabs and persist selection in the URL hash

### DIFF
--- a/static/js/core.js
+++ b/static/js/core.js
@@ -76,6 +76,37 @@
         return true; // All other tabs are always available
     }
 
+    // ── URL hash state ──
+    // The hash carries the active tab and, on tabs that have per-view state,
+    // query-style params after a "?": e.g. "#traffic?iface=eth0&hist=eth0".
+    // Splitting on "?" keeps tab routing working while letting a tab persist
+    // its selected interface across reloads.
+    BM._hashTab = function() {
+        return location.hash.replace(/^#/, '').split('?')[0];
+    };
+    BM._hashParams = function() {
+        return new URLSearchParams(location.hash.split('?')[1] || '');
+    };
+    // _setHashParam updates one param without disturbing the tab or other
+    // params. Pass null/'' to remove it. Uses replaceState so it doesn't spam
+    // history or fire hashchange.
+    BM._setHashParam = function(key, value) {
+        var params = BM._hashParams();
+        if (value === null || value === undefined || value === '') {
+            params.delete(key);
+        } else {
+            params.set(key, value);
+        }
+        var tab = BM._hashTab() || BM._activeTab || 'traffic';
+        var qs = params.toString();
+        var newHash = '#' + tab + (qs ? '?' + qs : '');
+        if (history.replaceState) {
+            history.replaceState(null, '', newHash);
+        } else {
+            location.hash = newHash;
+        }
+    };
+
     window._switchTab = function(tab) {
         // Guard: if tab is unavailable, fallback to traffic
         if (!_isTabAvailable(tab)) {
@@ -91,10 +122,14 @@
         document.querySelectorAll('.main-nav-tab').forEach(function(t) {
             t.classList.toggle('active', t.getAttribute('data-tab') === tab);
         });
+        // Preserve any per-tab params (e.g. the selected interface) so switching
+        // away and back — or reloading — keeps the view intact.
+        var qs = BM._hashParams().toString();
+        var newHash = '#' + tab + (qs ? '?' + qs : '');
         if (history.replaceState) {
-            history.replaceState(null, '', '#' + tab);
+            history.replaceState(null, '', newHash);
         } else {
-            location.hash = tab;
+            location.hash = newHash;
         }
         if (tab === 'speedtest' && !_stHistoryLoaded) {
             _stHistoryLoaded = true;
@@ -141,13 +176,13 @@
 
     // Restore tab from URL hash on load
     (function() {
-        var hash = location.hash.replace('#', '');
+        var hash = BM._hashTab();
         var validTabs = ['traffic', 'nat', 'dns', 'wifi', 'network', 'monitor', 'speedtest', 'debug'];
         if (hash && validTabs.indexOf(hash) !== -1 && _isTabAvailable(hash)) {
             setTimeout(function() { window._switchTab(hash); }, 0);
         }
         window.addEventListener('hashchange', function() {
-            var h = location.hash.replace('#', '');
+            var h = BM._hashTab();
             if (h && validTabs.indexOf(h) !== -1 && h !== BM._activeTab && _isTabAvailable(h)) {
                 window._switchTab(h);
             }

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -76,36 +76,8 @@
         return true; // All other tabs are always available
     }
 
-    // ── URL hash state ──
-    // The hash carries the active tab and, on tabs that have per-view state,
-    // query-style params after a "?": e.g. "#traffic?iface=eth0&hist=eth0".
-    // Splitting on "?" keeps tab routing working while letting a tab persist
-    // its selected interface across reloads.
-    BM._hashTab = function() {
-        return location.hash.replace(/^#/, '').split('?')[0];
-    };
-    BM._hashParams = function() {
-        return new URLSearchParams(location.hash.split('?')[1] || '');
-    };
-    // _setHashParam updates one param without disturbing the tab or other
-    // params. Pass null/'' to remove it. Uses replaceState so it doesn't spam
-    // history or fire hashchange.
-    BM._setHashParam = function(key, value) {
-        var params = BM._hashParams();
-        if (value === null || value === undefined || value === '') {
-            params.delete(key);
-        } else {
-            params.set(key, value);
-        }
-        var tab = BM._hashTab() || BM._activeTab || 'traffic';
-        var qs = params.toString();
-        var newHash = '#' + tab + (qs ? '?' + qs : '');
-        if (history.replaceState) {
-            history.replaceState(null, '', newHash);
-        } else {
-            location.hash = newHash;
-        }
-    };
+    // Hash-state helpers (BM._hashTab / _hashParams / _setHashParam) live in
+    // utils.js so they're defined before the deferred tab modules parse.
 
     window._switchTab = function(tab) {
         // Guard: if tab is unavailable, fallback to traffic

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -129,7 +129,8 @@
     var _historyRefreshInterval = null;
     var _historyData = {};            // accumulated /api/interfaces/history points, pruned to 24h
     var _lastHistoryTs = 0;           // newest point seen; refreshes fetch ?since= from here
-    var selectedHistoryIface = null;  // null = All (mirrors the Live chart's selectedIface)
+    // null = All. Restored from the URL hash so a reload keeps the selection.
+    var selectedHistoryIface = (BM._hashParams && BM._hashParams().get('hist')) || null;
 
     // Build the 24h chart datasets from _historyData, honouring the interface
     // toggle. Mirrors BM.updateChart for the Live chart: a single selected
@@ -137,7 +138,13 @@
     // the per-series RX/TX legend toggles keep working on top.
     function _renderHistoryChart() {
         var names = Object.keys(_historyData).sort();
-        if (selectedHistoryIface && names.indexOf(selectedHistoryIface) === -1) selectedHistoryIface = null;
+        // Only clear a hash-restored selection once data has actually loaded and
+        // the interface genuinely isn't present — not during the initial empty
+        // window, which would wipe a valid selection before its points arrive.
+        if (selectedHistoryIface && names.length && names.indexOf(selectedHistoryIface) === -1) {
+            selectedHistoryIface = null;
+            if (BM._setHashParam) BM._setHashParam('hist', null);
+        }
         var list = selectedHistoryIface ? [selectedHistoryIface] : names;
         var ds = [], ci = 0;
         for (var ni = 0; ni < list.length; ni++) {
@@ -172,7 +179,7 @@
         el.innerHTML = h;
     }
 
-    window._shi = function(n) { selectedHistoryIface = n; _renderHistoryIfaceTabs(); _renderHistoryChart(); };
+    window._shi = function(n) { selectedHistoryIface = n; if (BM._setHashParam) BM._setHashParam('hist', n); _renderHistoryIfaceTabs(); _renderHistoryChart(); };
 
     // First call fetches the full 24h history; refreshes fetch only ?since= the newest point
     // already held and merge, so the periodic refresh parses a few KB instead of the multi-MB
@@ -292,14 +299,18 @@
     BM._asnChart = asnChart;
     BM._ipvChart = ipvChart;
 
-    var selectedIface = null;
+    // Restore the selected interface from the URL hash so a reload keeps it.
+    var selectedIface = (BM._hashParams && BM._hashParams().get('iface')) || null;
     var _yAxisMax = 0;
     var _yAxisSig = '';  // signature of the visible series; changes on interface toggle
     var _yAxisTick = 0;  // throttles the percentile recompute (see updateChart)
 
     BM.updateChart = function() {
         var ds = [], ci = 0;
-        var list = selectedIface ? [selectedIface] : Array.from(BM.knownIfaces);
+        // Sort so the series order (and thus colour assignment) is stable across
+        // reloads and matches the 24h chart, instead of following the order
+        // interfaces happened to be discovered in.
+        var list = selectedIface ? [selectedIface] : Array.from(BM.knownIfaces).sort();
         for (var n of list) {
             if (!BM.chartData[n]) continue;
             var c = chartColors[ci % chartColors.length];
@@ -352,13 +363,14 @@
     BM.renderIfaceTabs = function() {
         var el = document.getElementById('ifaceTabs');
         var h = '<div class="iface-tab' + (selectedIface === null ? ' active' : '') + '" onclick="window._si(null)">All</div>';
-        BM.knownIfaces.forEach(function(n) {
+        // Sorted so the tab order is the same on every load and matches the 24h row.
+        Array.from(BM.knownIfaces).sort().forEach(function(n) {
             h += '<div class="iface-tab' + (selectedIface === n ? ' active' : '') + '" onclick="window._si(\'' + n + '\')">' + n + '</div>';
         });
         el.innerHTML = h;
     };
 
-    window._si = function(n) { selectedIface = n; BM.renderIfaceTabs(); BM.updateChart(); };
+    window._si = function(n) { selectedIface = n; if (BM._setHashParam) BM._setHashParam('iface', n); BM.renderIfaceTabs(); BM.updateChart(); };
 
     function classifyIface(f) {
         if (f.wan) return 'wan';

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -305,7 +305,20 @@
     var _yAxisSig = '';  // signature of the visible series; changes on interface toggle
     var _yAxisTick = 0;  // throttles the percentile recompute (see updateChart)
 
+    // Drop a hash-restored selection once interfaces are known but the chosen
+    // one isn't among them (a stale bookmark, or a removed interface), so the
+    // view falls back to All instead of an empty chart with no active tab.
+    // Mirrors the 24h chart's guard. Only acts once knownIfaces is populated,
+    // so a valid selection isn't wiped during the initial empty window.
+    function _normalizeSelectedIface() {
+        if (selectedIface && BM.knownIfaces.size && !BM.knownIfaces.has(selectedIface)) {
+            selectedIface = null;
+            if (BM._setHashParam) BM._setHashParam('iface', null);
+        }
+    }
+
     BM.updateChart = function() {
+        _normalizeSelectedIface();
         var ds = [], ci = 0;
         // Sort so the series order (and thus colour assignment) is stable across
         // reloads and matches the 24h chart, instead of following the order
@@ -361,6 +374,7 @@
     };
 
     BM.renderIfaceTabs = function() {
+        _normalizeSelectedIface();
         var el = document.getElementById('ifaceTabs');
         var h = '<div class="iface-tab' + (selectedIface === null ? ' active' : '') + '" onclick="window._si(null)">All</div>';
         // Sorted so the tab order is the same on every load and matches the 24h row.

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -265,7 +265,12 @@
                 BM.chartData[name] = { rx: rx, tx: tx };
             }
             if (BM.renderIfaceTabs) BM.renderIfaceTabs();
-            if (BM.updateChart) BM.updateChart();
+            // Force a y-axis rescale: the backfilled window can contain far larger
+            // peaks than the handful of live points added since reload, and a plain
+            // updateChart() skips recompute when the interface is unchanged and it
+            // isn't a 10th tick — which would leave the axis stuck at the small
+            // live-only scale even though the big history is now drawn.
+            if (BM.updateChart) BM.updateChart(true);
         }).catch(function(e) { console.error('live backfill:', e); });
     };
 
@@ -317,7 +322,7 @@
         }
     }
 
-    BM.updateChart = function() {
+    BM.updateChart = function(forceRescale) {
         _normalizeSelectedIface();
         var ds = [], ci = 0;
         // Sort so the series order (and thus colour assignment) is stable across
@@ -340,7 +345,7 @@
         // always immediately on an interface toggle, so the axis still drops
         // right away when a series is hidden.
         var sig = selectedIface === null ? '__all__' : selectedIface;
-        var recompute = (sig !== _yAxisSig) || (_yAxisTick % 10 === 0);
+        var recompute = forceRescale || (sig !== _yAxisSig) || (_yAxisTick % 10 === 0);
         _yAxisTick++;
         if (recompute) {
             var vals = [];
@@ -356,8 +361,8 @@
                 vals.sort(function(a, b) { return a - b; });
                 target = vals[Math.floor((vals.length - 1) * 0.99)] * 1.15;
             }
-            if (sig !== _yAxisSig || target >= _yAxisMax) {
-                _yAxisMax = target;                              // toggle or genuine rise → snap
+            if (forceRescale || sig !== _yAxisSig || target >= _yAxisMax) {
+                _yAxisMax = target;                              // forced reload, toggle, or genuine rise → snap
             } else {
                 _yAxisMax = Math.max(target, _yAxisMax * 0.9);   // ease down smoothly, no flicker
             }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -213,4 +213,41 @@
         for (var v = niceMin; v <= niceMax + step * 0.5; v += step) ticks.push(Math.round(v * 1e6) / 1e6);
         return { min: niceMin, max: niceMax, step: step, ticks: ticks };
     };
+
+    // ── URL hash state ──
+    // The hash carries the active tab and, on tabs with per-view state,
+    // query-style params after a "?": e.g. "#traffic?iface=eth0&hist=eth0".
+    // Splitting on "?" keeps tab routing working while letting a tab persist
+    // its selected interface across reloads.
+    //
+    // These live in utils.js (not core.js) because scripts load with `defer`
+    // and so execute in document order — utils.js first, tab modules next,
+    // core.js last. A tab module that reads its saved selection at parse time
+    // (e.g. traffic.js initialising selectedIface) needs these defined already,
+    // which they wouldn't be if they lived in core.js.
+    BM._hashTab = function() {
+        return location.hash.replace(/^#/, '').split('?')[0];
+    };
+    BM._hashParams = function() {
+        return new URLSearchParams(location.hash.split('?')[1] || '');
+    };
+    // _setHashParam updates one param without disturbing the tab or other
+    // params. Pass null/'' to remove it. Uses replaceState so it doesn't spam
+    // history or fire hashchange.
+    BM._setHashParam = function(key, value) {
+        var params = BM._hashParams();
+        if (value === null || value === undefined || value === '') {
+            params.delete(key);
+        } else {
+            params.set(key, value);
+        }
+        var tab = BM._hashTab() || BM._activeTab || 'traffic';
+        var qs = params.toString();
+        var newHash = '#' + tab + (qs ? '?' + qs : '');
+        if (history.replaceState) {
+            history.replaceState(null, '', newHash);
+        } else {
+            location.hash = newHash;
+        }
+    };
 })();


### PR DESCRIPTION
The Live (1h) chart listed interfaces in discovery order (iterating the knownIfaces Set), so the tab row could reshuffle between loads and didn't match the alphabetically-sorted 24h row. Both rows now sort alphabetically, giving a stable order that's identical every time.

Interface selection was also lost on refresh — only the active tab was stored in the hash. The hash now carries query-style params (e.g. #traffic?iface=eth0&hist=eth0) for the Live and 24h selections; they're restored on load and preserved across tab switches. A small set of hash helpers in core.js keeps tab routing working alongside the new params.


Claude-Session: https://claude.ai/code/session_01DdZ5oGUyXMM5EAb1JXhkig