### PR TITLE
Cut down background bandwidth;  DEBUG_HTTP_LOG for request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ cp env.example /opt/bandwidth-monitor/.env
 | `TLS_CERT_FILE` | *(empty)* | TLS certificate path (required when `LISTEN_PROTOCOL=https`) |
 | `TLS_KEY_FILE` | *(empty)* | TLS private key path (required when `LISTEN_PROTOCOL=https`) |
 | `PROMISCUOUS` | `true` | Enable promiscuous mode for packet capture (`true`/`false`) |
-| `DEBUG_HTTP_LOG` | `false` | Log every HTTP request (method, path+query, remote addr, duration) to stdout. Opt-in and noisy — useful for debugging client request patterns (e.g. verifying `?since=`/`?iface=` params) |
+| `DEBUG_HTTP_LOG` | `false` | Log every HTTP request (method, path+query, remote addr, status, response size in bytes, duration) to stdout. Opt-in and noisy — useful for debugging client request patterns (e.g. verifying `?since=`/`?iface=` params and the resulting response size) |
 | `INTERFACES` | *(all)* | Comma-separated list of interfaces to monitor and display (e.g. `eth0,ppp0,wg0`). Controls both the web UI and packet capture. If not set, all interfaces are used. |
 | `GEO_CITY` | `GeoLite2-City.mmdb` | Path to GeoLite2 City MMDB (includes country, city, coordinates for map). ~57 MB. For devices with limited flash (e.g. OpenWrt routers), use `GeoLite2-Country.mmdb` (~6 MB) instead — set `GEO_CITY=GeoLite2-Country.mmdb`. Country data still works, just without city-level map precision. |
 | `GEO_ASN` | `GeoLite2-ASN.mmdb` | Path to GeoLite2 ASN MMDB (~11 MB) |

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ cp env.example /opt/bandwidth-monitor/.env
 | `TLS_CERT_FILE` | *(empty)* | TLS certificate path (required when `LISTEN_PROTOCOL=https`) |
 | `TLS_KEY_FILE` | *(empty)* | TLS private key path (required when `LISTEN_PROTOCOL=https`) |
 | `PROMISCUOUS` | `true` | Enable promiscuous mode for packet capture (`true`/`false`) |
+| `DEBUG_HTTP_LOG` | `false` | Log every HTTP request (method, path+query, remote addr, duration) to stdout. Opt-in and noisy — useful for debugging client request patterns (e.g. verifying `?since=`/`?iface=` params) |
 | `INTERFACES` | *(all)* | Comma-separated list of interfaces to monitor and display (e.g. `eth0,ppp0,wg0`). Controls both the web UI and packet capture. If not set, all interfaces are used. |
 | `GEO_CITY` | `GeoLite2-City.mmdb` | Path to GeoLite2 City MMDB (includes country, city, coordinates for map). ~57 MB. For devices with limited flash (e.g. OpenWrt routers), use `GeoLite2-Country.mmdb` (~6 MB) instead — set `GEO_CITY=GeoLite2-Country.mmdb`. Country data still works, just without city-level map precision. |
 | `GEO_ASN` | `GeoLite2-ASN.mmdb` | Path to GeoLite2 ASN MMDB (~11 MB) |

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ Makefile                  → build, install, GeoIP download targets
 | `/api/debug/traceroute` | POST | ICMP traceroute with SSE progress; params: `target`, `count` (probes/hop), `maxttl` |
 | `/api/debug/dns` | GET | DNS check against 14 servers + resolver leak test; params: `domain`, `type` |
 | `/api/summary` | GET | Compact summary for menu bar clients |
-| `/api/events` | GET | SSE stream — pushes all data every second (Server-Sent Events) |
+| `/api/events` | GET | SSE stream — pushes interface rates, talkers, DNS/WiFi/latency summaries every second (Server-Sent Events, gzip-compressed when the client accepts it). Conntrack and topology are deliberately excluded — poll `/api/conntrack`/`/api/topology` directly instead |
 | `/api/liveactivity/register` | POST | Register an iOS Live Activity push token (only available when `APNS_KEY_FILE` is set) |
 
 ---

--- a/env.example
+++ b/env.example
@@ -14,6 +14,10 @@ LISTEN_PROTOCOL=http
 # Enable promiscuous mode for packet capture (true/false).
 # PROMISCUOUS=true
 
+# Log every HTTP request (method, path+query, remote addr, duration) to
+# stdout. Opt-in and noisy — useful for debugging client request patterns.
+# DEBUG_HTTP_LOG=true
+
 # HTTPS example:
 # LISTEN=:8443
 # LISTEN_PROTOCOL=https

--- a/env.example
+++ b/env.example
@@ -14,8 +14,9 @@ LISTEN_PROTOCOL=http
 # Enable promiscuous mode for packet capture (true/false).
 # PROMISCUOUS=true
 
-# Log every HTTP request (method, path+query, remote addr, duration) to
-# stdout. Opt-in and noisy — useful for debugging client request patterns.
+# Log every HTTP request (method, path+query, remote addr, status, response
+# size in bytes, duration) to stdout. Opt-in and noisy — useful for debugging
+# client request patterns.
 # DEBUG_HTTP_LOG=true
 
 # HTTPS example:

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -851,7 +852,14 @@ func fetchExternalIP() string {
 }
 
 // buildPayload assembles the JSON payload sent over the SSE stream.
-func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, ts *topology.Scanner, dnsRes *resolver.Resolver, origin *originResolver) map[string]interface{} {
+//
+// The full conntrack table and topology graph are deliberately excluded: a
+// busy router's NAT table (up to 200 IPv4 + 200 IPv6 entries, each with
+// hostname/geo/ASN enrichment) resent whole every second is the dominant
+// cost of this stream, regardless of whether the NAT or Network tab is even
+// open. Both have dedicated endpoints (/api/conntrack, /api/topology) that
+// the respective tabs poll directly, only while visible.
+func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, lm *latency.Monitor, ts *topology.Scanner, dnsRes *resolver.Resolver, origin *originResolver) map[string]interface{} {
 	geo := t.GetGeoBreakdown()
 	var ov *topology.Overview
 	if ts != nil {
@@ -912,16 +920,8 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 	if wp != nil {
 		payload["wifi"] = wp.GetSummary()
 	}
-	if ct != nil {
-		if s := ct.GetSummary(); s != nil {
-			payload["conntrack"] = s
-		}
-	}
 	if lm != nil {
 		payload["latency"] = lm.GetStatus()
-	}
-	if ov != nil {
-		payload["topology"] = ov
 	}
 	return payload
 }
@@ -934,7 +934,7 @@ func buildPayload(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, w
 // backed up (e.g. hibernating laptop, congested link), only the most recent
 // payload is kept — preventing kernel send-buffer buildup (same backpressure
 // logic that PR #18 added to the old WebSocket handler).
-func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, ct *conntrack.Tracker, lm *latency.Monitor, ts *topology.Scanner, dnsRes *resolver.Resolver, geoDB *geoip.DB) http.HandlerFunc {
+func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Provider, lm *latency.Monitor, ts *topology.Scanner, dnsRes *resolver.Resolver, geoDB *geoip.DB) http.HandlerFunc {
 	origin := newOriginResolver(geoDB)
 	return func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
@@ -948,6 +948,21 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("X-Accel-Buffering", "no")
 
+		// The bulk of the payload (talkers, sparklines, DNS/WiFi summaries) is
+		// repetitive JSON — field names and similar-valued numbers — that
+		// compresses well. EventSource-driving browsers always advertise
+		// Accept-Encoding: gzip, so this applies to virtually every real
+		// client without any version negotiation.
+		var out io.Writer = w
+		flush := flusher.Flush
+		if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			gz := gzip.NewWriter(w)
+			defer gz.Close()
+			out = gz
+			flush = func() { gz.Flush(); flusher.Flush() }
+		}
+
 		// Non-blocking write channel: the ticker produces payloads and a
 		// dedicated writer goroutine drains them.  If the client is backed
 		// up, only the most recent payload is kept.
@@ -958,15 +973,15 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 		go func() {
 			defer close(writerDone)
 			for data := range sendCh {
-				if _, err := fmt.Fprintf(w, "data: %s\n\n", data); err != nil {
+				if _, err := fmt.Fprintf(out, "data: %s\n\n", data); err != nil {
 					return
 				}
-				flusher.Flush()
+				flush()
 			}
 		}()
 
 		// Send initial payload immediately.
-		data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, ts, dnsRes, origin))
+		data, err := json.Marshal(buildPayload(c, t, dp, wp, lm, ts, dnsRes, origin))
 		if err != nil {
 			close(sendCh)
 			return
@@ -985,7 +1000,7 @@ func SSE(c *collector.Collector, t *talkers.Tracker, dp dns.Provider, wp wifi.Pr
 			case <-writerDone:
 				return
 			case <-ticker.C:
-				data, err := json.Marshal(buildPayload(c, t, dp, wp, ct, lm, ts, dnsRes, origin))
+				data, err := json.Marshal(buildPayload(c, t, dp, wp, lm, ts, dnsRes, origin))
 				if err != nil {
 					continue
 				}

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 	tlsKeyFile := env("TLS_KEY_FILE", "")
 	promiscuous := env("PROMISCUOUS", "true")
 	promiscuousBool, _ := strconv.ParseBool(promiscuous)
+	debugHTTPLog, _ := strconv.ParseBool(env("DEBUG_HTTP_LOG", "false"))
 
 	if listenProto != "http" && listenProto != "https" {
 		log.Fatalf("LISTEN_PROTOCOL: invalid value %q (expected http or https)", listenProto)
@@ -379,9 +380,16 @@ func main() {
 	if listenProto == "https" {
 		log.Printf("server: TLS enabled cert=%s key=%s", tlsCertFile, tlsKeyFile)
 	}
+	var handler http.Handler = mux
+	if debugHTTPLog {
+		handler = withRequestLog(handler)
+		log.Printf("server: DEBUG_HTTP_LOG enabled — logging every request to stdout")
+	}
+	handler = withSignature(handler)
+
 	srv := &http.Server{
 		Addr:              listenAddr,
-		Handler:           withSignature(mux),
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
@@ -466,5 +474,17 @@ func withSignature(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Bandwidth-Monitor", version.String())
 		h.ServeHTTP(w, r)
+	})
+}
+
+// withRequestLog wraps an http.Handler to log method, path+query, and remote
+// addr for every request to stdout. Opt-in via DEBUG_HTTP_LOG — useful for
+// watching what clients actually request (e.g. confirming a browser client
+// is sending the expected ?since=/?iface= params), but noisy for normal use.
+func withRequestLog(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		h.ServeHTTP(w, r)
+		log.Printf("http: %s %s %s %s", r.Method, r.URL.RequestURI(), r.RemoteAddr, time.Since(start))
 	})
 }

--- a/main.go
+++ b/main.go
@@ -339,7 +339,7 @@ func main() {
 	mux.HandleFunc("/api/debug/tcpcheck", handler.DebugTCPCheck(statsCollector))
 	mux.HandleFunc("/api/summary", handler.MenuBarSummary(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker))
 	mux.HandleFunc("/api/topology", handler.TopologySummary(topoScanner))
-	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, conntrackTracker, latencyMonitor, topoScanner, dnsResolver, geoDB))
+	mux.HandleFunc("/api/events", handler.SSE(statsCollector, talkerTracker, dnsProvider, wifiProvider, latencyMonitor, topoScanner, dnsResolver, geoDB))
 	if liveActivityMgr != nil {
 		mux.HandleFunc("/api/liveactivity/register", handler.LiveActivityRegister(liveActivityMgr))
 	}

--- a/main.go
+++ b/main.go
@@ -477,14 +477,51 @@ func withSignature(h http.Handler) http.Handler {
 	})
 }
 
-// withRequestLog wraps an http.Handler to log method, path+query, and remote
-// addr for every request to stdout. Opt-in via DEBUG_HTTP_LOG — useful for
-// watching what clients actually request (e.g. confirming a browser client
-// is sending the expected ?since=/?iface= params), but noisy for normal use.
+// responseLogger wraps http.ResponseWriter to capture the status code and
+// bytes written, for withRequestLog. It implements http.Flusher (delegating
+// to the underlying ResponseWriter) so the SSE handler's type-assertion for
+// flush support keeps working when logging is enabled.
+type responseLogger struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (rl *responseLogger) WriteHeader(status int) {
+	rl.status = status
+	rl.ResponseWriter.WriteHeader(status)
+}
+
+func (rl *responseLogger) Write(b []byte) (int, error) {
+	if rl.status == 0 {
+		rl.status = http.StatusOK
+	}
+	n, err := rl.ResponseWriter.Write(b)
+	rl.bytes += n
+	return n, err
+}
+
+func (rl *responseLogger) Flush() {
+	if f, ok := rl.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// withRequestLog wraps an http.Handler to log method, path+query, remote
+// addr, status, response size, and duration for every request to stdout.
+// Opt-in via DEBUG_HTTP_LOG — useful for watching what clients actually
+// request and how much data each response actually costs (e.g. confirming a
+// browser client is sending ?since=/?iface= and getting a small response
+// back, not the full history dump), but noisy for normal use.
 func withRequestLog(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		h.ServeHTTP(w, r)
-		log.Printf("http: %s %s %s %s", r.Method, r.URL.RequestURI(), r.RemoteAddr, time.Since(start))
+		rl := &responseLogger{ResponseWriter: w}
+		h.ServeHTTP(rl, r)
+		status := rl.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		log.Printf("http: %s %s %s %d %dB %s", r.Method, r.URL.RequestURI(), r.RemoteAddr, status, rl.bytes, time.Since(start))
 	})
 }

--- a/static/js/core.js
+++ b/static/js/core.js
@@ -111,6 +111,12 @@
             _stHistoryLoaded = true;
             if (BM.loadSpeedTestHistory) BM.loadSpeedTestHistory();
         }
+        // NAT/Network poll their own REST endpoints instead of riding the 1s
+        // SSE tick (see nat.js/network.js) — only while their tab is visible.
+        if (BM._stopNATPolling) BM._stopNATPolling();
+        if (BM._stopNetworkPolling) BM._stopNetworkPolling();
+        if (tab === 'nat' && BM._startNATPolling) BM._startNATPolling();
+        if (tab === 'network' && BM._startNetworkPolling) BM._startNetworkPolling();
         if (BM._lastPayload) _renderTab(tab, BM._lastPayload, true);
     };
 
@@ -143,9 +149,9 @@
         } else if (tab === 'wifi') {
             if (BM.updateWiFi) BM.updateWiFi(d.wifi || null);
         } else if (tab === 'network') {
-            if (BM.updateNetwork) BM.updateNetwork(d.topology || null, d.topology_bandwidth || d.top_bandwidth || []);
-        } else if (tab === 'nat') {
-            if (BM.updateNAT) BM.updateNAT(d.conntrack || null);
+            // Topology graph itself comes from network.js's own poll of
+            // /api/topology; only the live per-node bandwidth rides the tick.
+            if (BM._updateNetworkBandwidth) BM._updateNetworkBandwidth(d.topology_bandwidth || d.top_bandwidth || []);
         }
     }
     BM._renderTab = _renderTab;

--- a/static/js/tabs/nat.js
+++ b/static/js/tabs/nat.js
@@ -248,6 +248,29 @@
         tb.innerHTML = h;
     }
 
+    // The NAT table used to ride along on the 1s SSE tick, but the full
+    // conntrack table (up to 200 IPv4 + 200 IPv6 entries with hostname/geo/ASN
+    // enrichment) resent every second — whether or not this tab is even open —
+    // was the dominant cost of that stream. Poll /api/conntrack directly
+    // instead, only while this tab is visible.
+    var _natPollInterval = null;
+
+    function _fetchConntrack() {
+        return fetch('/api/conntrack').then(function(r) { return r.json(); }).then(function(data) {
+            if (data) BM.updateNAT(data);
+        }).catch(function(e) { console.error('conntrack load:', e); });
+    }
+
+    BM._startNATPolling = function() {
+        if (_natPollInterval) return;
+        _fetchConntrack();
+        _natPollInterval = setInterval(_fetchConntrack, 5000);
+    };
+
+    BM._stopNATPolling = function() {
+        if (_natPollInterval) { clearInterval(_natPollInterval); _natPollInterval = null; }
+    };
+
     // Wire search/filter on NAT entry table to re-render (with debounce on search)
     var _natSearchTimer = null;
     (function() {

--- a/static/js/tabs/network.js
+++ b/static/js/tabs/network.js
@@ -51,6 +51,37 @@
         window._filterNetworkClients();
     };
 
+    // The topology graph used to ride along on the 1s SSE tick, but a busy
+    // LAN's full node/link list resent every second — whether or not this tab
+    // is even open — was needless waste; the scanner itself only refreshes
+    // every 30s server-side. Poll /api/topology directly instead, only while
+    // this tab is visible. Per-node live bandwidth (which does need to feel
+    // live) keeps arriving every second via the SSE tick through
+    // BM._updateNetworkBandwidth, re-rendering the graph with the topology
+    // already cached from the last poll.
+    var _topoPollInterval = null;
+
+    function _fetchTopology() {
+        return fetch('/api/topology').then(function(r) { return r.json(); }).then(function(data) {
+            if (data) BM.updateNetwork(data, _lastBandwidth);
+        }).catch(function(e) { console.error('topology load:', e); });
+    }
+
+    BM._startNetworkPolling = function() {
+        if (_topoPollInterval) return;
+        _fetchTopology();
+        _topoPollInterval = setInterval(_fetchTopology, 15000);
+    };
+
+    BM._stopNetworkPolling = function() {
+        if (_topoPollInterval) { clearInterval(_topoPollInterval); _topoPollInterval = null; }
+    };
+
+    BM._updateNetworkBandwidth = function(bandwidth) {
+        _lastBandwidth = bandwidth || [];
+        if (_lastTopology) renderNetworkTopology(_lastTopology, _lastBandwidth);
+    };
+
     // ── Client table rendering ──
 
     window._filterNetworkClients = function() {


### PR DESCRIPTION
## Summary
- Adds an opt-in `DEBUG_HTTP_LOG` env var that logs method, path+query, remote addr, status, response size, and duration for every HTTP request to stdout. Off by default.
- Fixes the actual regression this was investigating: the SSE `/api/events` stream resent the *full* conntrack table (up to 200 IPv4 + 200 IPv6 entries with hostname/geo/ASN enrichment) and the full topology graph every second, to every connected browser tab, regardless of whether the NAT or Network tab was even open. On a busy router this was the dominant source of ongoing bandwidth from just having the page open (~1.6Mbps sustained, confirmed via `DEBUG_HTTP_LOG`).
  - `conntrack`/`topology` removed from the SSE payload; both already have dedicated REST endpoints (`/api/conntrack`, `/api/topology`).
  - The NAT and Network tabs now poll those endpoints directly, only while their tab is visible (NAT every 5s, topology every 15s) — starting/stopping as you switch tabs.
  - The Network tab's live per-node bandwidth still updates every second via the SSE tick; only the (mostly static) topology graph itself moved to polling.
  - The remaining SSE payload is gzip-compressed when the client supports it (every real browser does).

## Context
Follow-up from investigating a bandwidth-usage regression (9be86b7, already fixed by 5d02c39) where the client fetched the full `/api/interfaces/history` payload on every reconnect. Adding `DEBUG_HTTP_LOG` to watch real request traffic surfaced that the actual live-page regression was elsewhere: the SSE stream's per-second conntrack/topology payload, not `/api/interfaces/history` (which was already fixed).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] Ran the server locally with `DEBUG_HTTP_LOG=true` and confirmed request logging (method, status, size, duration) for a `/api/interfaces/history?since=&iface=` request and a plain `/api/summary` request.
- [x] Confirmed the SSE payload's key set no longer includes `conntrack`/`topology` (verified with and without `Accept-Encoding: gzip`), while `topology_bandwidth` still does.
- [x] Confirmed `/api/conntrack` and `/api/topology` still work standalone.
- [x] Playwright: loaded the page, switched to the NAT tab (saw `/api/conntrack` fetch on open + one more after 5s), switched to the Network tab (saw `/api/topology` fetch on open), switched away to another tab and confirmed neither endpoint was polled again — no console/page errors during the flow.
- [x] Measured wire size: ~9.7KB uncompressed vs ~1.5KB gzip-compressed for the same SSE window (on this sandbox's near-empty dataset; savings scale with payload size on real deployments).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RhvFZaJdfEoFqKmhgfh6HN)_