### PR TITLE
UI consistency cleanup, System Overview improvements, and network topology fixes

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -614,20 +614,21 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 	}
 
 	payload := map[string]interface{}{
-		"interfaces":         c.GetAll(),
-		"sparklines":         c.GetSparklines(5*time.Minute, 50),
-		"protocols":          t.GetProtocolBreakdown(),
-		"ip_versions":        t.GetIPVersionBreakdown(),
-		"countries":          geo.Countries,
-		"asns":               geo.ASNs,
-		"top_bandwidth":      t.TopByBandwidth(10),
-		"topology_bandwidth": topologyBandwidth,
-		"top_volume":         t.TopByVolume(10),
-		"unique_ips":         t.UniqueIPs(),
-		"uptime_secs":        readUptime(),
-		"load_avg":           readLoadAvg(),
-		"processes":          func() map[string]int { r, t := readProcessCount(); return map[string]int{"running": r, "total": t} }(),
-		"timestamp":          time.Now().UnixMilli(),
+		"interfaces":          c.GetAll(),
+		"sparklines":          c.GetSparklines(5*time.Minute, 50),
+		"protocols":           t.GetProtocolBreakdown(),
+		"ip_versions":         t.GetIPVersionBreakdown(),
+		"countries":           geo.Countries,
+		"asns":                geo.ASNs,
+		"top_bandwidth":       t.TopByBandwidth(10),
+		"topology_bandwidth":  topologyBandwidth,
+		"top_volume":          t.TopByVolume(10),
+		"unique_ips":          t.UniqueIPs(),
+		"uptime_secs":         readUptime(),
+		"process_uptime_secs": time.Since(processStartTime).Seconds(),
+		"load_avg":            readLoadAvg(),
+		"processes":           func() map[string]int { r, t := readProcessCount(); return map[string]int{"running": r, "total": t} }(),
+		"timestamp":           time.Now().UnixMilli(),
 	}
 	if origin != nil {
 		if og := origin.resolve(c); og != nil {
@@ -744,6 +745,10 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 		}
 	}
 }
+
+// processStartTime records when this handler package was initialised, used to compute the
+// running process's own uptime (distinct from the host's system uptime).
+var processStartTime = time.Now()
 
 // readUptime reads the system uptime from /proc/uptime in seconds.
 func readUptime() float64 {

--- a/static/index.html
+++ b/static/index.html
@@ -53,7 +53,7 @@
                     <div class="card-subtitle" id="systemSubtitle">Loading…</div>
                 </div>
             </div>
-            <div id="systemStats" style="padding:0 16px 16px;display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:12px"></div>
+            <div id="systemStats" class="system-stats"></div>
         </div>
 
         <div class="stats-row" id="statsRow"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -22,7 +22,7 @@
                     <button class="theme-btn" data-theme-val="dark" title="Dark"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg></button>
                 </div>
                 <div class="status-badge">
-                    <span class="status-dot" id="statusDot"></span>
+                    <span class="status-dot" id="statusDot" role="img" aria-label="Connection status: connecting"></span>
                     <span id="statusText">Connecting</span>
                 </div>
             </div>
@@ -337,8 +337,8 @@
                         <div class="card-subtitle" id="natTableSubtitle">Active conntrack entries (top 200 by traffic volume)</div>
                     </div>
                     <div style="display:flex;gap:8px;align-items:center">
-                        <input type="text" id="natSearch" placeholder="Filter entries…" style="padding:4px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text-1);font-size:12px;width:200px;outline:none">
-                        <select id="natFilter" style="padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text-1);font-size:12px;outline:none">
+                        <input type="text" id="natSearch" class="input-control input-control--sm" placeholder="Filter entries…" style="width:200px">
+                        <select id="natFilter" class="select-control select-control--sm">
                             <option value="all">All NAT Types</option>
                             <option value="snat">SNAT</option>
                             <option value="dnat">DNAT</option>
@@ -652,8 +652,8 @@
                         <div class="card-subtitle">Per-client wireless traffic &amp; signal</div>
                     </div>
                     <div style="display:flex;gap:8px;align-items:center">
-                        <input type="text" id="wifiClientSearch" placeholder="Filter clients…" style="padding:4px 10px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text-1);font-size:12px;width:180px;outline:none">
-                        <select id="wifiClientSort" style="padding:4px 8px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--text-1);font-size:12px;outline:none">
+                        <input type="text" id="wifiClientSearch" class="input-control input-control--sm" placeholder="Filter clients…" style="width:180px">
+                        <select id="wifiClientSort" class="select-control select-control--sm">
                             <option value="traffic">Sort: Traffic</option>
                             <option value="rate">Sort: Rate</option>
                             <option value="name">Sort: Name</option>
@@ -692,26 +692,26 @@
         <div id="networkHasData" style="display:none">
 
         <!-- Summary stats -->
-        <div class="wifi-stats-row" style="grid-template-columns:repeat(5,1fr)" id="networkStatsRow">
-            <div class="wifi-stat-card">
-                <div class="wifi-stat-label">Total Nodes</div>
-                <div class="wifi-stat-value net-nodes" id="netTotalNodes">0</div>
+        <div class="net-stats-row" style="grid-template-columns:repeat(5,1fr)" id="networkStatsRow">
+            <div class="net-stat-card">
+                <div class="net-stat-label">Total Nodes</div>
+                <div class="net-stat-value net-nodes" id="netTotalNodes">0</div>
             </div>
-            <div class="wifi-stat-card">
-                <div class="wifi-stat-label">Gateway</div>
-                <div class="wifi-stat-value net-gw" id="netGateway">&mdash;</div>
+            <div class="net-stat-card">
+                <div class="net-stat-label">Gateway</div>
+                <div class="net-stat-value net-gw" id="netGateway">&mdash;</div>
             </div>
-            <div class="wifi-stat-card">
-                <div class="wifi-stat-label">Access Points</div>
-                <div class="wifi-stat-value net-aps" id="netTotalAPs">0</div>
+            <div class="net-stat-card">
+                <div class="net-stat-label">Access Points</div>
+                <div class="net-stat-value net-aps" id="netTotalAPs">0</div>
             </div>
-            <div class="wifi-stat-card">
-                <div class="wifi-stat-label">Clients</div>
-                <div class="wifi-stat-value net-clients" id="netTotalClients">0</div>
+            <div class="net-stat-card">
+                <div class="net-stat-label">Clients</div>
+                <div class="net-stat-value net-clients" id="netTotalClients">0</div>
             </div>
-            <div class="wifi-stat-card">
-                <div class="wifi-stat-label">Discovery Sources</div>
-                <div class="wifi-stat-value net-sources" id="netSources" style="font-size:14px">&mdash;</div>
+            <div class="net-stat-card">
+                <div class="net-stat-label">Discovery Sources</div>
+                <div class="net-stat-value net-sources" id="netSources" style="font-size:14px">&mdash;</div>
             </div>
         </div>
 
@@ -723,7 +723,7 @@
                     <div class="card-subtitle">Approximate local network map &mdash; derived from ARP, NDP, LLDP, and controller data</div>
                 </div>
                 <div style="display:flex;gap:8px;align-items:center">
-                    <select id="networkLayout" class="wifi-client-sort" onchange="window._updateNetworkLayout()">
+                    <select id="networkLayout" class="select-control select-control--sm" onchange="window._updateNetworkLayout()">
                         <option value="tree" selected>Tree</option>
                         <option value="radial">Radial</option>
                     </select>
@@ -742,8 +742,8 @@
                     <div class="card-subtitle" id="networkClientCount">0 nodes discovered</div>
                 </div>
                 <div style="display:flex;gap:8px;align-items:center">
-                    <input type="text" id="networkClientSearch" placeholder="Filter by name, IP, MAC…" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;width:200px;outline:none" oninput="window._filterNetworkClients()">
-                    <select id="networkClientSort" class="wifi-client-sort" onchange="window._filterNetworkClients()">
+                    <input type="text" id="networkClientSearch" class="input-control" placeholder="Filter by name, IP, MAC…" style="width:200px" oninput="window._filterNetworkClients()">
+                    <select id="networkClientSort" class="select-control select-control--sm" onchange="window._filterNetworkClients()">
                         <option value="type">Sort: Type</option>
                         <option value="name">Sort: Name</option>
                         <option value="ip">Sort: IP</option>
@@ -898,8 +898,8 @@
                 </div>
             </div>
             <div style="padding:12px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;border-top:1px solid var(--border)">
-                <input type="text" id="trTarget" placeholder="IP or hostname (e.g. 1.1.1.1)" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;width:220px;outline:none;font-family:'JetBrains Mono',monospace">
-                <input type="number" id="trCount" value="20" min="1" max="100" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;width:70px;outline:none" title="Probes per hop">
+                <input type="text" id="trTarget" class="input-control" placeholder="IP or hostname (e.g. 1.1.1.1)" style="width:220px;font-family:var(--font-mono)">
+                <input type="number" id="trCount" class="input-control" value="20" min="1" max="100" style="width:70px" title="Probes per hop">
                 <span style="font-size:11px;color:var(--text-2)">probes/hop</span>
                 <button class="speedtest-btn" id="trBtn" onclick="window._runTraceroute()">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><polygon points="5 3 19 12 5 21 5 3"/></svg>
@@ -951,8 +951,8 @@
                 </div>
             </div>
             <div style="padding:12px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;border-top:1px solid var(--border)">
-                <input type="text" id="dnsCheckDomain" placeholder="Domain (e.g. example.com)" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;width:220px;outline:none;font-family:'JetBrains Mono',monospace">
-                <select id="dnsCheckType" style="padding:6px 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;outline:none">
+                <input type="text" id="dnsCheckDomain" class="input-control" placeholder="Domain (e.g. example.com)" style="width:220px;font-family:var(--font-mono)">
+                <select id="dnsCheckType" class="select-control">
                     <option value="A">A</option>
                     <option value="AAAA">AAAA</option>
                     <option value="MX">MX</option>
@@ -990,7 +990,7 @@
                 </div>
             </div>
             <div style="padding:12px 20px;display:flex;gap:10px;align-items:center;flex-wrap:wrap;border-top:1px solid var(--border)">
-                <input type="text" id="mtuTarget" placeholder="IP or hostname (e.g. 1.1.1.1)" style="padding:6px 12px;border-radius:6px;border:1px solid var(--border);background:var(--bg-2);color:var(--text-0);font-size:13px;width:220px;outline:none;font-family:'JetBrains Mono',monospace">
+                <input type="text" id="mtuTarget" class="input-control" placeholder="IP or hostname (e.g. 1.1.1.1)" style="width:220px;font-family:var(--font-mono)">
                 <button class="speedtest-btn" id="mtuBtn" onclick="window._runMTUDiscovery()">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><path d="M12 2v20M2 12h20"/></svg>
                     Discover

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -174,6 +174,7 @@
 
         sse.onopen = function() {
             document.getElementById('statusDot').className = 'status-dot';
+            document.getElementById('statusDot').setAttribute('aria-label', 'Connection status: live');
             document.getElementById('statusText').textContent = 'Live';
             // Backfill the Live Traffic chart from stored history so a reload or
             // a gap from a disconnect/hibernate is filled in, not lost.
@@ -181,6 +182,7 @@
         };
         sse.onerror = function() {
             document.getElementById('statusDot').className = 'status-dot error';
+            document.getElementById('statusDot').setAttribute('aria-label', 'Connection status: reconnecting');
             document.getElementById('statusText').textContent = 'Reconnecting';
         };
         sse.onmessage = function(e) {

--- a/static/js/tabs/network.js
+++ b/static/js/tabs/network.js
@@ -20,7 +20,13 @@
         var nodes = topo.nodes || [];
         var aps = nodes.filter(function(n) { return n.type === 'ap'; });
         var clients = nodes.filter(function(n) { return n.type === 'client'; });
-        var gw = nodes.filter(function(n) { return n.type === 'gateway'; });
+        // The gateway node's type may be 'gateway' or, when it's also the
+        // ARP-visible device on the WAN interface, 'wan_gw' (the two are
+        // merged into one node rather than shown as duplicates). Look it
+        // up by the authoritative topo.gateway ID instead of filtering by
+        // type so this stat stays correct either way.
+        var gwNode = nodes.find(function(n) { return n.id === topo.gateway; }) ||
+            nodes.find(function(n) { return n.type === 'gateway' || n.type === 'wan_gw'; });
         var sources = {};
         nodes.forEach(function(n) {
             (n.source || '').split(',').forEach(function(s) { if (s) sources[s] = true; });
@@ -31,9 +37,8 @@
         document.getElementById('netTotalClients').textContent = clients.length;
         document.getElementById('netSources').textContent = Object.keys(sources).join(', ') || '—';
 
-        if (gw.length > 0) {
-            var gwn = gw[0];
-            document.getElementById('netGateway').textContent = gwn.hostname || (gwn.ips && gwn.ips[0]) || gwn.mac || '—';
+        if (gwNode) {
+            document.getElementById('netGateway').textContent = gwNode.hostname || (gwNode.ips && gwNode.ips[0]) || gwNode.mac || '—';
         } else {
             document.getElementById('netGateway').textContent = '—';
         }

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -420,10 +420,11 @@
         var sub = document.getElementById('systemSubtitle');
         if (!el) return;
         function stat(label, value, cls) {
-            return '<div style="padding:8px 4px"><div style="font-size:10px;color:var(--text-2);margin-bottom:4px">' + label + '</div><div style="font-size:15px;font-weight:700;font-variant-numeric:tabular-nums' + (cls ? ';color:var(--' + cls + ')' : '') + '">' + value + '</div></div>';
+            return '<div class="system-stat"><div class="system-stat-label">' + label + '</div><div class="system-stat-value' + (cls ? ' ' + cls : '') + '">' + value + '</div></div>';
         }
         var h = '';
         h += stat('Uptime', d && d.uptime_secs ? BM.formatUptime(d.uptime_secs) : '—');
+        h += stat('Process Uptime', d && d.process_uptime_secs ? BM.formatUptime(d.process_uptime_secs) : '—');
         if (d && d.load_avg) {
             h += stat('Load 1m', d.load_avg[0].toFixed(2));
             h += stat('Load 5m', d.load_avg[1].toFixed(2));

--- a/static/style.css
+++ b/static/style.css
@@ -249,6 +249,41 @@ body {
     padding: 16px 20px;
 }
 
+/* ── System Overview stats grid ── */
+.system-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+    padding: 0 20px 16px;
+}
+
+.system-stat {
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+}
+
+.system-stat-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-2);
+    margin-bottom: 4px;
+}
+
+.system-stat-value {
+    font-size: 16px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: -0.02em;
+    color: var(--text-0);
+}
+
+.system-stat-value.rx { color: var(--rx); }
+.system-stat-value.tx { color: var(--tx); }
+
 /* ── Chart ── */
 .chart-section { margin-bottom: 20px; }
 

--- a/static/style.css
+++ b/static/style.css
@@ -254,7 +254,7 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
     gap: 10px;
-    padding: 0 20px 16px;
+    padding: 16px 20px;
 }
 
 .system-stat {

--- a/static/style.css
+++ b/static/style.css
@@ -12,6 +12,7 @@
     --bg-2: #18181b;
     --bg-3: #1f1f23;
     --bg-hover: #27272a;
+    --card: var(--bg-2);
     --accent: #3b82f6;
     --accent-dim: rgba(59, 130, 246, 0.12);
     --rx: #22d3ee;
@@ -26,6 +27,7 @@
     --success: #22c55e;
     --warning: #eab308;
     --radius: 8px;
+    --font-mono: 'JetBrains Mono', monospace;
 }
 
 /* ── Light theme (explicit) ── */
@@ -751,21 +753,21 @@ canvas { outline: none; }
 }
 
 /* ── WiFi Section ── */
-.wifi-stats-row {
+.wifi-stats-row, .net-stats-row {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 12px;
     margin-bottom: 16px;
 }
 
-.wifi-stat-card {
+.wifi-stat-card, .net-stat-card {
     background: var(--bg-1);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     padding: 14px 18px;
 }
 
-.wifi-stat-label {
+.wifi-stat-label, .net-stat-label {
     font-size: 10px;
     font-weight: 600;
     text-transform: uppercase;
@@ -774,7 +776,7 @@ canvas { outline: none; }
     margin-bottom: 4px;
 }
 
-.wifi-stat-value {
+.wifi-stat-value, .net-stat-value {
     font-size: 22px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
@@ -786,11 +788,10 @@ canvas { outline: none; }
 .wifi-stat-value.clients { color: var(--rx); }
 .wifi-stat-value.ssids { color: var(--tx); }
 
-.wifi-stat-value.net-nodes { color: var(--text-0); }
-.wifi-stat-value.net-gw { color: var(--accent); font-size: 15px; }
-.wifi-stat-value.net-aps { color: #34d399; }
-.wifi-stat-value.net-clients { color: var(--rx); }
-.wifi-stat-value.net-sources { color: var(--text-1); }
+.net-stat-value.net-gw { color: var(--accent); font-size: 15px; }
+.net-stat-value.net-aps { color: #34d399; }
+.net-stat-value.net-clients { color: var(--rx); }
+.net-stat-value.net-sources { color: var(--text-1); }
 
 /* Signal strength badges */
 .signal-badge {
@@ -970,6 +971,32 @@ canvas { outline: none; }
     color: var(--text-0);
     box-shadow: 0 1px 2px rgba(0,0,0,0.08);
 }
+
+/* ── Unified text input / select controls (search, filter, sort) ── */
+.input-control, .select-control {
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg-2);
+    color: var(--text-0);
+    font-size: 13px;
+    font-family: 'Inter', sans-serif;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.select-control { padding: 6px 10px; }
+
+.input-control::placeholder { color: var(--text-2); }
+
+.input-control:focus, .select-control:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-dim);
+}
+
+/* Compact variants for inline card-header filters */
+.input-control--sm { padding: 4px 10px; font-size: 12px; }
+.select-control--sm { padding: 4px 8px; font-size: 12px; }
 
 .nat-badge {
     display: inline-block;

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -1511,9 +1511,6 @@ func (s *Scanner) inferLinks(nodeMap map[string]*Node, linkSet map[string]*Link,
 		if hasUpstream[swMAC] {
 			continue
 		}
-		if gwNode == nil {
-			continue
-		}
 		// Route through the uplink switch if this is a different switch
 		if uplinkSwitch != "" && swMAC != uplinkSwitch {
 			linkKey := fmt.Sprintf("%s|%s", uplinkSwitch, swMAC)
@@ -1522,20 +1519,35 @@ func (s *Scanner) inferLinks(nodeMap map[string]*Node, linkSet map[string]*Link,
 				TargetID: swMAC,
 				Type:     LinkWired,
 			}
-		} else {
-			linkKey := fmt.Sprintf("%s|%s", gwNode.ID, swMAC)
-			linkSet[linkKey] = &Link{
-				SourceID: gwNode.ID,
-				TargetID: swMAC,
-				Type:     LinkWired,
-			}
+			hasUpstream[swMAC] = true
+			continue
+		}
+		// Otherwise this switch uplinks directly into self — self is the
+		// actual LAN router/hub these devices are physically attached to.
+		// Only fall back to the WAN gateway if we have no self node at all
+		// (e.g. self couldn't be discovered), since the gateway is the
+		// upstream-of-self WAN device, not a stand-in for the LAN router.
+		target := selfID
+		if target == "" && gwNode != nil {
+			target = gwNode.ID
+		}
+		if target == "" {
+			continue
+		}
+		linkKey := fmt.Sprintf("%s|%s", target, swMAC)
+		linkSet[linkKey] = &Link{
+			SourceID: target,
+			TargetID: swMAC,
+			Type:     LinkWired,
 		}
 		hasUpstream[swMAC] = true
 	}
 
 	// Ensure every AP has an upstream link.  APs may already be linked
 	// as sources of wireless client links, but they still need a parent
-	// connection (to a switch on the same interface, or to the gateway).
+	// connection (to a switch on the same interface, to self — the LAN
+	// router these devices are physically attached to — or, failing
+	// that, to the WAN gateway).
 	for mac, node := range nodeMap {
 		if node.Type != NodeAP {
 			continue
@@ -1551,6 +1563,9 @@ func (s *Scanner) inferLinks(nodeMap map[string]*Node, linkSet map[string]*Link,
 			if swMAC, ok := lookupSwitch(node.Iface); ok {
 				target = swMAC
 			}
+		}
+		if target == "" && selfID != "" {
+			target = selfID
 		}
 		if target == "" && gwNode != nil {
 			target = gwNode.ID
@@ -1575,7 +1590,9 @@ func (s *Scanner) inferLinks(nodeMap map[string]*Node, linkSet map[string]*Link,
 	}
 
 	// Connect remaining orphan nodes: prefer routing wired clients
-	// through a switch, otherwise connect directly to the gateway.
+	// through a switch, then through self (the LAN router these devices
+	// are physically attached to), and only fall back to the WAN
+	// gateway if self is unknown.
 	for mac, node := range nodeMap {
 		if linked[mac] {
 			continue
@@ -1589,6 +1606,9 @@ func (s *Scanner) inferLinks(nodeMap map[string]*Node, linkSet map[string]*Link,
 			if swMAC, ok := lookupSwitch(node.Iface); ok {
 				target = swMAC
 			}
+		}
+		if target == "" && selfID != "" {
+			target = selfID
 		}
 		if target == "" && gwNode != nil {
 			target = gwNode.ID

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -331,26 +331,50 @@ func (s *Scanner) discoverWANGateway(nodeMap map[string]*Node, linkSet map[strin
 		iface := ifaceNames[n.LinkIndex]
 		id := "wan-" + mac
 
-		if _, exists := nodeMap[id]; exists {
-			continue
-		}
-
-		nodeMap[id] = &Node{
-			ID:       id,
-			MAC:      mac,
-			IPs:      []string{ip},
-			Hostname: "WAN Gateway",
-			Type:     NodeWANGW,
-			Iface:    iface,
-			Source:   "arp",
+		// discoverGateway() may have already created a node for this same
+		// device — keyed by bare MAC — from the default route (e.g. an
+		// ISP router that's both the default gateway and the ARP-visible
+		// device on the WAN interface). Reuse that node instead of adding
+		// a second one, otherwise the same physical device shows up twice
+		// in the tree under two different IDs.
+		if existing, ok := nodeMap[mac]; ok {
+			id = mac
+			existing.Type = NodeWANGW
+			if existing.Hostname == "" {
+				existing.Hostname = "WAN Gateway"
+			}
+			if existing.Iface == "" {
+				existing.Iface = iface
+			}
+			if !slices.Contains(existing.IPs, ip) {
+				existing.IPs = append(existing.IPs, ip)
+			}
+			if !strings.Contains(existing.Source, "arp") {
+				existing.Source += ",arp"
+			}
+		} else {
+			if _, exists := nodeMap[id]; exists {
+				continue
+			}
+			nodeMap[id] = &Node{
+				ID:       id,
+				MAC:      mac,
+				IPs:      []string{ip},
+				Hostname: "WAN Gateway",
+				Type:     NodeWANGW,
+				Iface:    iface,
+				Source:   "arp",
+			}
 		}
 
 		linkKey := fmt.Sprintf("%s|%s", id, selfNode)
-		linkSet[linkKey] = &Link{
-			SourceID: id,
-			TargetID: selfNode,
-			Type:     LinkWAN,
-			Label:    iface,
+		if _, exists := linkSet[linkKey]; !exists {
+			linkSet[linkKey] = &Link{
+				SourceID: id,
+				TargetID: selfNode,
+				Type:     LinkWAN,
+				Label:    iface,
+			}
 		}
 		wanIDs = append(wanIDs, id)
 	}


### PR DESCRIPTION
## Summary

Frontend consistency cleanup plus two real topology bugs found while testing on a live deployment. All API/SSE changes are additive and backward-compatible.

### UI consistency (`c84aec5`)
- Defined previously-undefined `--card` / `--font-mono` CSS vars
- Replaced ~11 inconsistent inline-styled `<input>`/`<select>` elements with new `.input-control` / `.select-control` classes (incl. focus states)
- Fixed the Network tab misusing `.wifi-stat-card` classes; added proper `.net-stat-card` / `.net-stat-label` / `.net-stat-value` classes
- Added `aria-label`/`role` to the connection status dot for a11y

### System Overview (`b18a04b`, `71e253e`)
- Replaced fully inline-styled stat grid with `.system-stats` / `.system-stat` classes
- Added a new **Process Uptime** stat (separate from host uptime), backed by an additive `process_uptime_secs` field on the `/api/events` SSE payload
- Fixed cramped spacing between the stats grid and the divider below the header

### Network topology fixes (`1f4e247`, `f68ee0e`)
- **Wrong parent bug**: `inferLinks()`'s fallback paths for unlinked switches, APs without a matching switch, and orphaned wired clients all defaulted to the WAN gateway node instead of `self` (the actual LAN router), nesting most LAN devices under the wrong parent in the tree. Now they correctly default to `self`.
- **Duplicate WAN gateway node**: `discoverGateway()` (default-route gateway) and `discoverWANGateway()` (ARP-scanned WAN interface) created two separate nodes when they were the same physical device (same MAC) — one keyed by bare MAC, one by `"wan-"+mac`. `discoverWANGateway()` now detects and merges into the existing node instead of duplicating it. Also fixed the Network tab's gateway summary stat to look up by `topo.gateway` id rather than filtering by `type === 'gateway'`, since the merged node may now be typed `wan_gw`.

## Verification

Built `.deb` packages and deployed to a live test host after each change, verifying via `curl` against `/`, `/api/events`, and `/api/topology`:
- Confirmed `process_uptime_secs` present in SSE payload
- Confirmed updated CSS/HTML served (cache-busted `?v=` hashes)
- Before/after topology fix: gateway-fallback bug caused most of 69 nodes to be nested under the WAN gateway; after the fix the WAN gateway has exactly 1 child (self) with self correctly hosting the downstream LAN devices
- Before/after dedup fix: node count went from 69 → 68 (one duplicate WAN gateway node removed), single `wan_gw` node now correctly merges data from both discovery paths (`source: route,arp,ndp`) with one `wan` link to `self`

No breaking changes to existing API responses — all changes are additive fields or frontend-only.