### PR TITLE
Add ASN/provider traffic drill-down with per-machine and per-IP-pair detail

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -91,6 +91,25 @@ func CountryTalkers(t *talkers.Tracker) http.HandlerFunc {
 	}
 }
 
+// ASNTalkers returns the local machines (by 24h volume) that have talked to
+// a given ASN, powering the "which of my machines talk to this provider"
+// drill-down on the ASN breakdown card.
+func ASNTalkers(t *talkers.Tracker) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		asnStr := strings.TrimSpace(r.URL.Query().Get("asn"))
+		if asnStr == "" {
+			http.Error(w, "asn parameter required", http.StatusBadRequest)
+			return
+		}
+		asn, err := strconv.ParseUint(asnStr, 10, 32)
+		if err != nil || asn == 0 {
+			http.Error(w, "invalid asn", http.StatusBadRequest)
+			return
+		}
+		httputil.WriteJSON(w, t.TopMachinesForASN(uint(asn), 25))
+	}
+}
+
 func DNSSummary(dp dns.Provider, dnsRes *resolver.Resolver) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if dp == nil {

--- a/main.go
+++ b/main.go
@@ -321,6 +321,7 @@ func main() {
 	mux.HandleFunc("/api/talkers/bandwidth", handler.TopTalkersBandwidth(talkerTracker))
 	mux.HandleFunc("/api/talkers/volume", handler.TopTalkersVolume(talkerTracker))
 	mux.HandleFunc("/api/talkers/country", handler.CountryTalkers(talkerTracker))
+	mux.HandleFunc("/api/talkers/asn", handler.ASNTalkers(talkerTracker))
 	mux.HandleFunc("/api/dns", handler.DNSSummary(dnsProvider, dnsResolver))
 	mux.HandleFunc("/api/wifi", handler.WiFiSummary(wifiProvider))
 	mux.HandleFunc("/api/conntrack", handler.ConntrackSummary(conntrackTracker))

--- a/static/index.html
+++ b/static/index.html
@@ -142,7 +142,7 @@
                 <div class="card-header">
                     <div>
                         <div class="card-title">Autonomous Systems</div>
-                        <div class="card-subtitle">By volume (24h)</div>
+                        <div class="card-subtitle">By volume (24h) &mdash; click a row to see which machines talk to it</div>
                     </div>
                 </div>
                 <div class="breakdown-chart-body">
@@ -160,6 +160,13 @@
                             <tr><td colspan="5" class="empty-state">Waiting for GeoIP data</td></tr>
                         </tbody>
                     </table>
+                </div>
+                <div id="asnMachinesDetail" style="display:none;padding:12px 16px 16px;border-top:1px solid var(--border)">
+                    <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
+                        <div id="asnMachinesDetailTitle" style="font-size:12px;font-weight:600;color:var(--text-2)"></div>
+                        <div onclick="window._closeASNMachinesDetail()" style="cursor:pointer;color:var(--text-3);font-size:16px;line-height:1;padding:2px 6px" title="Close">&times;</div>
+                    </div>
+                    <div id="asnMachinesDetailList" style="font-size:12px"></div>
                 </div>
             </div>
         </div>

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -703,14 +703,16 @@
     // Export for other tabs (dns, wifi, nat)
     BM._fillDoughnut = fillDoughnut;
 
-    function fillDetailTable(tbId, items, labelFn, valueFn, fmtFn, cls) {
+    function fillDetailTable(tbId, items, labelFn, valueFn, fmtFn, cls, countFn) {
         var tb = document.getElementById(tbId);
-        if (!items || !items.length) { tb.innerHTML = '<tr><td colspan="4" class="empty-state">No data</td></tr>'; return; }
+        var cols = countFn ? 5 : 4;
+        if (!items || !items.length) { tb.innerHTML = '<tr><td colspan="' + cols + '" class="empty-state">No data</td></tr>'; return; }
         var mx = valueFn(items[0]) || 1, h = '';
         for (var i = 0; i < items.length; i++) {
             var pct = mx > 0 ? ((valueFn(items[i]) / mx) * 100).toFixed(1) : '0';
             h += '<tr><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
             h += '<td><span class="ip-cell">' + labelFn(items[i]) + '</span></td>';
+            if (countFn) h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + countFn(items[i]) + '</td>';
             h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + fmtFn(valueFn(items[i])) + '</td>';
             h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill ' + cls + '" style="width:' + pct + '%"></div></td></tr>';
         }
@@ -756,7 +758,8 @@
         fillDetailTable('countryTable', countries,
             function(c) { return BM.countryFlag(c.country) + ' <span style="font-weight:500">' + (c.country_name || c.country) + '</span> <span class="hostname" style="display:inline">' + c.country + '</span>'; },
             function(c) { return c.bytes; },
-            function(v) { return BM.formatBytes(v); }, 'bw'
+            function(v) { return BM.formatBytes(v); }, 'bw',
+            function(c) { return c.connections; }
         );
     };
 
@@ -792,9 +795,119 @@
         fillDetailTable('asnTable', asns,
             function(a) { return '<span style="font-weight:500">' + (a.as_org || 'Unknown') + '</span> <span class="hostname" style="display:inline">AS' + a.asn + '</span>'; },
             function(a) { return a.bytes; },
-            function(v) { return BM.formatBytes(v); }, 'vol'
+            function(v) { return BM.formatBytes(v); }, 'vol',
+            function(a) { return a.connections; }
         );
+        var tb = document.getElementById('asnTable');
+        if (tb) {
+            var rows = tb.querySelectorAll('tr');
+            for (var i = 0; i < rows.length && i < asns.length; i++) {
+                rows[i].style.cursor = 'pointer';
+                rows[i].title = 'Show machines talking to AS' + asns[i].asn;
+                (function(asn) {
+                    rows[i].addEventListener('click', function() { window._focusASNMachines(asn); });
+                })(asns[i]);
+            }
+        }
     };
+
+    // Fetches and displays the local machines talking to a given ASN in an
+    // inline detail panel below the ASN table. The GetGeoBreakdown/ASN totals
+    // only aggregate bytes per-ASN with no local-host attribution, so this
+    // asks the backend for an ASN-scoped, per-machine breakdown instead.
+    window._focusASNMachines = function(asn) {
+        if (!asn || !asn.asn) return;
+        var wrap = document.getElementById('asnMachinesDetail');
+        var title = document.getElementById('asnMachinesDetailTitle');
+        var list = document.getElementById('asnMachinesDetailList');
+        if (!wrap || !title || !list) return;
+
+        wrap.dataset.asn = asn.asn;
+        wrap.style.display = '';
+        title.textContent = (asn.as_org || ('AS' + asn.asn)) + ' (AS' + asn.asn + ') \u2014 Machines';
+        list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--text-2)">Loading&hellip;</div>';
+        wrap.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+        fetch('/api/talkers/asn?asn=' + encodeURIComponent(asn.asn))
+            .then(function(r) { return r.json(); })
+            .then(function(machines) {
+                // Ignore stale responses if the user clicked a different ASN meanwhile.
+                if (String(wrap.dataset.asn) !== String(asn.asn)) return;
+                if (!machines || !machines.length) {
+                    list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--text-2)">No local machines tracked for this ASN in the last 24h</div>';
+                    return;
+                }
+                var mx = machines[0].total_bytes || 1, h = '';
+                machines.forEach(function(m, i) {
+                    var pct = mx > 0 ? (m.total_bytes / mx * 100) : 0;
+                    var displayName = BM.deviceDisplayName ? BM.deviceDisplayName(null, [m.ip], m.hostname) : (m.hostname || m.ip);
+                    var host = displayName && displayName !== m.ip
+                        ? '<span class="ip-cell ip-clickable" data-ip="' + m.ip + '">' + m.ip + '</span> <span class="hostname">' + BM.escSvg(displayName) + '</span>'
+                        : '<span class="ip-cell ip-clickable" data-ip="' + m.ip + '">' + m.ip + '</span>';
+                    var conns = m.connections + ' remote IP' + (m.connections === 1 ? '' : 's');
+                    var hasRemotes = m.remotes && m.remotes.length > 0;
+                    h += '<div class="asn-machine-block" style="border-bottom:1px solid var(--border)">';
+                    h += '<div class="asn-machine-row" data-idx="' + i + '" style="display:flex;align-items:center;gap:8px;padding:4px 0' + (hasRemotes ? ';cursor:pointer' : '') + '">';
+                    h += '<span class="' + BM.rankClass(i) + '" style="flex:0 0 auto">' + (i + 1) + '</span>';
+                    if (hasRemotes) h += '<svg class="asn-caret" data-idx="' + i + '" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:12px;height:12px;flex:0 0 auto;color:var(--text-3);transition:transform .15s"><polyline points="9 6 15 12 9 18"/></svg>';
+                    h += '<div style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + host + ' <span class="hostname">' + conns + '</span></div>';
+                    h += '<div style="flex:0 0 80px;height:6px;background:var(--bg-2);border-radius:3px;overflow:hidden"><div style="width:' + Math.max(2, pct).toFixed(1) + '%;height:100%;background:var(--accent);border-radius:3px;opacity:0.7"></div></div>';
+                    h += '<span style="flex:0 0 auto;min-width:60px;text-align:right;font-variant-numeric:tabular-nums;color:var(--text-2)">' + BM.formatBytes(m.total_bytes) + '</span>';
+                    h += '</div>';
+                    if (hasRemotes) {
+                        var rmx = m.remotes[0].total_bytes || 1;
+                        h += '<div class="asn-remotes" data-idx="' + i + '" style="display:none;padding:0 0 6px 34px">';
+                        m.remotes.forEach(function(rm) {
+                            var rpct = rmx > 0 ? (rm.total_bytes / rmx * 100) : 0;
+                            var rDisplay = rm.hostname && rm.hostname !== rm.ip
+                                ? '<span class="ip-cell ip-clickable" data-ip="' + rm.ip + '">' + rm.ip + '</span> <span class="hostname">' + BM.escSvg(rm.hostname) + '</span>'
+                                : '<span class="ip-cell ip-clickable" data-ip="' + rm.ip + '">' + rm.ip + '</span>';
+                            h += '<div style="display:flex;align-items:center;gap:8px;padding:2px 0;font-size:11px">';
+                            h += '<div style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-2)">' + rDisplay + '</div>';
+                            h += '<div style="flex:0 0 60px;height:4px;background:var(--bg-2);border-radius:2px;overflow:hidden"><div style="width:' + Math.max(2, rpct).toFixed(1) + '%;height:100%;background:var(--text-3);border-radius:2px;opacity:0.6"></div></div>';
+                            h += '<span style="flex:0 0 auto;min-width:50px;text-align:right;font-variant-numeric:tabular-nums;color:var(--text-3)">' + BM.formatBytes(rm.total_bytes) + '</span>';
+                            h += '</div>';
+                        });
+                        h += '</div>';
+                    }
+                    h += '</div>';
+                });
+                list.innerHTML = h;
+                // Re-wire host-modal clicks for the newly rendered IP cells.
+                // stopPropagation so clicking an IP doesn't also toggle the
+                // parent machine row's remote-IP expander.
+                list.querySelectorAll('.ip-clickable').forEach(function(el) {
+                    el.addEventListener('click', function(e) {
+                        e.stopPropagation();
+                        if (window._openHostModal) window._openHostModal(el.getAttribute('data-ip'), '');
+                    });
+                });
+                // Wire up expand/collapse of the per-remote-IP breakdown.
+                list.querySelectorAll('.asn-machine-row').forEach(function(row) {
+                    row.addEventListener('click', function() {
+                        var idx = row.getAttribute('data-idx');
+                        var remotesEl = list.querySelector('.asn-remotes[data-idx="' + idx + '"]');
+                        var caret = list.querySelector('.asn-caret[data-idx="' + idx + '"]');
+                        if (!remotesEl) return;
+                        var isOpen = remotesEl.style.display !== 'none';
+                        remotesEl.style.display = isOpen ? 'none' : '';
+                        if (caret) caret.style.transform = isOpen ? '' : 'rotate(90deg)';
+                    });
+                });
+            })
+            .catch(function(e) {
+                if (String(wrap.dataset.asn) !== String(asn.asn)) return;
+                list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--danger)">Failed to load: ' + e + '</div>';
+            });
+    };
+
+    window._closeASNMachinesDetail = function() {
+        var wrap = document.getElementById('asnMachinesDetail');
+        if (!wrap) return;
+        wrap.style.display = 'none';
+        delete wrap.dataset.asn;
+    };
+
 
     // ── Chart theme sync ──
     // These charts are created in other modules; we collect them at runtime

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -23,6 +23,10 @@ const (
 	maxAge                          = 24 * time.Hour
 	maxHostsPerBucket               = 10000 // cap to bound memory on busy routers
 
+	// Pair tracking (local host -> remote host) for ASN/provider drill-downs.
+	maxPairsPerBucket      = 20000 // total distinct (local,remote) pairs per bucket
+	maxRemotesPerLocalHost = 500   // distinct remotes tracked per local host per bucket
+
 	// Rate ring: short circular buffer for responsive rate calculation.
 	// 6 slots × 5s = 30s window. Rates are computed over the filled
 	// portion of the ring, so peaks show within 5–10s instead of 60–120s.
@@ -59,6 +63,13 @@ type bucket struct {
 	hosts      map[string]*hostAccum
 	protoBytes map[string]uint64
 	ipVerBytes map[string]uint64
+
+	// pairs tracks per-(local host, remote host) byte/packet totals, keyed
+	// by local IP -> remote IP. This powers "which of my machines talk to
+	// ASN/provider X" drill-downs, which need local-host attribution that
+	// the flat `hosts` totals above cannot provide (hosts only tracks each
+	// IP's own totals, not who it talked to).
+	pairs map[string]map[string]*hostAccum
 }
 
 // rateSlot is one slot in the short rate ring buffer.
@@ -208,6 +219,7 @@ func (t *Tracker) Run() {
 		hosts:      make(map[string]*hostAccum),
 		protoBytes: make(map[string]uint64),
 		ipVerBytes: make(map[string]uint64),
+		pairs:      make(map[string]map[string]*hostAccum),
 	}
 
 	go t.rotateBuckets()
@@ -673,6 +685,8 @@ func (t *Tracker) accountDirection(p *parsedPkt, current *bucket, rSlot *rateSlo
 				h.txBytes += p.wireLen
 			}
 		}
+		// local (src) -> remote (dst): upload from the local host's perspective.
+		t.recordPair(current, p.srcStr, p.dstStr, p.wireLen, 0, p.wireLen)
 	} else if !p.srcLocal && p.dstLocal {
 		if h, ok := current.hosts[p.dstStr]; ok {
 			h.rxBytes += p.wireLen
@@ -685,6 +699,8 @@ func (t *Tracker) accountDirection(p *parsedPkt, current *bucket, rSlot *rateSlo
 		if h, ok := current.hosts[p.srcStr]; ok {
 			h.rxBytes += p.wireLen
 		}
+		// remote (src) -> local (dst): download from the local host's perspective.
+		t.recordPair(current, p.dstStr, p.srcStr, p.wireLen, p.wireLen, 0)
 		if rSlot != nil {
 			if h, ok := rSlot.hosts[p.srcStr]; ok {
 				h.rxBytes += p.wireLen
@@ -732,6 +748,45 @@ func (t *Tracker) accountDirection(p *parsedPkt, current *bucket, rSlot *rateSlo
 	}
 }
 
+// recordPair updates the (local host, remote host) pair accumulator used by
+// ASN/provider drill-downs (e.g. "which of my machines talk to AS15169?").
+// Bounded by maxPairsPerBucket and maxRemotesPerLocalHost so a port-scanner
+// or similar high-fanout traffic pattern can't cause unbounded growth.
+//
+// The router's own interface IPs (selfIPs) are excluded from the "local"
+// side: the router itself isn't a LAN client, and its own traffic (DNS
+// resolution, NTP, package updates, this app's own latency/speedtest
+// probes, etc.) would otherwise show up as a single "machine" talking to
+// nearly every ASN, drowning out actual client attribution. This mirrors
+// the selfIPs exclusion already applied in TopByVolume/TopByBandwidth/
+// TopByCountry/GetGeoBreakdown.
+// Must be called with t.mu held.
+func (t *Tracker) recordPair(current *bucket, localIP, remoteIP string, wireLen, rx, tx uint64) {
+	if _, isSelf := t.selfIPs[localIP]; isSelf {
+		return
+	}
+	remotes, ok := current.pairs[localIP]
+	if !ok {
+		if len(current.pairs) >= maxPairsPerBucket {
+			return
+		}
+		remotes = make(map[string]*hostAccum)
+		current.pairs[localIP] = remotes
+	}
+	acc, ok := remotes[remoteIP]
+	if !ok {
+		if len(remotes) >= maxRemotesPerLocalHost {
+			return
+		}
+		acc = &hostAccum{}
+		remotes[remoteIP] = acc
+	}
+	acc.bytes += wireLen
+	acc.rxBytes += rx
+	acc.txBytes += tx
+	acc.packets++
+}
+
 func (t *Tracker) rotateBuckets() {
 	ticker := time.NewTicker(bucketSize)
 	defer ticker.Stop()
@@ -763,6 +818,7 @@ func (t *Tracker) rotateBuckets() {
 				hosts:      make(map[string]*hostAccum),
 				protoBytes: make(map[string]uint64),
 				ipVerBytes: make(map[string]uint64),
+				pairs:      make(map[string]map[string]*hostAccum),
 			}
 			t.mu.Unlock()
 		case <-t.stopCh:
@@ -1016,6 +1072,153 @@ func (t *Tracker) GetGeoBreakdown() *GeoBreakdown {
 		ASNs:      asnResult,
 	}
 }
+
+// ASNRemoteStat holds a single remote IP's 24h traffic contribution within
+// an ASN, nested under a MachineASNStat so the UI can show exact local<->
+// remote IP pairs instead of just a per-machine sum.
+type ASNRemoteStat struct {
+	IP         string `json:"ip"`
+	Hostname   string `json:"hostname,omitempty"`
+	TotalBytes uint64 `json:"total_bytes"`
+	RxBytes    uint64 `json:"rx_bytes"`
+	TxBytes    uint64 `json:"tx_bytes"`
+	Packets    uint64 `json:"packets"`
+}
+
+// MachineASNStat holds a local host's aggregated 24h traffic to a specific
+// ASN/provider, powering the "which of my machines talk to AS X" drill-down.
+type MachineASNStat struct {
+	IP          string          `json:"ip"`
+	Hostname    string          `json:"hostname,omitempty"`
+	TotalBytes  uint64          `json:"total_bytes"`
+	RxBytes     uint64          `json:"rx_bytes"`
+	TxBytes     uint64          `json:"tx_bytes"`
+	Packets     uint64          `json:"packets"`
+	Connections int             `json:"connections"` // distinct remote IPs within the ASN
+	Remotes     []ASNRemoteStat `json:"remotes"`      // per-remote-IP breakdown, sorted by bytes desc
+}
+
+// maxRemotesInResponse caps how many remote IPs are returned per local host
+// in the ASN drill-down, so a host with hundreds of short-lived connections
+// (e.g. to a CDN) doesn't bloat the response.
+const maxRemotesInResponse = 50
+
+// TopMachinesForASN returns the local hosts (by 24h total bytes) that have
+// talked to the given ASN, along with each host's traffic totals toward it
+// and a per-remote-IP breakdown. Unlike GetGeoBreakdown (which only totals
+// bytes per-ASN with no local-host attribution), this walks the local->remote
+// pair accumulators built by recordPair so it can answer "who on my network
+// talks to this provider, and which specific remote IPs".
+func (t *Tracker) TopMachinesForASN(asn uint, n int) []MachineASNStat {
+	if t.geoDB == nil || !t.geoDB.Available() || asn == 0 {
+		return nil
+	}
+
+	// Step 1: merge the per-bucket (local -> remote) pair totals under lock.
+	t.mu.RLock()
+	agg := make(map[string]map[string]*hostAccum)
+	merge := func(pairs map[string]map[string]*hostAccum) {
+		for local, remotes := range pairs {
+			lm, ok := agg[local]
+			if !ok {
+				lm = make(map[string]*hostAccum, len(remotes))
+				agg[local] = lm
+			}
+			for remote, acc := range remotes {
+				a, ok := lm[remote]
+				if !ok {
+					a = &hostAccum{}
+					lm[remote] = a
+				}
+				a.bytes += acc.bytes
+				a.rxBytes += acc.rxBytes
+				a.txBytes += acc.txBytes
+				a.packets += acc.packets
+			}
+		}
+	}
+	for _, b := range t.buckets {
+		merge(b.pairs)
+	}
+	if t.current != nil {
+		merge(t.current.pairs)
+	}
+	t.mu.RUnlock()
+
+	// Step 2: GeoIP lookups outside the lock — filter remotes to the wanted
+	// ASN, keeping the per-remote breakdown (not just a sum) per local host.
+	type acc struct {
+		bytes, rx, tx, packets uint64
+		remotes                map[string]*hostAccum
+	}
+	byHost := make(map[string]*acc)
+	for local, remotes := range agg {
+		for remote, a := range remotes {
+			geo := t.geoDB.Lookup(remote)
+			if geo == nil || geo.ASN != asn {
+				continue
+			}
+			h, ok := byHost[local]
+			if !ok {
+				h = &acc{remotes: make(map[string]*hostAccum)}
+				byHost[local] = h
+			}
+			h.bytes += a.bytes
+			h.rx += a.rxBytes
+			h.tx += a.txBytes
+			h.packets += a.packets
+			h.remotes[remote] = a
+		}
+	}
+
+	list := make([]MachineASNStat, 0, len(byHost))
+	for ip, h := range byHost {
+		remotes := make([]ASNRemoteStat, 0, len(h.remotes))
+		for remoteIP, a := range h.remotes {
+			remotes = append(remotes, ASNRemoteStat{
+				IP:         remoteIP,
+				TotalBytes: a.bytes,
+				RxBytes:    a.rxBytes,
+				TxBytes:    a.txBytes,
+				Packets:    a.packets,
+			})
+		}
+		sort.Slice(remotes, func(i, j int) bool {
+			return remotes[i].TotalBytes > remotes[j].TotalBytes
+		})
+		if len(remotes) > maxRemotesInResponse {
+			remotes = remotes[:maxRemotesInResponse]
+		}
+		list = append(list, MachineASNStat{
+			IP:          ip,
+			TotalBytes:  h.bytes,
+			RxBytes:     h.rx,
+			TxBytes:     h.tx,
+			Packets:     h.packets,
+			Connections: len(h.remotes),
+			Remotes:     remotes,
+		})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].TotalBytes > list[j].TotalBytes
+	})
+	if len(list) > n {
+		list = list[:n]
+	}
+
+	// Step 3: Hostname (DNS) enrichment only for the trimmed result — both
+	// for the local host itself and for each of its listed remote IPs.
+	for i := range list {
+		if t.dns != nil {
+			list[i].Hostname = t.dns.LookupAddrAsync(list[i].IP)
+			for j := range list[i].Remotes {
+				list[i].Remotes[j].Hostname = t.dns.LookupAddrAsync(list[i].Remotes[j].IP)
+			}
+		}
+	}
+	return list
+}
+
 
 // BucketPoint is a single 1-minute data point for a host.
 type BucketPoint struct {


### PR DESCRIPTION
## What
Adds the ability to filter traffic by ASN/provider and see which local machines are talking to it.

Clicking an ASN in the Traffic tab's "Autonomous Systems" breakdown now opens a drill-down showing:
- Every local machine that has talked to that ASN, with its 24h total bytes
- Expanding a machine reveals the individual remote IPs (with reverse-DNS hostnames) it exchanged traffic with, and how many bytes each one contributed

## Changes
- **talkers**: track per-bucket (local host → remote host) traffic pairs, bounded to cap memory use on busy networks. The router's own interface IPs are excluded from this tracking so its own traffic isn't misattributed as a client machine.
- **talkers**: new `TopMachinesForASN` returning per-machine totals plus a sorted, capped list of contributing remote IPs for a given ASN.
- **handler/main**: new `GET /api/talkers/asn?asn=<n>` endpoint.
- **frontend**: ASN rows in the breakdown table are now clickable, opening an expandable per-machine panel with the local↔remote IP pair breakdown.
- **frontend**: fixed the Country/ASN detail tables silently rendering an empty "IPs" column (header existed but no cell was ever emitted for it).

## Testing
Built and deployed to a live router for manual verification: confirmed the ASN drill-down returns correct per-machine and per-remote-IP totals matching the ASN chart's totals, confirmed the router's own address no longer appears as a "machine" across every ASN, and confirmed the "IPs" column now populates correctly in both the Country and ASN detail tables.