### PR TITLE
Fix security/concurrency bugs and XSS/race issues found in deep audit

### DIFF
--- a/adguard/adguard.go
+++ b/adguard/adguard.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -168,8 +169,8 @@ func (c *Client) QueryLog(clientIP string, limit int) ([]dns.QueryLogEntry, erro
 	if limit <= 0 || limit > 200 {
 		limit = 50
 	}
-	url := fmt.Sprintf("%s/control/querylog?search=%s&limit=%d", c.baseURL, clientIP, limit)
-	req, err := http.NewRequest("GET", url, nil)
+	reqURL := fmt.Sprintf("%s/control/querylog?search=%s&limit=%d", c.baseURL, url.QueryEscape(clientIP), limit)
+	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -225,7 +225,7 @@ func HostDNSLog(dnsProvider dns.Provider) http.HandlerFunc {
 			http.Error(w, "ip parameter required", http.StatusBadRequest)
 			return
 		}
-		if len(ip) > 45 {
+		if len(ip) > 45 || net.ParseIP(ip) == nil {
 			http.Error(w, "invalid ip", http.StatusBadRequest)
 			return
 		}
@@ -250,6 +250,9 @@ func HostDNSLog(dnsProvider dns.Provider) http.HandlerFunc {
 			log.Printf("host dns log: %v", err)
 			httputil.WriteJSON(w, response{Available: false})
 			return
+		}
+		if entries == nil {
+			entries = []dns.QueryLogEntry{}
 		}
 		httputil.WriteJSON(w, response{Available: true, Queries: entries})
 	}

--- a/pihole/pihole.go
+++ b/pihole/pihole.go
@@ -125,9 +125,13 @@ func (c *Client) Run() { c.Runner.Run(c.interval, c.poll) }
 
 // authenticate obtains (or reuses) a session ID from the Pi-hole API.
 func (c *Client) authenticate() (string, error) {
+	c.mu.RLock()
 	if c.sid != "" && time.Now().Before(c.sidExpiry.Add(-30*time.Second)) {
-		return c.sid, nil
+		sid := c.sid
+		c.mu.RUnlock()
+		return sid, nil
 	}
+	c.mu.RUnlock()
 
 	body, _ := json.Marshal(authReq{Password: c.password})
 	resp, err := c.httpClient.Post(c.baseURL+"/api/auth", "application/json", bytes.NewReader(body))
@@ -149,9 +153,12 @@ func (c *Client) authenticate() (string, error) {
 		return "", fmt.Errorf("auth: session not valid (wrong password?)")
 	}
 
+	c.mu.Lock()
 	c.sid = ar.Session.SID
 	c.sidExpiry = time.Now().Add(time.Duration(ar.Session.Validity) * time.Second)
-	return c.sid, nil
+	sid := c.sid
+	c.mu.Unlock()
+	return sid, nil
 }
 
 func (c *Client) apiGet(path string, target interface{}) error {
@@ -175,7 +182,9 @@ func (c *Client) apiGet(path string, target interface{}) error {
 
 	// If we get 401, invalidate the SID and retry once
 	if resp.StatusCode == http.StatusUnauthorized {
+		c.mu.Lock()
 		c.sid = ""
+		c.mu.Unlock()
 		sid, err = c.authenticate()
 		if err != nil {
 			return fmt.Errorf("re-auth: %w", err)

--- a/static/js/components/host-modal.js
+++ b/static/js/components/host-modal.js
@@ -19,11 +19,18 @@
         fetch('/api/host?ip=' + encodeURIComponent(ip))
             .then(function(r) { return r.json(); })
             .then(function(d) {
+                // Guard against a stale response: if the user opened a
+                // different host before this fetch resolved, don't clobber
+                // the modal with the wrong host's data.
+                if (modal.dataset.ip !== ip) return;
                 d._mac = mac || '';
                 renderHostModal(d, title, subtitle, body);
                 loadHostDNSLog(ip, body);
             })
-            .catch(function(e) { body.innerHTML = '<div style="text-align:center;padding:32px;color:var(--danger)">Failed to load: ' + e + '</div>'; });
+            .catch(function(e) {
+                if (modal.dataset.ip !== ip) return;
+                body.innerHTML = '<div style="text-align:center;padding:32px;color:var(--danger)">Failed to load: ' + e + '</div>';
+            });
     };
 
     window._renameHostDevice = function() {
@@ -157,9 +164,11 @@
     function loadHostDNSLog(ip, bodyEl) {
         var section = bodyEl.querySelector('#hostDNSSection');
         if (!section) return;
+        var modal = document.getElementById('hostModal');
         fetch('/api/host/dns?ip=' + encodeURIComponent(ip))
             .then(function(r) { return r.json(); })
             .then(function(d) {
+                if (modal.dataset.ip !== ip) return;
                 if (!d || !d.available || !d.queries || !d.queries.length) return;
                 var h = '<div style="font-size:14px;font-weight:600;margin-bottom:10px">Recent DNS Queries <span style="font-weight:400;color:var(--text-2);font-size:12px">(' + d.queries.length + ')</span></div>';
                 h += '<div style="overflow-x:auto;max-height:250px;overflow-y:auto;border:1px solid var(--border);border-radius:8px">';

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -4,7 +4,11 @@
 
     // ── Theme management ──
     (function initTheme() {
-        var saved = localStorage.getItem('bw-theme') || 'auto';
+        function getSavedTheme() {
+            try { return localStorage.getItem('bw-theme') || 'auto'; }
+            catch (e) { return 'auto'; }
+        }
+        var saved = getSavedTheme();
         document.documentElement.setAttribute('data-theme', saved);
         var toggle = document.getElementById('themeToggle');
         if (toggle) {
@@ -17,14 +21,14 @@
                 if (!btn) return;
                 var val = btn.getAttribute('data-theme-val');
                 document.documentElement.setAttribute('data-theme', val);
-                localStorage.setItem('bw-theme', val);
+                try { localStorage.setItem('bw-theme', val); } catch (e) { /* localStorage unavailable (private browsing, disabled, or full) */ }
                 btns.forEach(function(b) { b.classList.toggle('active', b.getAttribute('data-theme-val') === val); });
                 if (BM._updateChartsForTheme) BM._updateChartsForTheme();
             });
         }
         if (window.matchMedia) {
             window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
-                if ((localStorage.getItem('bw-theme') || 'auto') === 'auto' && BM._updateChartsForTheme) BM._updateChartsForTheme();
+                if (getSavedTheme() === 'auto' && BM._updateChartsForTheme) BM._updateChartsForTheme();
             });
         }
     })();

--- a/static/js/tabs/monitor.js
+++ b/static/js/tabs/monitor.js
@@ -240,9 +240,9 @@
             for (var i = 0; i < countries.length; i++) {
                 var c = countries[i];
                 var pct = total > 0 ? (c.bytes / total * 100) : 0;
-                th += '<div style="display:flex;align-items:center;gap:6px;padding:3px 6px;border-radius:4px;background:var(--bg-1);cursor:pointer" onclick="window._focusCountryTraffic(\'' + c.country + '\')" title="Find in Top Talkers">';
+                th += '<div style="display:flex;align-items:center;gap:6px;padding:3px 6px;border-radius:4px;background:var(--bg-1);cursor:pointer" onclick="window._focusCountryTraffic(\'' + BM.escJs(c.country) + '\')" title="Find in Top Talkers">';
                 th += '<span style="width:20px;text-align:center">' + BM.countryFlag(c.country) + '</span>';
-                th += '<span style="font-weight:600;width:24px">' + c.country + '</span>';
+                th += '<span style="font-weight:600;width:24px">' + BM.escSvg(c.country) + '</span>';
                 th += '<div style="flex:1;height:6px;background:var(--bg-2);border-radius:3px;overflow:hidden"><div style="width:' + Math.max(2, pct).toFixed(1) + '%;height:100%;background:' + activeColor + ';border-radius:3px;opacity:0.7"></div></div>';
                 th += '<span style="font-variant-numeric:tabular-nums;color:var(--text-2);min-width:55px;text-align:right">' + BM.formatBytes(c.bytes) + '</span>';
                 th += '<span style="color:var(--text-3);min-width:38px;text-align:right">' + pct.toFixed(1) + '%</span>';

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -174,7 +174,7 @@
         var h = '<div class="iface-tab' + (selectedHistoryIface === null ? ' active' : '') + '" onclick="window._shi(null)">All</div>';
         for (var i = 0; i < names.length; i++) {
             var n = names[i];
-            h += '<div class="iface-tab' + (selectedHistoryIface === n ? ' active' : '') + '" onclick="window._shi(\'' + n + '\')">' + n + '</div>';
+            h += '<div class="iface-tab' + (selectedHistoryIface === n ? ' active' : '') + '" onclick="window._shi(\'' + BM.escJs(n) + '\')">' + BM.escSvg(n) + '</div>';
         }
         el.innerHTML = h;
     }
@@ -384,7 +384,7 @@
         var h = '<div class="iface-tab' + (selectedIface === null ? ' active' : '') + '" onclick="window._si(null)">All</div>';
         // Sorted so the tab order is the same on every load and matches the 24h row.
         Array.from(BM.knownIfaces).sort().forEach(function(n) {
-            h += '<div class="iface-tab' + (selectedIface === n ? ' active' : '') + '" onclick="window._si(\'' + n + '\')">' + n + '</div>';
+            h += '<div class="iface-tab' + (selectedIface === n ? ' active' : '') + '" onclick="window._si(\'' + BM.escJs(n) + '\')">' + BM.escSvg(n) + '</div>';
         });
         el.innerHTML = h;
     };
@@ -545,7 +545,7 @@
 
     BM.renderTalkers = function(tid, talkers, vk, fmt, cls) {
         var tb = document.getElementById(tid);
-        if (!talkers || !talkers.length) { tb.innerHTML = '<tr><td colspan="6" class="empty-state">No data &mdash; requires root / CAP_NET_RAW</td></tr>'; return; }
+        if (!talkers || !talkers.length) { tb.innerHTML = '<tr><td colspan="7" class="empty-state">No data &mdash; requires root / CAP_NET_RAW</td></tr>'; return; }
 
         var hasDirection = false;
         for (var di = 0; di < talkers.length; di++) {
@@ -559,13 +559,13 @@
             var flag = t.country ? BM.countryFlag(t.country) + ' ' : '';
             var geo = '';
             var geoName = (t.city && t.country_name) ? t.city + ', ' + t.country_name : (t.country_name || '');
-            if (t.as_org) geo = '<span class="hostname">' + flag + geoName + ' &middot; AS' + (t.asn || '') + ' ' + t.as_org + '</span>';
-            else if (geoName) geo = '<span class="hostname">' + flag + geoName + '</span>';
+            if (t.as_org) geo = '<span class="hostname">' + flag + BM.escSvg(geoName) + ' &middot; AS' + (t.asn || '') + ' ' + BM.escSvg(t.as_org) + '</span>';
+            else if (geoName) geo = '<span class="hostname">' + flag + BM.escSvg(geoName) + '</span>';
             var displayName = BM.deviceDisplayName(null, [t.ip], t.hostname);
             var host = displayName && displayName !== t.ip
-                ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span><span class="hostname">' + displayName + '</span>' + geo
+                ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span><span class="hostname">' + BM.escSvg(displayName) + '</span>' + geo
                 : '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span>' + geo;
-            h += '<tr' + (t.country ? ' data-country="' + t.country + '"' : '') + '><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
+            h += '<tr' + (t.country ? ' data-country="' + BM.escSvg(t.country) + '"' : '') + '><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
             h += '<td>' + BM.favoriteStarHtml(t.ip) + '</td>';
             h += '<td>' + host + '</td>';
             if (hasDirection) {

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -49,6 +49,23 @@
         return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
     };
 
+    /* Escapes a string for safe embedding as a single-quoted JS string
+     * literal inside an inline onclick="..." HTML attribute, e.g.
+     * onclick="fn('" + BM.escJs(name) + "')" . Escapes backslash/quote for
+     * the JS string context, then HTML-escapes so the value can't break out
+     * of the (double-quoted) attribute itself. */
+    BM.escJs = function(s) {
+        return String(s == null ? '' : s)
+            .replace(/\\/g, '\\\\')
+            .replace(/'/g, "\\'")
+            .replace(/\n/g, '\\n')
+            .replace(/\r/g, '')
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    };
+
     /* Reusable SSE-style stream reader for POST endpoints that return
      * Server-Sent Events (e.g. speed test, traceroute, MTU discovery).
      * opts: { url, method, onMessage(parsed), onDone(), onError(err) } */


### PR DESCRIPTION
Deep audit of the whole codebase (backend + frontend) turned up a handful of real bugs, now fixed. No API changes — everything stays backward compatible.

**Backend**
- `adguard`: the client IP passed to `/api/host/dns?ip=` was interpolated unescaped into the outgoing AdGuard querylog request URL — a malicious IP value could inject extra query parameters into that request. Now escaped with `url.QueryEscape`.
- `handler`: `HostDNSLog` now validates the `ip` param is an actual IP (previously only length was checked), and normalizes a nil query log slice to `[]` in the JSON response.
- `pihole`: session id / expiry reads and writes are now protected by the client's mutex, consistent with how `stats` is already protected.

**Frontend**
- `traffic.js`: AS org, geo (city/country), and device display name are now escaped before being inserted into talker row HTML; the `data-country` attribute is escaped; interface names used in inline `onclick` handlers are escaped; the empty-state row's `colspan` is widened to safely cover both the 5- and 7-column table layouts.
- `monitor.js`: the country code used in the Active Countries list's `onclick` handler is now escaped.
- `host-modal.js`: fixed a race where opening a new host's modal while a previous host's `/api/host` or `/api/host/dns` fetch was still in flight could render the wrong host's data — both callbacks now check the modal is still showing the requested IP before rendering.
- `core.js`: theme `localStorage` reads/writes are now wrapped in try/catch so the toggle doesn't throw in private browsing / storage-disabled environments.

Verified: cross-compiled build + `go vet` clean, all touched JS passes `node --check`, deployed the packaged `.deb` to a test host and confirmed live: invalid IPs are rejected (400) while valid IPs still work, and the served JS contains all the fixes.