### PR TITLE
Fix speedtest HTTP/2 bottleneck, add single vs multi-stream comparison

### DIFF
--- a/speedtest/speedtest.go
+++ b/speedtest/speedtest.go
@@ -2,6 +2,7 @@ package speedtest
 
 import (
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
@@ -18,9 +19,17 @@ type Result struct {
 	Server       string  `json:"server"`
 	DownloadMbps float64 `json:"download_mbps"`
 	UploadMbps   float64 `json:"upload_mbps"`
-	PingMs       float64 `json:"ping_ms"`
-	JitterMs     float64 `json:"jitter_ms"`
-	Timestamp    int64   `json:"timestamp"`
+	// DownloadSingleMbps/UploadSingleMbps are measured with a single TCP
+	// connection (parallelism=1), run right before the full multi-stream
+	// test. Comparing the two shows whether the link's aggregate capacity
+	// is being limited by a per-connection cap (ISP per-flow shaping,
+	// single-stream TCP window/RTT limits, etc) rather than the link
+	// itself. Omitted from JSON if a value couldn't be measured.
+	DownloadSingleMbps float64 `json:"download_single_mbps,omitempty"`
+	UploadSingleMbps   float64 `json:"upload_single_mbps,omitempty"`
+	PingMs             float64 `json:"ping_ms"`
+	JitterMs           float64 `json:"jitter_ms"`
+	Timestamp          int64   `json:"timestamp"`
 }
 
 // Progress is sent over SSE while a test is running.
@@ -107,31 +116,53 @@ func (t *Tester) run(ch chan<- Progress) {
 	ch <- Progress{Phase: "ping", Percent: 100, Value: pingMs}
 	log.Printf("speedtest: ping=%.1fms jitter=%.1fms", pingMs, jitterMs)
 
+	// Single-stream sub-tests run first and briefly, purely as a point of
+	// comparison against the full multi-stream result below — a large gap
+	// between the two usually means something (ISP per-flow shaping, a
+	// slow-start-limited high-RTT path, etc) is capping a single TCP
+	// connection well below the link's real aggregate capacity. Failures
+	// here are non-fatal: they're a bonus diagnostic, not the primary result.
+	ch <- Progress{Phase: "download-single", Percent: 0, Value: 0}
+	dlSingleMbps, err := measureDownload(server, 1, singleStreamDuration, "download-single", ch)
+	if err != nil {
+		log.Printf("speedtest: single-stream download measurement failed (non-fatal): %v", err)
+		dlSingleMbps = 0
+	}
+
 	ch <- Progress{Phase: "download", Percent: 0, Value: 0}
-	dlMbps, err := measureDownload(server, ch)
+	dlMbps, err := measureDownload(server, downloadParallelism, downloadDuration, "download", ch)
 	if err != nil {
 		log.Printf("speedtest: download failed: %v", err)
 		ch <- Progress{Phase: "error", Value: 0}
 		return
 	}
-	log.Printf("speedtest: download=%.1f Mbps", dlMbps)
+	log.Printf("speedtest: download=%.1f Mbps (single-stream=%.1f Mbps)", dlMbps, dlSingleMbps)
+
+	ch <- Progress{Phase: "upload-single", Percent: 0, Value: 0}
+	ulSingleMbps, err := measureUpload(server, 1, singleStreamDuration, "upload-single", ch)
+	if err != nil {
+		log.Printf("speedtest: single-stream upload measurement failed (non-fatal): %v", err)
+		ulSingleMbps = 0
+	}
 
 	ch <- Progress{Phase: "upload", Percent: 0, Value: 0}
-	ulMbps, err := measureUpload(server, ch)
+	ulMbps, err := measureUpload(server, uploadParallelism, uploadDuration, "upload", ch)
 	if err != nil {
 		log.Printf("speedtest: upload failed: %v", err)
 		ch <- Progress{Phase: "error", Value: 0}
 		return
 	}
-	log.Printf("speedtest: upload=%.1f Mbps", ulMbps)
+	log.Printf("speedtest: upload=%.1f Mbps (single-stream=%.1f Mbps)", ulMbps, ulSingleMbps)
 
 	result := Result{
-		Server:       server,
-		DownloadMbps: dlMbps,
-		UploadMbps:   ulMbps,
-		PingMs:       pingMs,
-		JitterMs:     jitterMs,
-		Timestamp:    time.Now().UnixMilli(),
+		Server:             server,
+		DownloadMbps:       dlMbps,
+		UploadMbps:         ulMbps,
+		DownloadSingleMbps: dlSingleMbps,
+		UploadSingleMbps:   ulSingleMbps,
+		PingMs:             pingMs,
+		JitterMs:           jitterMs,
+		Timestamp:          time.Now().UnixMilli(),
 	}
 
 	t.mu.Lock()
@@ -263,16 +294,45 @@ loop:
 	return mbps, nil
 }
 
-func measureDownload(server string, ch chan<- Progress) (float64, error) {
-	const (
-		duration    = 15 * time.Second
-		parallelism = 6
-	)
+// newSpeedTransport builds a dedicated HTTP/1.1-only Transport for a single
+// speedtest worker connection.
+//
+// Go's http.DefaultTransport auto-negotiates HTTP/2 over TLS, and multiple
+// http.Client values that fall back to it (nil Transport.Base) all share
+// that one global Transport/connection pool. For an HTTP/2 origin, that
+// means every "parallel" worker ends up multiplexed over a single TCP
+// connection with a single congestion-control window — throughput is then
+// capped at whatever one TCP stream can sustain, which is far below the
+// aggregate a real multi-connection speed test needs to saturate a fast
+// link. Forcing HTTP/1.1 with a private Transport per worker guarantees
+// each one gets its own independent TCP connection (and congestion
+// window), which is how genuine multi-stream throughput tests reach the
+// link's actual capacity.
+func newSpeedTransport() *http.Transport {
+	return &http.Transport{
+		MaxIdleConnsPerHost: 1,
+		DisableCompression:  true,
+		// A non-nil (even empty) TLSNextProto map disables the automatic
+		// HTTP/2 upgrade, keeping this connection on HTTP/1.1.
+		TLSNextProto: map[string]func(string, *tls.Conn) http.RoundTripper{},
+	}
+}
 
+// Speed test timing/parallelism knobs.
+const (
+	downloadDuration     = 15 * time.Second
+	downloadParallelism  = 6
+	uploadDuration       = 15 * time.Second
+	uploadParallelism    = 6
+	singleStreamDuration = 4 * time.Second
+	uploadChunkSize      = 4 * 1024 * 1024
+)
+
+func measureDownload(server string, parallelism int, duration time.Duration, phase string, ch chan<- Progress) (float64, error) {
 	workerFn := func(deadline time.Time, counter *int64, mu *sync.Mutex) {
 		client := &http.Client{
 			Timeout:   duration + 5*time.Second,
-			Transport: httputil.WrapTransport(nil),
+			Transport: httputil.WrapTransport(newSpeedTransport()),
 		}
 		buf := make([]byte, 256*1024)
 		for time.Now().Before(deadline) {
@@ -295,22 +355,16 @@ func measureDownload(server string, ch chan<- Progress) (float64, error) {
 		}
 	}
 
-	return measureThroughput("download", duration, parallelism, workerFn, ch)
+	return measureThroughput(phase, duration, parallelism, workerFn, ch)
 }
 
-func measureUpload(server string, ch chan<- Progress) (float64, error) {
-	const (
-		duration    = 15 * time.Second
-		parallelism = 6
-		chunkSize   = 4 * 1024 * 1024
-	)
-
+func measureUpload(server string, parallelism int, duration time.Duration, phase string, ch chan<- Progress) (float64, error) {
 	workerFn := func(deadline time.Time, counter *int64, mu *sync.Mutex) {
 		client := &http.Client{
 			Timeout:   duration + 5*time.Second,
-			Transport: httputil.WrapTransport(nil),
+			Transport: httputil.WrapTransport(newSpeedTransport()),
 		}
-		data := make([]byte, chunkSize)
+		data := make([]byte, uploadChunkSize)
 		rand.Read(data)
 
 		for time.Now().Before(deadline) {
@@ -323,7 +377,7 @@ func measureUpload(server string, ch chan<- Progress) (float64, error) {
 			if e != nil {
 				return
 			}
-			req.ContentLength = int64(chunkSize)
+			req.ContentLength = int64(uploadChunkSize)
 			req.Header.Set("Content-Type", "application/octet-stream")
 
 			resp, e := client.Do(req)
@@ -335,7 +389,7 @@ func measureUpload(server string, ch chan<- Progress) (float64, error) {
 		}
 	}
 
-	return measureThroughput("upload", duration, parallelism, workerFn, ch)
+	return measureThroughput(phase, duration, parallelism, workerFn, ch)
 }
 
 type countingReader struct {

--- a/static/index.html
+++ b/static/index.html
@@ -852,20 +852,22 @@
                 <div class="speedtest-gauge-unit">ms</div>
             </div>
             <div class="speedtest-gauge-card">
-                <div class="speedtest-gauge-label">DOWNLOAD</div>
+                <div class="speedtest-gauge-label" title="Aggregate throughput using 6 parallel connections, like a real download would use">DOWNLOAD <span class="speedtest-gauge-label-hint">(6 streams)</span></div>
                 <div class="speedtest-gauge-wrap">
                     <canvas id="stDownGauge" width="160" height="100"></canvas>
                 </div>
                 <div class="speedtest-gauge-value" id="stDownValue">--</div>
                 <div class="speedtest-gauge-unit">Mbps</div>
+                <div class="speedtest-gauge-sub" id="stDownSingleValue" title="Throughput of a single TCP connection — a large gap vs. the 6-stream number above usually means per-connection shaping/limits, not the link itself"></div>
             </div>
             <div class="speedtest-gauge-card">
-                <div class="speedtest-gauge-label">UPLOAD</div>
+                <div class="speedtest-gauge-label" title="Aggregate throughput using 6 parallel connections, like a real upload would use">UPLOAD <span class="speedtest-gauge-label-hint">(6 streams)</span></div>
                 <div class="speedtest-gauge-wrap">
                     <canvas id="stUpGauge" width="160" height="100"></canvas>
                 </div>
                 <div class="speedtest-gauge-value" id="stUpValue">--</div>
                 <div class="speedtest-gauge-unit">Mbps</div>
+                <div class="speedtest-gauge-sub" id="stUpSingleValue" title="Throughput of a single TCP connection — a large gap vs. the 6-stream number above usually means per-connection shaping/limits, not the link itself"></div>
             </div>
             <div class="speedtest-gauge-card">
                 <div class="speedtest-gauge-label">JITTER</div>

--- a/static/js/tabs/speedtest.js
+++ b/static/js/tabs/speedtest.js
@@ -38,11 +38,13 @@
         }
     }
 
-    function updateSpeedTestGauges(ping, download, upload, jitter) {
+    function updateSpeedTestGauges(ping, download, upload, jitter, downloadSingle, uploadSingle) {
         var pingEl = document.getElementById('stPingValue');
         var downEl = document.getElementById('stDownValue');
         var upEl = document.getElementById('stUpValue');
         var jitterEl = document.getElementById('stJitterValue');
+        var downSubEl = document.getElementById('stDownSingleValue');
+        var upSubEl = document.getElementById('stUpSingleValue');
 
         pingEl.textContent = ping >= 0 ? ping.toFixed(1) : '--';
         downEl.textContent = download >= 0 ? download.toFixed(1) : '--';
@@ -53,6 +55,25 @@
         drawGauge('stDownGauge', download >= 0 ? download : 0, 1000, '#3b82f6');
         drawGauge('stUpGauge', upload >= 0 ? upload : 0, 1000, '#a78bfa');
         drawGauge('stJitterGauge', jitter >= 0 ? jitter : 0, 50, '#f59e0b');
+
+        if (downSubEl) {
+            if (downloadSingle > 0 && download > 0) {
+                var dRatio = download / downloadSingle;
+                downSubEl.textContent = '1 stream: ' + downloadSingle.toFixed(1) + ' Mbps' +
+                    (dRatio >= 1.3 ? ' (' + dRatio.toFixed(1) + '\u00d7 slower than 6 streams)' : ' (about the same as 6 streams)');
+            } else {
+                downSubEl.textContent = '';
+            }
+        }
+        if (upSubEl) {
+            if (uploadSingle > 0 && upload > 0) {
+                var uRatio = upload / uploadSingle;
+                upSubEl.textContent = '1 stream: ' + uploadSingle.toFixed(1) + ' Mbps' +
+                    (uRatio >= 1.3 ? ' (' + uRatio.toFixed(1) + '\u00d7 slower than 6 streams)' : ' (about the same as 6 streams)');
+            } else {
+                upSubEl.textContent = '';
+            }
+        }
     }
 
     function renderSpeedTestHistory(results) {
@@ -66,11 +87,13 @@
             var r = results[i];
             var d = new Date(r.timestamp);
             var dateStr = d.toLocaleDateString() + ' ' + d.toLocaleTimeString();
+            var dlSingle = r.download_single_mbps ? ' <span style="color:var(--text-3);font-weight:400" title="Single-stream download">(1 stream: ' + r.download_single_mbps.toFixed(1) + ' Mbps)</span>' : '';
+            var ulSingle = r.upload_single_mbps ? ' <span style="color:var(--text-3);font-weight:400" title="Single-stream upload">(1 stream: ' + r.upload_single_mbps.toFixed(1) + ' Mbps)</span>' : '';
             h += '<tr>';
             h += '<td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
             h += '<td style="font-size:12px;white-space:nowrap">' + dateStr + '</td>';
-            h += '<td style="font-variant-numeric:tabular-nums;font-weight:600;color:var(--rx)">' + r.download_mbps.toFixed(1) + ' Mbps</td>';
-            h += '<td style="font-variant-numeric:tabular-nums;font-weight:600;color:var(--tx)">' + r.upload_mbps.toFixed(1) + ' Mbps</td>';
+            h += '<td style="font-variant-numeric:tabular-nums;font-weight:600;color:var(--rx)">' + r.download_mbps.toFixed(1) + ' Mbps' + dlSingle + '</td>';
+            h += '<td style="font-variant-numeric:tabular-nums;font-weight:600;color:var(--tx)">' + r.upload_mbps.toFixed(1) + ' Mbps' + ulSingle + '</td>';
             h += '<td style="font-variant-numeric:tabular-nums">' + r.ping_ms.toFixed(1) + ' ms</td>';
             h += '<td style="font-variant-numeric:tabular-nums">' + r.jitter_ms.toFixed(1) + ' ms</td>';
             h += '</tr>';
@@ -88,7 +111,7 @@
             renderSpeedTestHistory(data.results || []);
             if (data.results && data.results.length) {
                 var last = data.results[0];
-                updateSpeedTestGauges(last.ping_ms, last.download_mbps, last.upload_mbps, last.jitter_ms);
+                updateSpeedTestGauges(last.ping_ms, last.download_mbps, last.upload_mbps, last.jitter_ms, last.download_single_mbps, last.upload_single_mbps);
             }
         }).catch(function() {});
     };
@@ -105,7 +128,7 @@
         wrap.style.display = '';
         var bar = document.getElementById('speedtestProgressBar');
         var phase = document.getElementById('speedtestPhase');
-        updateSpeedTestGauges(-1, -1, -1, -1);
+        updateSpeedTestGauges(-1, -1, -1, -1, -1, -1);
         bar.style.width = '0%';
         phase.textContent = 'Connecting...';
 
@@ -113,6 +136,8 @@
         var currentDownload = -1;
         var currentUpload = -1;
         var currentJitter = -1;
+        var currentDownloadSingle = -1;
+        var currentUploadSingle = -1;
 
         fetch('/api/speedtest/run', { method: 'POST' }).then(function(resp) {
             if (resp.status === 409) {
@@ -145,30 +170,42 @@
             function handleProgress(p) {
                 if (p.phase === 'ping') {
                     phase.textContent = 'Measuring latency...';
-                    bar.style.width = (p.percent * 0.15) + '%';
+                    bar.style.width = (p.percent * 0.10) + '%';
                     bar.className = 'speedtest-progress-bar-fill ping';
                     if (p.percent >= 100 && p.value > 0) {
                         currentPing = p.value;
                     }
-                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter);
+                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter, currentDownloadSingle, currentUploadSingle);
+                } else if (p.phase === 'download-single') {
+                    currentDownloadSingle = p.value;
+                    phase.textContent = 'Testing download (1 stream)... ' + p.value.toFixed(1) + ' Mbps';
+                    bar.style.width = (10 + p.percent * 0.10) + '%';
+                    bar.className = 'speedtest-progress-bar-fill download';
+                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter, currentDownloadSingle, currentUploadSingle);
                 } else if (p.phase === 'download') {
                     currentDownload = p.value;
-                    phase.textContent = 'Testing download... ' + p.value.toFixed(1) + ' Mbps';
-                    bar.style.width = (15 + p.percent * 0.40) + '%';
+                    phase.textContent = 'Testing download (6 streams)... ' + p.value.toFixed(1) + ' Mbps';
+                    bar.style.width = (20 + p.percent * 0.40) + '%';
                     bar.className = 'speedtest-progress-bar-fill download';
-                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter);
+                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter, currentDownloadSingle, currentUploadSingle);
+                } else if (p.phase === 'upload-single') {
+                    currentUploadSingle = p.value;
+                    phase.textContent = 'Testing upload (1 stream)... ' + p.value.toFixed(1) + ' Mbps';
+                    bar.style.width = (60 + p.percent * 0.10) + '%';
+                    bar.className = 'speedtest-progress-bar-fill upload';
+                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter, currentDownloadSingle, currentUploadSingle);
                 } else if (p.phase === 'upload') {
                     currentUpload = p.value;
-                    phase.textContent = 'Testing upload... ' + p.value.toFixed(1) + ' Mbps';
-                    bar.style.width = (55 + p.percent * 0.40) + '%';
+                    phase.textContent = 'Testing upload (6 streams)... ' + p.value.toFixed(1) + ' Mbps';
+                    bar.style.width = (70 + p.percent * 0.30) + '%';
                     bar.className = 'speedtest-progress-bar-fill upload';
-                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter);
+                    updateSpeedTestGauges(currentPing, currentDownload, currentUpload, currentJitter, currentDownloadSingle, currentUploadSingle);
                 } else if (p.phase === 'done' && p.result) {
                     phase.textContent = 'Complete!';
                     bar.style.width = '100%';
                     bar.className = 'speedtest-progress-bar-fill done';
                     var r = p.result;
-                    updateSpeedTestGauges(r.ping_ms, r.download_mbps, r.upload_mbps, r.jitter_ms);
+                    updateSpeedTestGauges(r.ping_ms, r.download_mbps, r.upload_mbps, r.jitter_ms, r.download_single_mbps, r.upload_single_mbps);
                     BM.loadSpeedTestHistory();
                     finishTest();
                 } else if (p.phase === 'error') {

--- a/static/style.css
+++ b/static/style.css
@@ -1149,6 +1149,19 @@ canvas { outline: none; }
     margin-top: 2px;
 }
 
+.speedtest-gauge-sub {
+    font-size: 10px;
+    color: var(--text-3);
+    margin-top: 6px;
+    min-height: 13px;
+}
+
+.speedtest-gauge-label-hint {
+    font-weight: 400;
+    opacity: 0.6;
+    font-size: 10px;
+}
+
 .speedtest-progress-wrap {
     background: var(--bg-1);
     border: 1px solid var(--border);


### PR DESCRIPTION
## What
- **Root-cause fix**: the speedtest's 6 "parallel" workers all shared Go's global `http.DefaultTransport`, which auto-negotiates HTTP/2 over TLS. Against an HTTP/2 server this multiplexes all requests onto a **single TCP connection** (one congestion window), defeating the entire purpose of multi-stream testing. Each worker now gets its own dedicated `http.Transport` with HTTP/2 disabled (`TLSNextProto` set to a non-nil empty map), forcing independent HTTP/1.1 connections — the same technique real speed test tools use.
- **New diagnostic**: a quick single-stream (1 connection) sub-test now runs before each multi-stream download/upload test. Results are exposed as new optional `Result` fields (`download_single_mbps` / `upload_single_mbps`, `omitempty`) and new SSE progress phases (`download-single` / `upload-single`) — fully additive, existing consumers of the API are unaffected. Single-stream failures are non-fatal (logged, defaults to 0); the main multi-stream tests keep their existing fatal-error behavior.
- **Frontend**: shows the single-stream number under the Download/Upload gauges and in the history table with plain-language context (e.g. "3.9× slower than 6 streams") instead of a bare number, so the comparison is actually meaningful at a glance.

## Why
A user reported the speedtest wasn't reaching anywhere near their gateway's advertised ~500Mbps. Investigation + live `curl` benchmarking on the test box confirmed the HTTP/2 connection-sharing theory: a single connection topped out ~100-160Mbps regardless of protocol, while 6 genuinely independent connections reached ~400Mbps.

## Verified
- `gofmt`/`go vet ./speedtest/...` clean, full cross-compiled build succeeds.
- Deployed the fix to a live test box and re-ran the app's own `/api/speedtest/run`:
  - Before: ~105 Mbps download / ~18 Mbps upload (single shared HTTP/2 connection)
  - After: **~420 Mbps download** / ~52 Mbps upload (6 independent HTTP/1.1 connections), with the new single-stream sub-test correctly reporting ~105 Mbps — confirming both the fix and that the new comparison metric behaves as intended.
- Verified the new UI wording/tooltips render correctly against the live deployment.

No breaking API changes — new fields/phases are additive only.