### PR TITLE
Add per-country Top Talkers drill-down for the world map

### DIFF
--- a/apns/apns.go
+++ b/apns/apns.go
@@ -118,7 +118,9 @@ func (c *Client) Send(token, environment string, staleAfter time.Duration, conte
 	var apnsBody struct {
 		Reason string `json:"reason"`
 	}
-	json.NewDecoder(resp.Body).Decode(&apnsBody)
+	if decErr := json.NewDecoder(resp.Body).Decode(&apnsBody); decErr != nil {
+		log.Printf("apns: failed to decode error body (status %d, apns-id=%s): %v", result.StatusCode, result.ApnsID, decErr)
+	}
 	result.Reason = apnsBody.Reason
 
 	if result.Dead() {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -71,6 +71,26 @@ func TopTalkersVolume(t *talkers.Tracker) http.HandlerFunc {
 	}
 }
 
+// CountryTalkers returns the top IPs (by 24h volume) for a given GeoIP
+// country code. Unlike the global Top Talkers lists, this searches every
+// known IP rather than just the overall top-10, so it can power a
+// "click a country on the world map" drill-down that finds traffic the
+// global list wouldn't otherwise surface.
+func CountryTalkers(t *talkers.Tracker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cc := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("cc")))
+		if cc == "" {
+			http.Error(w, "cc parameter required", http.StatusBadRequest)
+			return
+		}
+		if len(cc) != 2 {
+			http.Error(w, "invalid cc", http.StatusBadRequest)
+			return
+		}
+		httputil.WriteJSON(w, t.TopByCountry(cc, 10))
+	}
+}
+
 func DNSSummary(dp dns.Provider, dnsRes *resolver.Resolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if dp == nil {
@@ -615,11 +635,15 @@ func (o *originResolver) doResolve(c *collector.Collector) *originGeo {
 	return nil
 }
 
+// externalIPClient is reused across calls to fetchExternalIP so we don't pay
+// for a new connection pool on every fallback lookup (this path only runs
+// when no globally-routable WAN IP was found, at most once per TTL refresh).
+var externalIPClient = &http.Client{Timeout: 3 * time.Second, Transport: httputil.WrapTransport(nil)}
+
 // fetchExternalIP queries ip.ffmuc.net to get the public IP when all
 // WAN addresses are behind CGNAT or not globally routable.
 func fetchExternalIP() string {
-	client := &http.Client{Timeout: 3 * time.Second, Transport: httputil.WrapTransport(nil)}
-	resp, err := client.Get("https://ip.ffmuc.net")
+	resp, err := externalIPClient.Get("https://ip.ffmuc.net")
 	if err != nil {
 		return ""
 	}

--- a/main.go
+++ b/main.go
@@ -320,6 +320,7 @@ func main() {
 	mux.HandleFunc("/api/interfaces/history", handler.InterfaceHistory(statsCollector))
 	mux.HandleFunc("/api/talkers/bandwidth", handler.TopTalkersBandwidth(talkerTracker))
 	mux.HandleFunc("/api/talkers/volume", handler.TopTalkersVolume(talkerTracker))
+	mux.HandleFunc("/api/talkers/country", handler.CountryTalkers(talkerTracker))
 	mux.HandleFunc("/api/dns", handler.DNSSummary(dnsProvider, dnsResolver))
 	mux.HandleFunc("/api/wifi", handler.WiFiSummary(wifiProvider))
 	mux.HandleFunc("/api/conntrack", handler.ConntrackSummary(conntrackTracker))

--- a/static/index.html
+++ b/static/index.html
@@ -789,7 +789,7 @@
             <div class="card-header">
                 <div>
                     <div class="card-title">Traffic World Map</div>
-                    <div class="card-subtitle">Live traffic flows by country &mdash; drag to pan, Ctrl+scroll to zoom, double-click to reset, click a country to find it in Top Talkers</div>
+                    <div class="card-subtitle">Live traffic flows by country &mdash; drag to pan, Ctrl+scroll to zoom, double-click to reset, click a country to see its top talkers</div>
                 </div>
             </div>
             <div id="worldMapContainer" style="width:100%;aspect-ratio:2/1;position:relative;overflow:hidden;cursor:grab">
@@ -803,6 +803,13 @@
             <div id="mapCountryTable" style="display:none;padding:0 16px 16px">
                 <div style="font-size:12px;font-weight:600;color:var(--text-2);margin-bottom:8px">Active Countries</div>
                 <div id="mapCountryList" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:4px;font-size:12px"></div>
+            </div>
+            <div id="mapCountryDetail" style="display:none;padding:0 16px 16px;border-top:1px solid var(--border)">
+                <div style="display:flex;align-items:center;justify-content:space-between;margin:12px 0 8px">
+                    <div id="mapCountryDetailTitle" style="font-size:12px;font-weight:600;color:var(--text-2)"></div>
+                    <div onclick="window._closeCountryDetail()" style="cursor:pointer;color:var(--text-3);font-size:16px;line-height:1;padding:2px 6px" title="Close">&times;</div>
+                </div>
+                <div id="mapCountryDetailList" style="font-size:12px"></div>
             </div>
         </div>
 

--- a/static/js/tabs/monitor.js
+++ b/static/js/tabs/monitor.js
@@ -252,22 +252,67 @@
         }
     };
 
-    // Switches to the Traffic tab and scrolls/highlights the Top Talkers
-    // rows matching a given country code, so clicking a country on the map
-    // (or in the Active Countries list) helps find who's actually talking
-    // to it.
+    // Fetches and displays the top IPs talking to/from a given country in an
+    // inline detail panel below the map. The global Top Talkers lists only
+    // ever cover the overall top-10 IPs, which frequently don't include any
+    // IP for a given country — so we ask the backend for a country-scoped
+    // top list instead of just searching the already-rendered Traffic tables.
     window._focusCountryTraffic = function(cc) {
         if (!cc) return;
-        if (window._switchTab) window._switchTab('traffic');
-        setTimeout(function() {
-            var rows = document.querySelectorAll('#bwTable tr[data-country="' + cc + '"], #volTable tr[data-country="' + cc + '"]');
-            if (!rows.length) return;
-            rows[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
-            rows.forEach(function(r) {
-                r.classList.add('country-focus-flash');
-                setTimeout(function() { r.classList.remove('country-focus-flash'); }, 2000);
+        var wrap = document.getElementById('mapCountryDetail');
+        var title = document.getElementById('mapCountryDetailTitle');
+        var list = document.getElementById('mapCountryDetailList');
+        if (!wrap || !title || !list) return;
+
+        wrap.dataset.cc = cc;
+        wrap.style.display = '';
+        title.textContent = BM.countryFlag(cc) + ' ' + cc + ' \u2014 Top Talkers';
+        list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--text-2)">Loading&hellip;</div>';
+        wrap.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+        fetch('/api/talkers/country?cc=' + encodeURIComponent(cc))
+            .then(function(r) { return r.json(); })
+            .then(function(talkers) {
+                // Ignore stale responses if the user clicked a different country meanwhile.
+                if (wrap.dataset.cc !== cc) return;
+                if (!talkers || !talkers.length) {
+                    list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--text-2)">No tracked IPs for this country in the last 24h</div>';
+                    return;
+                }
+                var mx = talkers[0].total_bytes || 1, h = '';
+                talkers.forEach(function(t, i) {
+                    var pct = mx > 0 ? (t.total_bytes / mx * 100) : 0;
+                    var displayName = BM.deviceDisplayName ? BM.deviceDisplayName(null, [t.ip], t.hostname) : (t.hostname || t.ip);
+                    var host = displayName && displayName !== t.ip
+                        ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span> <span class="hostname">' + BM.escSvg(displayName) + '</span>'
+                        : '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span>';
+                    var geo = t.as_org ? '<span class="hostname">AS' + (t.asn || '') + ' ' + BM.escSvg(t.as_org) + '</span>' : '';
+                    h += '<div style="display:flex;align-items:center;gap:8px;padding:4px 0;border-bottom:1px solid var(--border)">';
+                    h += '<span class="' + BM.rankClass(i) + '" style="flex:0 0 auto">' + (i + 1) + '</span>';
+                    h += '<div style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + host + ' ' + geo + '</div>';
+                    h += '<div style="flex:0 0 80px;height:6px;background:var(--bg-2);border-radius:3px;overflow:hidden"><div style="width:' + Math.max(2, pct).toFixed(1) + '%;height:100%;background:var(--accent);border-radius:3px;opacity:0.7"></div></div>';
+                    h += '<span style="flex:0 0 auto;min-width:60px;text-align:right;font-variant-numeric:tabular-nums;color:var(--text-2)">' + BM.formatBytes(t.total_bytes) + '</span>';
+                    h += '</div>';
+                });
+                list.innerHTML = h;
+                // Re-wire host-modal clicks for the newly rendered IP cells.
+                list.querySelectorAll('.ip-clickable').forEach(function(el) {
+                    el.addEventListener('click', function() {
+                        if (window._openHostModal) window._openHostModal(el.getAttribute('data-ip'), '');
+                    });
+                });
+            })
+            .catch(function(e) {
+                if (wrap.dataset.cc !== cc) return;
+                list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--danger)">Failed to load: ' + e + '</div>';
             });
-        }, 60);
+    };
+
+    window._closeCountryDetail = function() {
+        var wrap = document.getElementById('mapCountryDetail');
+        if (!wrap) return;
+        wrap.style.display = 'none';
+        delete wrap.dataset.cc;
     };
 
     // ── Map zoom/pan ──

--- a/static/style.css
+++ b/static/style.css
@@ -1365,14 +1365,6 @@ canvas { outline: none; }
 .net-node { cursor: pointer; }
 .net-node:hover circle:nth-child(2) { filter: brightness(1.3); }
 
-.country-focus-flash {
-    animation: countryFocusFlash 2s ease-out;
-}
-@keyframes countryFocusFlash {
-    0% { background: rgba(34, 211, 238, 0.35); }
-    100% { background: transparent; }
-}
-
 /* Device rename affordance in the host modal */
 .device-name-edit { cursor: pointer; color: var(--text-2); font-size: 12px; margin-left: 6px; opacity: 0.7; }
 .device-name-edit:hover { opacity: 1; color: var(--accent); }

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -287,6 +287,82 @@ func (t *Tracker) TopByVolume(n int) []TalkerStat {
 	return list
 }
 
+// TopByCountry returns the top n IPs (by 24h total bytes) whose GeoIP country
+// code matches cc. The global Top Talkers lists (TopByVolume/TopByBandwidth)
+// only ever cover the overall top-n IPs, which frequently contain nothing for
+// a given country — this powers the "click a country on the world map" UI
+// drill-down so it can find IPs regardless of their rank in the global list.
+func (t *Tracker) TopByCountry(cc string, n int) []TalkerStat {
+	if t.geoDB == nil || !t.geoDB.Available() || cc == "" {
+		return nil
+	}
+
+	// Step 1: Copy raw per-IP totals under lock (same source as TopByVolume).
+	t.mu.RLock()
+	totals := make(map[string]*TalkerStat)
+	for _, b := range t.buckets {
+		for ip, acc := range b.hosts {
+			if _, ok := totals[ip]; !ok {
+				totals[ip] = &TalkerStat{IP: ip}
+			}
+			totals[ip].TotalBytes += acc.bytes
+			totals[ip].RxBytes += acc.rxBytes
+			totals[ip].TxBytes += acc.txBytes
+			totals[ip].Packets += acc.packets
+		}
+	}
+	if t.current != nil {
+		for ip, acc := range t.current.hosts {
+			if _, ok := totals[ip]; !ok {
+				totals[ip] = &TalkerStat{IP: ip}
+			}
+			totals[ip].TotalBytes += acc.bytes
+			totals[ip].RxBytes += acc.rxBytes
+			totals[ip].TxBytes += acc.txBytes
+			totals[ip].Packets += acc.packets
+		}
+	}
+	t.mu.RUnlock()
+
+	// Step 2: GeoIP lookup outside the lock to find IPs matching cc. Every
+	// known IP has to be checked (same cost as GetGeoBreakdown) since the
+	// country isn't known ahead of a lookup; this endpoint is only called
+	// on-demand (user click), not on every SSE tick.
+	list := make([]TalkerStat, 0, 16)
+	for _, s := range totals {
+		ip := net.ParseIP(s.IP)
+		if _, isSelf := t.selfIPs[s.IP]; isSelf {
+			continue
+		}
+		if ip != nil && ip.IsLoopback() {
+			continue
+		}
+		if ip != nil && netutil.IsLocal(ip, t.localNets) {
+			continue
+		}
+		geo := t.geoDB.Lookup(s.IP)
+		if geo == nil || geo.Country != cc {
+			continue
+		}
+		s.SetGeo(geo.Country, geo.CountryName, geo.City, geo.Latitude, geo.Longitude, geo.ASN, geo.ASOrg)
+		list = append(list, *s)
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].TotalBytes > list[j].TotalBytes
+	})
+	if len(list) > n {
+		list = list[:n]
+	}
+
+	// Step 3: Hostname (DNS) enrichment only for the trimmed result.
+	for i := range list {
+		if t.dns != nil {
+			list[i].Hostname = t.dns.LookupAddrAsync(list[i].IP)
+		}
+	}
+	return list
+}
+
 func (t *Tracker) TopByBandwidth(n int) []TalkerStat {
 	// Use the short rate ring (5s slots, ~30s window) for responsive rate
 	// calculation. The 1-minute buckets are still used for 24h volume.


### PR DESCRIPTION
Fixes a real bug: clicking a country on the traffic world map was supposed to surface who's actually talking to it, but it only ever searched the already-rendered Top Talkers tables — which just hold the overall top-10 IPs by volume/bandwidth. Most countries have no IP in that global top-10, so clicking them showed nothing.

- `talkers`: new `TopByCountry(cc, n)` scans all known IPs (the same work the world map's country breakdown already does every render) and returns the top IPs whose GeoIP country matches — rather than relying on the global top-10 list happening to contain a match.
- `handler`/`main`: exposes it as `GET /api/talkers/country?cc=XX` — new, additive endpoint, existing APIs untouched.
- `monitor.js`: clicking a country now fetches this endpoint and shows an inline "Top Talkers" panel right under the map (IP/hostname, ASN/org, byte bar, rank), instead of jumping to the Traffic tab and hoping for a match. Stale responses are ignored if you click a different country before the fetch resolves. Removed the now-unused flash-highlight CSS.

Also folded in two small findings from the ongoing bug sweep:
- `apns`: log (rather than silently swallow) a failed error-body decode.
- `handler`: reuse one `http.Client` for the external-IP fallback lookup instead of allocating a new one on every call.

Verified: cross-compiled build clean, `go vet`/`gofmt` clean, JS syntax-checked, deployed the packaged `.deb` to a test host and confirmed live — `/api/talkers/country?cc=US`/`cc=DE` return real per-country talker lists, invalid country codes are rejected with 400, and the served JS/HTML contain the new detail panel.