### PR TITLE
Add topology drill-down, device labels/favorites, per-device DNS log

### DIFF
--- a/adguard/adguard.go
+++ b/adguard/adguard.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -141,6 +142,77 @@ func (c *Client) Available() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.stats != nil
+}
+
+// queryLogResponse mirrors the subset of AdGuard Home's /control/querylog
+// response we care about.
+type queryLogResponse struct {
+	Data []struct {
+		Time     string `json:"time"`
+		Client   string `json:"client"`
+		Reason   string `json:"reason"`
+		Status   string `json:"status"`
+		ElapsedM string `json:"elapsedMs"`
+		Question struct {
+			Name string `json:"name"`
+			Type string `json:"type"`
+		} `json:"question"`
+	} `json:"data"`
+}
+
+// QueryLog returns the most recent DNS queries made by clientIP, newest
+// first. It implements dns.ClientQueryLogger. AdGuard Home's "search" query
+// param matches either a domain name or a client IP, so it's constrained
+// here to an exact client match to avoid pulling in unrelated domain hits.
+func (c *Client) QueryLog(clientIP string, limit int) ([]dns.QueryLogEntry, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	url := fmt.Sprintf("%s/control/querylog?search=%s&limit=%d", c.baseURL, clientIP, limit)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.user != "" {
+		req.SetBasicAuth(c.user, c.pass)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("adguard: querylog status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var qlr queryLogResponse
+	if err := json.NewDecoder(resp.Body).Decode(&qlr); err != nil {
+		return nil, err
+	}
+
+	out := make([]dns.QueryLogEntry, 0, len(qlr.Data))
+	for _, e := range qlr.Data {
+		// The search param can also match on domain name, so double-check
+		// the client IP to keep results scoped to this one client.
+		if e.Client != clientIP {
+			continue
+		}
+		elapsed := 0.0
+		fmt.Sscanf(e.ElapsedM, "%f", &elapsed)
+		out = append(out, dns.QueryLogEntry{
+			Time:      e.Time,
+			Domain:    e.Question.Name,
+			Type:      e.Question.Type,
+			Blocked:   strings.HasPrefix(e.Reason, "Filtered"),
+			Reason:    e.Reason,
+			ElapsedMs: elapsed,
+		})
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
 }
 
 func parseDomainEntries(raw []map[string]float64, limit int) []dns.DomainStat {

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -47,3 +47,21 @@ type UpstreamStat struct {
 	Responses int     `json:"responses"`
 	AvgMs     float64 `json:"avg_ms"`
 }
+
+// QueryLogEntry is a single recent DNS query made by a client.
+type QueryLogEntry struct {
+	Time      string  `json:"time"`
+	Domain    string  `json:"domain"`
+	Type      string  `json:"type,omitempty"`
+	Blocked   bool    `json:"blocked"`
+	Reason    string  `json:"reason,omitempty"`
+	ElapsedMs float64 `json:"elapsed_ms,omitempty"`
+}
+
+// ClientQueryLogger is implemented by providers that can return recent
+// per-client query history (e.g. AdGuard Home's /control/querylog). It is
+// intentionally separate from Provider so existing providers that can't
+// support it (NextDNS, Pi-hole today) aren't forced to implement a stub.
+type ClientQueryLogger interface {
+	QueryLog(clientIP string, limit int) ([]QueryLogEntry, error)
+}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -214,6 +214,47 @@ func HostDetail(t *talkers.Tracker, ct *conntrack.Tracker, geoDB *geoip.DB) http
 	}
 }
 
+// HostDNSLog returns recent DNS queries made by a specific client IP, if the
+// configured DNS provider supports per-client query history (currently only
+// AdGuard Home does, via dns.ClientQueryLogger). Additive endpoint; existing
+// clients that don't call it are unaffected.
+func HostDNSLog(dnsProvider dns.Provider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ip := r.URL.Query().Get("ip")
+		if ip == "" {
+			http.Error(w, "ip parameter required", http.StatusBadRequest)
+			return
+		}
+		if len(ip) > 45 {
+			http.Error(w, "invalid ip", http.StatusBadRequest)
+			return
+		}
+
+		type response struct {
+			Available bool                `json:"available"`
+			Queries   []dns.QueryLogEntry `json:"queries"`
+		}
+
+		if dnsProvider == nil || !dnsProvider.Available() {
+			httputil.WriteJSON(w, response{Available: false})
+			return
+		}
+		logger, ok := dnsProvider.(dns.ClientQueryLogger)
+		if !ok {
+			httputil.WriteJSON(w, response{Available: false})
+			return
+		}
+
+		entries, err := logger.QueryLog(ip, 50)
+		if err != nil {
+			log.Printf("host dns log: %v", err)
+			httputil.WriteJSON(w, response{Available: false})
+			return
+		}
+		httputil.WriteJSON(w, response{Available: true, Queries: entries})
+	}
+}
+
 // MenuBarSummary returns a compact JSON snapshot for menu-bar widgets.
 func MenuBarSummary(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ctr *conntrack.Tracker) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -324,6 +324,7 @@ func main() {
 	mux.HandleFunc("/api/wifi", handler.WiFiSummary(wifiProvider))
 	mux.HandleFunc("/api/conntrack", handler.ConntrackSummary(conntrackTracker))
 	mux.HandleFunc("/api/host", handler.HostDetail(talkerTracker, conntrackTracker, geoDB))
+	mux.HandleFunc("/api/host/dns", handler.HostDNSLog(dnsProvider))
 	mux.HandleFunc("/api/latency", handler.LatencyStatus(latencyMonitor))
 	mux.HandleFunc("/api/speedtest/run", handler.SpeedTestRun(speedTester))
 	mux.HandleFunc("/api/speedtest/results", handler.SpeedTestResults(speedTester))

--- a/static/index.html
+++ b/static/index.html
@@ -652,6 +652,9 @@
                         <div class="card-subtitle">Per-client wireless traffic &amp; signal</div>
                     </div>
                     <div style="display:flex;gap:8px;align-items:center">
+                        <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-2);cursor:pointer;white-space:nowrap">
+                            <input type="checkbox" id="wifiPinnedOnly"> Pinned only
+                        </label>
                         <input type="text" id="wifiClientSearch" class="input-control input-control--sm" placeholder="Filter clients…" style="width:180px">
                         <select id="wifiClientSort" class="select-control select-control--sm">
                             <option value="traffic">Sort: Traffic</option>
@@ -664,6 +667,7 @@
                 <table>
                     <thead><tr>
                         <th>#</th>
+                        <th></th>
                         <th>Client</th>
                         <th>SSID</th>
                         <th>AP</th>
@@ -676,7 +680,7 @@
                         <th style="width:14%"></th>
                     </tr></thead>
                     <tbody id="wifiClientTable">
-                        <tr><td colspan="11" class="empty-state">Waiting for data</td></tr>
+                        <tr><td colspan="12" class="empty-state">Waiting for data</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -742,6 +746,9 @@
                     <div class="card-subtitle" id="networkClientCount">0 nodes discovered</div>
                 </div>
                 <div style="display:flex;gap:8px;align-items:center">
+                    <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-2);cursor:pointer;white-space:nowrap">
+                        <input type="checkbox" id="networkPinnedOnly" onchange="window._filterNetworkClients()"> Pinned only
+                    </label>
                     <input type="text" id="networkClientSearch" class="input-control" placeholder="Filter by name, IP, MAC…" style="width:200px" oninput="window._filterNetworkClients()">
                     <select id="networkClientSort" class="select-control select-control--sm" onchange="window._filterNetworkClients()">
                         <option value="type">Sort: Type</option>
@@ -755,6 +762,7 @@
                 <table class="wifi-client-table">
                     <thead>
                         <tr>
+                            <th></th>
                             <th>Type</th>
                             <th>Name / Hostname</th>
                             <th>IP(s)</th>
@@ -1042,6 +1050,8 @@
 
     <!-- Shared utilities -->
     <script src="js/utils.js" defer></script>
+    <script src="js/components/device-labels.js" defer></script>
+    <script src="js/components/device-favorites.js" defer></script>
     <!-- Tab modules (order: tabs before core, core calls connect) -->
     <script src="js/tabs/traffic.js" defer></script>
     <script src="js/tabs/dns.js" defer></script>

--- a/static/js/components/device-favorites.js
+++ b/static/js/components/device-favorites.js
@@ -1,0 +1,77 @@
+(function() {
+    'use strict';
+    var BM = window.BM;
+
+    // ── Favorites / pinned devices ──
+    // Purely client-side (localStorage), keyed the same way as custom
+    // device labels (MAC if known, else IP). Lets operators star devices
+    // they want to keep an eye on (a NAS, a kid's laptop, etc.) and filter
+    // tables down to just those.
+
+    var STORAGE_KEY = 'bm_device_favorites_v1';
+
+    function loadAll() {
+        try {
+            return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') || {};
+        } catch (e) {
+            return {};
+        }
+    }
+
+    function saveAll(map) {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+        } catch (e) { /* localStorage unavailable or full; ignore */ }
+    }
+
+    function normKey(key) {
+        return (key || '').toString().trim().toLowerCase();
+    }
+
+    BM.isFavoriteDevice = function(key) {
+        var k = normKey(key);
+        if (!k) return false;
+        return !!loadAll()[k];
+    };
+
+    BM.setFavoriteDevice = function(key, fav) {
+        var k = normKey(key);
+        if (!k) return;
+        var map = loadAll();
+        if (fav) map[k] = true; else delete map[k];
+        saveAll(map);
+    };
+
+    BM.toggleFavoriteDevice = function(key) {
+        var fav = !BM.isFavoriteDevice(key);
+        BM.setFavoriteDevice(key, fav);
+        return fav;
+    };
+
+    BM.hasAnyFavorites = function() {
+        var map = loadAll();
+        for (var k in map) if (map[k]) return true;
+        return false;
+    };
+
+    // Renders a clickable star button for a device row. `key` is the
+    // MAC/IP used for storage; stopPropagation keeps it from also
+    // triggering a parent row's click-to-open-modal handler.
+    BM.favoriteStarHtml = function(key) {
+        if (!key) return '';
+        var fav = BM.isFavoriteDevice(key);
+        return '<span class="fav-star' + (fav ? ' fav-star-active' : '') + '" data-fav-key="' +
+            BM.escSvg(key) + '" title="' + (fav ? 'Unpin device' : 'Pin device') + '" ' +
+            'onclick="event.stopPropagation();window._toggleFavoriteStar(this)">' + (fav ? '\u2605' : '\u2606') + '</span>';
+    };
+
+    window._toggleFavoriteStar = function(el) {
+        var key = el.getAttribute('data-fav-key');
+        var fav = BM.toggleFavoriteDevice(key);
+        el.classList.toggle('fav-star-active', fav);
+        el.textContent = fav ? '\u2605' : '\u2606';
+        el.title = fav ? 'Unpin device' : 'Pin device';
+        if (window._refreshAllViews) window._refreshAllViews();
+        else if (window._refreshFavoriteFilters) window._refreshFavoriteFilters();
+    };
+})();

--- a/static/js/components/device-labels.js
+++ b/static/js/components/device-labels.js
@@ -1,0 +1,68 @@
+(function() {
+    'use strict';
+    var BM = window.BM;
+
+    // ── Custom device names/labels ──
+    // Purely client-side (localStorage), keyed by MAC address when known,
+    // falling back to IP. Lets operators rename "client 192.168.1.47" to
+    // something meaningful ("Kid's Xbox") without any backend changes —
+    // the override is applied wherever a hostname/name would be shown.
+
+    var STORAGE_KEY = 'bm_device_labels_v1';
+
+    function loadAll() {
+        try {
+            return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') || {};
+        } catch (e) {
+            return {};
+        }
+    }
+
+    function saveAll(map) {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+        } catch (e) { /* localStorage unavailable or full; ignore */ }
+    }
+
+    function normKey(key) {
+        return (key || '').toString().trim().toLowerCase();
+    }
+
+    // Returns the raw custom label for a single key, or '' if none set.
+    BM.getDeviceLabel = function(key) {
+        var k = normKey(key);
+        if (!k) return '';
+        var map = loadAll();
+        return map[k] || '';
+    };
+
+    // Sets (or clears, if name is empty) the custom label for a key.
+    BM.setDeviceLabel = function(key, name) {
+        var k = normKey(key);
+        if (!k) return;
+        var map = loadAll();
+        name = (name || '').trim();
+        if (name) map[k] = name; else delete map[k];
+        saveAll(map);
+    };
+
+    // Resolves the best display name for a device: custom label (by MAC,
+    // then by IP) takes priority over the discovered hostname/fallback.
+    BM.deviceDisplayName = function(mac, ips, fallback) {
+        var label = BM.getDeviceLabel(mac);
+        if (!label && ips && ips.length) {
+            for (var i = 0; i < ips.length && !label; i++) {
+                label = BM.getDeviceLabel(ips[i]);
+            }
+        }
+        return label || fallback || '';
+    };
+
+    // Returns the primary key (mac if present, else first ip) used to store
+    // a label for a device, so callers can wire up rename UI consistently.
+    BM.deviceLabelKey = function(mac, ips) {
+        if (mac) return mac;
+        if (ips && ips.length) return ips[0];
+        return '';
+    };
+})();

--- a/static/js/components/host-modal.js
+++ b/static/js/components/host-modal.js
@@ -3,12 +3,14 @@
     var BM = window.BM;
 
     // ── Host Detail Modal ──
-    window._openHostModal = function(ip) {
+    window._openHostModal = function(ip, mac) {
         var modal = document.getElementById('hostModal');
         var body = document.getElementById('hostModalBody');
         var title = document.getElementById('hostModalTitle');
         var subtitle = document.getElementById('hostModalSubtitle');
         modal.style.display = '';
+        modal.dataset.ip = ip;
+        modal.dataset.mac = mac || '';
         title.textContent = ip;
         subtitle.textContent = 'Loading…';
         body.innerHTML = '<div style="text-align:center;padding:32px;color:var(--text-2)">Loading…</div>';
@@ -16,9 +18,36 @@
 
         fetch('/api/host?ip=' + encodeURIComponent(ip))
             .then(function(r) { return r.json(); })
-            .then(function(d) { renderHostModal(d, title, subtitle, body); })
+            .then(function(d) {
+                d._mac = mac || '';
+                renderHostModal(d, title, subtitle, body);
+                loadHostDNSLog(ip, body);
+            })
             .catch(function(e) { body.innerHTML = '<div style="text-align:center;padding:32px;color:var(--danger)">Failed to load: ' + e + '</div>'; });
     };
+
+    window._renameHostDevice = function() {
+        var modal = document.getElementById('hostModal');
+        var ip = modal.dataset.ip;
+        var mac = modal.dataset.mac;
+        var key = BM.deviceLabelKey(mac, ip ? [ip] : []);
+        if (!key) return;
+        var current = BM.getDeviceLabel(key);
+        var name = window.prompt('Custom name for ' + (mac || ip) + ':', current);
+        if (name === null) return;
+        BM.setDeviceLabel(key, name);
+        var title = document.getElementById('hostModalTitle');
+        var d = title._lastData;
+        if (d) {
+            var flag = d.country ? BM.countryFlag(d.country) + ' ' : '';
+            title.innerHTML = flag + BM.escSvg(name.trim() || d.hostname || d.ip) + renamePencilHtml();
+        }
+        if (window._refreshAllViews) window._refreshAllViews();
+    };
+
+    function renamePencilHtml() {
+        return ' <span class="device-name-edit" title="Rename this device" onclick="window._renameHostDevice()">&#9998;</span>';
+    }
 
     window._closeHostModal = function() {
         document.getElementById('hostModal').style.display = 'none';
@@ -34,7 +63,9 @@
 
     function renderHostModal(d, titleEl, subtitleEl, bodyEl) {
         var flag = d.country ? BM.countryFlag(d.country) + ' ' : '';
-        titleEl.textContent = flag + (d.hostname || d.ip);
+        var displayName = BM.deviceDisplayName(d._mac, [d.ip], d.hostname) || d.hostname || d.ip;
+        titleEl.innerHTML = flag + BM.escSvg(displayName) + renamePencilHtml();
+        titleEl._lastData = d;
         var sub = d.ip;
         if (d.city && d.country_name) sub += ' \u00b7 ' + d.city + ', ' + d.country_name;
         else if (d.country_name) sub += ' \u00b7 ' + d.country_name;
@@ -114,7 +145,49 @@
             h += '<div style="text-align:center;padding:20px;color:var(--text-2);font-size:13px">No active connections tracked for this host</div>';
         }
 
+        // Recent DNS queries — filled in asynchronously by loadHostDNSLog()
+        // once /api/host/dns responds, since it may hit a slower remote
+        // DNS provider API rather than in-memory state like the rest of
+        // this modal.
+        h += '<div id="hostDNSSection" style="margin-top:20px"></div>';
+
         bodyEl.innerHTML = h;
+    }
+
+    function loadHostDNSLog(ip, bodyEl) {
+        var section = bodyEl.querySelector('#hostDNSSection');
+        if (!section) return;
+        fetch('/api/host/dns?ip=' + encodeURIComponent(ip))
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                if (!d || !d.available || !d.queries || !d.queries.length) return;
+                var h = '<div style="font-size:14px;font-weight:600;margin-bottom:10px">Recent DNS Queries <span style="font-weight:400;color:var(--text-2);font-size:12px">(' + d.queries.length + ')</span></div>';
+                h += '<div style="overflow-x:auto;max-height:250px;overflow-y:auto;border:1px solid var(--border);border-radius:8px">';
+                h += '<table style="width:100%;font-size:12px;border-collapse:collapse"><thead><tr style="background:var(--bg-2);position:sticky;top:0">';
+                h += '<th style="padding:8px 10px;text-align:left;font-size:11px;font-weight:600;color:var(--text-2)">Time</th>';
+                h += '<th style="padding:8px 10px;text-align:left;font-size:11px;font-weight:600;color:var(--text-2)">Domain</th>';
+                h += '<th style="padding:8px 10px;text-align:left;font-size:11px;font-weight:600;color:var(--text-2)">Type</th>';
+                h += '<th style="padding:8px 10px;text-align:left;font-size:11px;font-weight:600;color:var(--text-2)">Result</th>';
+                h += '</tr></thead><tbody>';
+                for (var i = 0; i < d.queries.length; i++) {
+                    var q = d.queries[i];
+                    var rowBg = i % 2 === 0 ? '' : ' style="background:var(--bg-1)"';
+                    var t = q.time ? new Date(q.time) : null;
+                    var timeStr = t && !isNaN(t.getTime()) ? t.toLocaleTimeString() : '—';
+                    var resultHtml = q.blocked
+                        ? '<span style="color:var(--danger)">Blocked</span>'
+                        : '<span style="color:var(--text-2)">Allowed</span>';
+                    h += '<tr' + rowBg + '>';
+                    h += '<td style="padding:6px 10px;white-space:nowrap;color:var(--text-2)">' + timeStr + '</td>';
+                    h += '<td style="padding:6px 10px;font-family:var(--font-mono,monospace);font-size:11px">' + BM.escSvg(q.domain || '') + '</td>';
+                    h += '<td style="padding:6px 10px;color:var(--text-2)">' + (q.type || '—') + '</td>';
+                    h += '<td style="padding:6px 10px">' + resultHtml + '</td>';
+                    h += '</tr>';
+                }
+                h += '</tbody></table></div>';
+                section.innerHTML = h;
+            })
+            .catch(function() { /* DNS provider unavailable or doesn't support per-client logs; leave section empty */ });
     }
 
     function renderHostHistoryChart(history) {

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -284,9 +284,9 @@
     BM._origUpdateWiFi = null;
     // Wrap updateWiFi after wifi-tab.js loads — defer wiring
     (function wireWiFiRerender() {
-        ['wifiClientSearch', 'wifiClientSort'].forEach(function(id) {
+        ['wifiClientSearch', 'wifiClientSort', 'wifiPinnedOnly'].forEach(function(id) {
             var el = document.getElementById(id);
-            if (el) el.addEventListener(id === 'wifiClientSearch' ? 'input' : 'change', function() {
+            if (el) el.addEventListener((id === 'wifiClientSearch') ? 'input' : 'change', function() {
                 if (_lastWiFi && BM.updateWiFi) BM.updateWiFi(_lastWiFi);
             });
         });
@@ -303,6 +303,14 @@
             }
         }, 100);
     })();
+
+    // Re-renders every tab that shows device tables, so toggling a pin/star
+    // (which is stored client-side only) is reflected everywhere immediately
+    // without waiting for the next SSE tick.
+    window._refreshAllViews = function() {
+        if (_lastWiFi && BM.updateWiFi) BM.updateWiFi(_lastWiFi);
+        if (window._filterNetworkClients) window._filterNetworkClients();
+    };
 
     connect();
 })();

--- a/static/js/tabs/network.js
+++ b/static/js/tabs/network.js
@@ -4,6 +4,8 @@
 
     var _lastTopology = null;
     var _lastBandwidth = [];
+    var _selectedNodeId = null;
+    var _lastNodeById = {};
 
     BM.updateNetwork = function(topo, bandwidth) {
         if (!topo || !topo.nodes || !topo.nodes.length) {
@@ -56,6 +58,7 @@
         var nodes = (_lastTopology.nodes || []).slice();
         var filter = ((document.getElementById('networkClientSearch') || {}).value || '').toLowerCase();
         var sortKey = ((document.getElementById('networkClientSort') || {}).value || 'type');
+        var pinnedOnly = !!(document.getElementById('networkPinnedOnly') || {}).checked;
 
         if (filter) {
             nodes = nodes.filter(function(n) {
@@ -66,6 +69,9 @@
                        (n.ssid || '').toLowerCase().indexOf(filter) !== -1 ||
                        (n.source || '').toLowerCase().indexOf(filter) !== -1;
             });
+        }
+        if (pinnedOnly) {
+            nodes = nodes.filter(function(n) { return BM.isFavoriteDevice(BM.deviceLabelKey(n.mac, n.ips)); });
         }
 
         if (sortKey === 'name') {
@@ -78,7 +84,7 @@
 
         var tb = document.getElementById('networkClientTable');
         if (!nodes.length) {
-            tb.innerHTML = '<tr><td colspan="9" class="empty-state">' + (filter ? 'No matching nodes' : 'No nodes discovered') + '</td></tr>';
+            tb.innerHTML = '<tr><td colspan="10" class="empty-state">' + (filter || pinnedOnly ? 'No matching nodes' : 'No nodes discovered') + '</td></tr>';
             return;
         }
         var h = '';
@@ -90,9 +96,12 @@
             if (n.signal && n.signal !== 0) {
                 sigStr = n.signal + ' dBm';
             }
+            var favKey = BM.deviceLabelKey(n.mac, n.ips);
+            var displayName = BM.deviceDisplayName(n.mac, n.ips, n.hostname);
             h += '<tr>';
+            h += '<td>' + BM.favoriteStarHtml(favKey) + '</td>';
             h += '<td><span class="net-type-badge net-type-' + n.type + '">' + typeIcon + ' ' + typeLabel + '</span></td>';
-            h += '<td>' + (n.hostname || '<span style="color:var(--text-2)">—</span>') + '</td>';
+            h += '<td>' + (displayName || '<span style="color:var(--text-2)">—</span>') + '</td>';
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + formatClickableIPs(n.ips) + '</td>';
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + (n.mac || '—') + '</td>';
             h += '<td>' + (n.iface || '—') + '</td>';
@@ -104,6 +113,7 @@
         }
         tb.innerHTML = h;
     };
+    window._refreshFavoriteFilters = window._filterNetworkClients;
 
     function formatClickableIPs(ips) {
         if (!ips || !ips.length) return '—';
@@ -241,6 +251,45 @@
             }
         });
 
+        // Parent map (BFS from root over the adjacency list) used to trace
+        // the path from any clicked node back up to the gateway/root,
+        // independent of which layout (tree/radial) is currently active.
+        var nodeParent = {};
+        (function computeParents() {
+            var visited = {};
+            visited[rootId] = true;
+            var queue = [rootId];
+            while (queue.length > 0) {
+                var cur = queue.shift();
+                var kids = childrenMap[cur] || [];
+                for (var i = 0; i < kids.length; i++) {
+                    var kid = kids[i].id;
+                    if (!visited[kid]) {
+                        visited[kid] = true;
+                        nodeParent[kid] = cur;
+                        queue.push(kid);
+                    }
+                }
+            }
+        })();
+
+        // Build the set of nodes/links along the path from the currently
+        // selected node up to the root, for the click-to-highlight feature.
+        var highlightNodes = {};
+        var highlightLinks = {};
+        if (_selectedNodeId && nodeById[_selectedNodeId]) {
+            var cur = _selectedNodeId;
+            highlightNodes[cur] = true;
+            var guard = 0;
+            while (nodeParent[cur] !== undefined && guard++ < 1000) {
+                var p = nodeParent[cur];
+                highlightLinks[cur + '|' + p] = true;
+                highlightLinks[p + '|' + cur] = true;
+                highlightNodes[p] = true;
+                cur = p;
+            }
+        }
+
         // Sort children so that downstream infrastructure (gateway, switch,
         // ap) comes first, keeping WAN/tunnel nodes to the edges.
         var childSortPrio = { 'gateway': 0, 'self': 1, 'switch': 2, 'ap': 3, 'client': 4, 'wan_gw': 5, 'tunnel': 6 };
@@ -291,6 +340,9 @@
             var from = nodePositions[l.source];
             var to = nodePositions[l.target];
             if (!from || !to) return;
+            if (highlightLinks[l.source + '|' + l.target]) {
+                svgHtml += '<line x1="' + from.x + '" y1="' + from.y + '" x2="' + to.x + '" y2="' + to.y + '" stroke="#fbbf24" stroke-width="4.5" stroke-linecap="round" opacity="0.55"/>';
+            }
             var dash = '';
             var col = lineCol;
             var sw = '1.5';
@@ -363,6 +415,13 @@
             if (!node) continue;
             var r = nodeRadius(node.type);
             var fill = nodeColor(node.type);
+            var isSelected = !!highlightNodes[nid];
+            svgHtml += '<g class="net-node" data-id="' + BM.escSvg(nid) + '">';
+            // Larger invisible hit area makes small client nodes easy to click.
+            svgHtml += '<circle cx="' + pos.x + '" cy="' + pos.y + '" r="' + (r + 10) + '" fill="transparent"/>';
+            if (isSelected) {
+                svgHtml += '<circle cx="' + pos.x + '" cy="' + pos.y + '" r="' + (r + 6) + '" fill="none" stroke="#fbbf24" stroke-width="2.5" opacity="0.85"><animate attributeName="opacity" values="0.85;0.35;0.85" dur="1.4s" repeatCount="indefinite"/></circle>';
+            }
             svgHtml += '<circle cx="' + pos.x + '" cy="' + pos.y + '" r="' + r + '" fill="' + fill + '" stroke="' + fill + '" stroke-width="2" fill-opacity="0.15"/>';
             var nr = nodeRates[nid];
             if (nr && nr.total > 0) {
@@ -374,14 +433,16 @@
             }
             var emoji = node.type === 'client' && node.device_class ? deviceClassEmoji(node.device_class) : nodeTypeEmoji(node.type);
             svgHtml += '<text x="' + pos.x + '" y="' + (pos.y + 4) + '" text-anchor="middle" font-size="' + (r > 14 ? 14 : 11) + '" fill="' + fill + '">' + emoji + '</text>';
-            var label = node.hostname || (node.ips && node.ips[0]) || node.mac || node.id;
+            var label = BM.deviceDisplayName(node.mac, node.ips, node.hostname) || (node.ips && node.ips[0]) || node.mac || node.id;
             if (label.length > 20) label = label.substring(0, 18) + '…';
             svgHtml += '<text x="' + pos.x + '" y="' + (pos.y + r + 14) + '" text-anchor="middle" font-size="11" fill="' + textCol + '">' + BM.escSvg(label) + '</text>';
             var typeLabel = node.device_class || node.type;
             svgHtml += '<text x="' + pos.x + '" y="' + (pos.y + r + 26) + '" text-anchor="middle" font-size="9" fill="' + textCol2 + '">' + typeLabel + '</text>';
+            svgHtml += '</g>';
         }
 
         svg.innerHTML = svgHtml;
+        _lastNodeById = nodeById;
 
         // Tooltip
         var tipEl = document.getElementById('netTooltip');
@@ -391,7 +452,7 @@
             tipEl.style.cssText = 'position:fixed;pointer-events:none;background:var(--card);color:var(--text-0);border:1px solid var(--border);padding:6px 10px;border-radius:6px;font-size:12px;font-family:Inter,sans-serif;z-index:9999;display:none;white-space:nowrap;box-shadow:0 4px 12px rgba(0,0,0,0.15)';
             document.body.appendChild(tipEl);
         }
-        // Bind hover listeners once: the SVG element persists across re-renders
+        // Bind hover/click listeners once: the SVG element persists across re-renders
         // (only its innerHTML is replaced), so re-adding them every render — which
         // runs on every SSE tick — leaked a handler per tick. Delegation via
         // closest() keeps working after the innerHTML swaps.
@@ -409,6 +470,19 @@
                 }
             });
             svg.addEventListener('mouseleave', function() { tipEl.style.display = 'none'; });
+            svg.style.cursor = 'default';
+            svg.addEventListener('click', function(e) {
+                var el = e.target.closest('.net-node');
+                if (!el) return;
+                var id = el.getAttribute('data-id');
+                var node = _lastNodeById[id];
+                if (!node) return;
+                _selectedNodeId = (_selectedNodeId === id) ? null : id;
+                if (_lastTopology) renderNetworkTopology(_lastTopology, _lastBandwidth);
+                if (node.ips && node.ips.length) {
+                    window._openHostModal(node.ips[0], node.mac);
+                }
+            });
         }
     }
 

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -545,7 +545,7 @@
 
     BM.renderTalkers = function(tid, talkers, vk, fmt, cls) {
         var tb = document.getElementById(tid);
-        if (!talkers || !talkers.length) { tb.innerHTML = '<tr><td colspan="5" class="empty-state">No data &mdash; requires root / CAP_NET_RAW</td></tr>'; return; }
+        if (!talkers || !talkers.length) { tb.innerHTML = '<tr><td colspan="6" class="empty-state">No data &mdash; requires root / CAP_NET_RAW</td></tr>'; return; }
 
         var hasDirection = false;
         for (var di = 0; di < talkers.length; di++) {
@@ -561,10 +561,12 @@
             var geoName = (t.city && t.country_name) ? t.city + ', ' + t.country_name : (t.country_name || '');
             if (t.as_org) geo = '<span class="hostname">' + flag + geoName + ' &middot; AS' + (t.asn || '') + ' ' + t.as_org + '</span>';
             else if (geoName) geo = '<span class="hostname">' + flag + geoName + '</span>';
-            var host = t.hostname && t.hostname !== t.ip
-                ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span><span class="hostname">' + t.hostname + '</span>' + geo
+            var displayName = BM.deviceDisplayName(null, [t.ip], t.hostname);
+            var host = displayName && displayName !== t.ip
+                ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span><span class="hostname">' + displayName + '</span>' + geo
                 : '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span>' + geo;
             h += '<tr><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
+            h += '<td>' + BM.favoriteStarHtml(t.ip) + '</td>';
             h += '<td>' + host + '</td>';
             if (hasDirection) {
                 if (isRate) {
@@ -582,9 +584,9 @@
         var thead = tb.parentElement.querySelector('thead tr');
         if (thead) {
             if (hasDirection) {
-                thead.innerHTML = '<th>#</th><th>Host</th><th style="width:12%">RX</th><th style="width:12%">TX</th><th style="width:12%">Total</th><th style="width:18%"></th>';
+                thead.innerHTML = '<th>#</th><th></th><th>Host</th><th style="width:12%">RX</th><th style="width:12%">TX</th><th style="width:12%">Total</th><th style="width:18%"></th>';
             } else {
-                thead.innerHTML = '<th>#</th><th>Host</th><th>' + (isRate ? 'Rate' : 'Total') + '</th><th style="width:28%"></th>';
+                thead.innerHTML = '<th>#</th><th></th><th>Host</th><th>' + (isRate ? 'Rate' : 'Total') + '</th><th style="width:28%"></th>';
             }
         }
         tb.innerHTML = h;

--- a/static/js/tabs/wifi.js
+++ b/static/js/tabs/wifi.js
@@ -156,10 +156,14 @@
                        (cl.ap_name || '').toLowerCase().indexOf(filter) !== -1;
             });
         }
+        var pinnedOnly = !!(document.getElementById('wifiPinnedOnly') || {}).checked;
+        if (pinnedOnly) {
+            clients = clients.filter(function(cl) { return BM.isFavoriteDevice(BM.deviceLabelKey(cl.mac, cl.ip ? [cl.ip] : [])); });
+        }
 
         var ctb = document.getElementById('wifiClientTable');
         if (!clients.length) {
-            ctb.innerHTML = '<tr><td colspan="11" class="empty-state">' + (filter ? 'No matching clients' : 'No wireless clients') + '</td></tr>';
+            ctb.innerHTML = '<tr><td colspan="12" class="empty-state">' + (filter || pinnedOnly ? 'No matching clients' : 'No wireless clients') + '</td></tr>';
         } else {
             var maxBw = 1;
             for (var i = 0; i < clients.length; i++) {
@@ -171,13 +175,18 @@
                 var cl = clients[i];
                 var total = (cl.tx_bytes || 0) + (cl.rx_bytes || 0);
                 var pct = maxBw > 0 ? ((total / maxBw) * 100).toFixed(1) : '0';
-                var name = cl.hostname || cl.ip || cl.mac || '—';
+                var ips = cl.ip ? [cl.ip] : [];
+                var name = BM.deviceDisplayName(cl.mac, ips, cl.hostname) || cl.ip || cl.mac || '—';
                 var sub = cl.ip && cl.hostname ? cl.ip : (cl.mac || '');
                 var sig = cl.signal || 0;
                 var sigClass = sig >= -50 ? 'sig-great' : sig >= -65 ? 'sig-good' : sig >= -75 ? 'sig-ok' : 'sig-weak';
+                var favKey = BM.deviceLabelKey(cl.mac, ips);
                 ch += '<tr>';
                 ch += '<td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
-                ch += '<td><span class="ip-cell">' + name + '</span>';
+                ch += '<td>' + BM.favoriteStarHtml(favKey) + '</td>';
+                ch += '<td>';
+                if (cl.ip) ch += '<span class="ip-cell ip-clickable" data-ip="' + cl.ip + '">' + name + '</span>';
+                else ch += '<span class="ip-cell">' + name + '</span>';
                 if (sub && sub !== name) ch += '<div style="font-size:10px;color:var(--text-2);font-family:JetBrains Mono,monospace">' + sub + '</div>';
                 ch += '</td>';
                 ch += '<td style="font-size:12px">' + (cl.ssid || '—') + '</td>';

--- a/static/style.css
+++ b/static/style.css
@@ -1357,6 +1357,18 @@ canvas { outline: none; }
 .ip-clickable { cursor: pointer; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; }
 .ip-clickable:hover { color: var(--accent); }
 
+/* Favorite/pin star used on device rows across Network, WiFi, and Traffic tables */
+.fav-star { cursor: pointer; color: var(--text-3); font-size: 14px; margin-right: 4px; user-select: none; display: inline-block; }
+.fav-star:hover { color: var(--accent); }
+.fav-star-active { color: #eab308; }
+
+.net-node { cursor: pointer; }
+.net-node:hover circle:nth-child(2) { filter: brightness(1.3); }
+
+/* Device rename affordance in the host modal */
+.device-name-edit { cursor: pointer; color: var(--text-2); font-size: 12px; margin-left: 6px; opacity: 0.7; }
+.device-name-edit:hover { opacity: 1; color: var(--accent); }
+
 /* ── Network Topology Tab ── */
 .net-type-badge {
     display: inline-flex; align-items: center; gap: 4px;


### PR DESCRIPTION
## Summary
Richer topology/WiFi/DNS visualizations, per-device drill-downs, and home-network-specific UX, as a follow-up to #101.

- **Clickable topology nodes**: clicking a node in the Network topology SVG opens the host detail modal and highlights the path from that node up to the gateway/root.
- **Custom device names**: devices can be given a custom display name (stored client-side, keyed by MAC/IP), shown consistently across the Network, WiFi, and Traffic tables, with a rename (✎) affordance in the host modal.
- **Favorites/pinning**: devices can be pinned as favorites (client-side), with a "Pinned only" filter on the Network and WiFi client tables.
- **Per-device DNS query drill-down**: the host modal now shows a "Recent DNS Queries" section, backed by a new optional `dns.ClientQueryLogger` interface implemented for AdGuard Home (via its `querylog` API), exposed at the new `/api/host/dns` endpoint. Degrades gracefully (empty/hidden section) when the configured DNS provider doesn't support it.

## Compatibility
- All backend changes are additive: `dns.Provider` is unchanged, `dns.ClientQueryLogger` is a new optional interface, and `/api/host/dns` is a new endpoint. Existing `/api/host` and `/api/topology` responses are unchanged.
- Custom labels and favorites are stored entirely client-side (localStorage); no new persisted server-side state.

## Testing
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build` succeeds.
- `gofmt -l` clean on all changed Go files.
- `node --check` passes on all changed/new JS files.
- Built a `.deb`, deployed to a live test host, and verified: new JS/CSS assets load, `/api/host/dns` responds with `available`/`queries` (and returns `available: true` when AdGuard is configured), `/api/host` and `/api/topology` responses are unaffected, and the service starts cleanly under systemd.