### PR TITLE
Fix frontend stream finalization and asset caching

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"crypto/sha256"
 	"embed"
-	"encoding/hex"
 	"fmt"
 	"io/fs"
 	"log"
@@ -34,6 +32,7 @@ import (
 	"bandwidth-monitor/topology"
 	"bandwidth-monitor/unifi"
 	"bandwidth-monitor/version"
+	"bandwidth-monitor/webassets"
 	"bandwidth-monitor/wifi"
 )
 
@@ -353,8 +352,10 @@ func main() {
 	// Safari caches the response with heuristic expiration and never
 	// revalidates — even on Cmd+R.  Injecting ?v=<hash> into the HTML
 	// forces the browser to fetch fresh assets after every build.
-	assetVersion := computeAssetVersions(staticFiles)
-	indexHTML := buildIndexHTML(staticFiles, assetVersion)
+	indexHTML, err := webassets.BuildIndexHTML(staticSub, version.String())
+	if err != nil {
+		log.Fatalf("Build embedded index: %v", err)
+	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" && r.URL.Path != "/index.html" {
@@ -430,42 +431,6 @@ func main() {
 		liveActivityMgr.Stop()
 	}
 	dnsResolver.Stop()
-}
-
-// computeAssetVersions hashes key embedded files to produce short
-// cache-busting version strings.  The returned map is keyed by
-// filename (e.g. "app.js") → 8-char hex hash.
-func computeAssetVersions(embedded embed.FS) map[string]string {
-	versions := make(map[string]string)
-	for _, name := range []string{"static/js/core.js", "static/style.css"} {
-		data, err := embedded.ReadFile(name)
-		if err != nil {
-			continue
-		}
-		h := sha256.Sum256(data)
-		// Use the path relative to static/ as key (e.g. "js/core.js", "style.css")
-		relPath := strings.TrimPrefix(name, "static/")
-		versions[relPath] = hex.EncodeToString(h[:4])
-	}
-	return versions
-}
-
-// buildIndexHTML reads the embedded index.html and injects ?v=<hash>
-// into script src and link href attributes for cache-busted assets.
-func buildIndexHTML(embedded embed.FS, versions map[string]string) []byte {
-	data, err := embedded.ReadFile("static/index.html")
-	if err != nil {
-		log.Fatalf("embedded index.html: %v", err)
-	}
-	html := string(data)
-	for name, ver := range versions {
-		// Replace href="style.css" → href="style.css?v=abcd1234"
-		// Replace src="app.js"     → src="app.js?v=abcd1234"
-		html = strings.ReplaceAll(html, `"`+name+`"`, `"`+name+"?v="+ver+`"`)
-	}
-	// Inject the build version into the header.
-	html = strings.Replace(html, "Bandwidth Monitor<span>v1.0</span>", "Bandwidth Monitor<span>"+version.String()+"</span>", 1)
-	return []byte(html)
 }
 
 // withSignature wraps an http.Handler to inject a X-Bandwidth-Monitor header

--- a/static/js/tabs/debug.js
+++ b/static/js/tabs/debug.js
@@ -59,6 +59,7 @@
 
         document.getElementById('trResults').style.display = 'none';
 
+        var finished = false;
         BM.streamSSE({
             url: '/api/debug/traceroute?target=' + encodeURIComponent(target) + '&count=' + count + (iface ? '&iface=' + encodeURIComponent(iface) : ''),
             method: 'POST',
@@ -81,14 +82,22 @@
                     finishTraceroute();
                 }
             },
-            onDone: function() {},
-            onError: function() {
-                phase.textContent = 'Connection error';
+            onDone: function() {
+                if (finished) return;
+                phase.textContent = 'Connection closed before traceroute completed';
+                bar.className = 'speedtest-progress-bar-fill error';
+                finishTraceroute();
+            },
+            onError: function(err) {
+                phase.textContent = 'Error — ' + BM.describeStreamError(err);
+                bar.className = 'speedtest-progress-bar-fill error';
                 finishTraceroute();
             }
         });
 
         function finishTraceroute() {
+            if (finished) return;
+            finished = true;
             _trRunning = false;
             btn.disabled = false;
             btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><polygon points="5 3 19 12 5 21 5 3"/></svg> Run';
@@ -152,6 +161,7 @@
 
         var probeCount = 0;
 
+        var finished = false;
         BM.streamSSE({
             url: '/api/debug/mtu?target=' + encodeURIComponent(target) + (iface ? '&iface=' + encodeURIComponent(iface) : ''),
             method: 'POST',
@@ -172,14 +182,22 @@
                     finishMTU();
                 }
             },
-            onDone: function() {},
-            onError: function() {
-                phase.textContent = 'Connection error';
+            onDone: function() {
+                if (finished) return;
+                phase.textContent = 'Connection closed before MTU discovery completed';
+                bar.className = 'speedtest-progress-bar-fill error';
+                finishMTU();
+            },
+            onError: function(err) {
+                phase.textContent = 'Error — ' + BM.describeStreamError(err);
+                bar.className = 'speedtest-progress-bar-fill error';
                 finishMTU();
             }
         });
 
         function finishMTU() {
+            if (finished) return;
+            finished = true;
             _mtuRunning = false;
             btn.disabled = false;
             btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><path d="M12 2v20M2 12h20"/></svg> Discover';

--- a/static/js/tabs/speedtest.js
+++ b/static/js/tabs/speedtest.js
@@ -175,35 +175,12 @@
         var iface = (ifaceSel && ifaceSel.style.display !== 'none') ? ifaceSel.value : '';
         var runUrl = '/api/speedtest/run' + (iface ? ('?iface=' + encodeURIComponent(iface)) : '');
 
-        fetch(runUrl, { method: 'POST' }).then(function(resp) {
-            if (resp.status === 409) {
-                phase.textContent = 'Test already running';
-                return;
-            }
-            var reader = resp.body.getReader();
-            var decoder = new TextDecoder();
-            var buffer = '';
+        var finished = false;
 
-            function processChunk() {
-                return reader.read().then(function(result) {
-                    if (result.done) return;
-                    buffer += decoder.decode(result.value, { stream: true });
-                    var lines = buffer.split('\n');
-                    buffer = lines.pop();
-
-                    for (var i = 0; i < lines.length; i++) {
-                        var line = lines[i].trim();
-                        if (!line.startsWith('data: ')) continue;
-                        try {
-                            var p = JSON.parse(line.substring(6));
-                            handleProgress(p);
-                        } catch(e) {}
-                    }
-                    return processChunk();
-                });
-            }
-
-            function handleProgress(p) {
+        BM.streamSSE({
+            url: runUrl,
+            method: 'POST',
+            onMessage: function(p) {
                 if (p.phase === 'ping') {
                     phase.textContent = 'Measuring latency...';
                     bar.style.width = (p.percent * 0.10) + '%';
@@ -245,19 +222,29 @@
                     BM.loadSpeedTestHistory();
                     finishTest();
                 } else if (p.phase === 'error') {
-                    phase.textContent = 'Error — test failed';
+                    phase.textContent = p.message || 'Error — test failed';
                     bar.className = 'speedtest-progress-bar-fill error';
                     finishTest();
                 }
+            },
+            onDone: function() {
+                if (finished) return;
+                phase.textContent = 'Connection closed before test completed';
+                bar.className = 'speedtest-progress-bar-fill error';
+                finishTest();
+            },
+            onError: function(err) {
+                phase.textContent = err && err.status === 409
+                    ? 'Test already running'
+                    : 'Error — ' + BM.describeStreamError(err);
+                bar.className = 'speedtest-progress-bar-fill error';
+                finishTest();
             }
-
-            return processChunk();
-        }).catch(function(e) {
-            phase.textContent = 'Connection error';
-            finishTest();
         });
 
         function finishTest() {
+            if (finished) return;
+            finished = true;
             _stRunning = false;
             btn.disabled = false;
             btn.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="width:14px;height:14px"><polygon points="5 3 19 12 5 21 5 3"/></svg> Start Test';

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -68,41 +68,60 @@
 
     /* Reusable SSE-style stream reader for POST endpoints that return
      * Server-Sent Events (e.g. speed test, traceroute, MTU discovery).
+     * onDone is called only for a clean EOF; HTTP, fetch, and read failures
+     * are passed to onError.
      * opts: { url, method, onMessage(parsed), onDone(), onError(err) } */
     BM.streamSSE = function(opts) {
         var method = opts.method || 'POST';
-        fetch(opts.url, { method: method }).then(function(resp) {
-            if (!resp.ok && opts.onError) {
-                if (resp.status === 409) { opts.onError('already running'); return; }
-                opts.onError('HTTP ' + resp.status);
-                return;
+        return fetch(opts.url, { method: method }).then(function(resp) {
+            if (!resp.ok) {
+                var httpError = new Error(resp.status === 409 ? 'Already running' : 'HTTP ' + resp.status);
+                httpError.status = resp.status;
+                throw httpError;
             }
+            if (!resp.body) throw new Error('Response body is not readable');
+
             var reader = resp.body.getReader();
             var decoder = new TextDecoder();
             var buffer = '';
 
+            function processLines(lines) {
+                for (var i = 0; i < lines.length; i++) {
+                    var line = lines[i].trim();
+                    if (!line.startsWith('data:')) continue;
+                    try {
+                        var p = JSON.parse(line.substring(5).trim());
+                        if (opts.onMessage) opts.onMessage(p);
+                    } catch(e) {}
+                }
+            }
+
             function processChunk() {
                 return reader.read().then(function(result) {
                     if (result.done) {
-                        if (opts.onDone) opts.onDone();
+                        buffer += decoder.decode();
+                        if (buffer) processLines([buffer]);
                         return;
                     }
                     buffer += decoder.decode(result.value, { stream: true });
                     var lines = buffer.split('\n');
                     buffer = lines.pop();
-                    for (var i = 0; i < lines.length; i++) {
-                        var line = lines[i].trim();
-                        if (!line.startsWith('data: ')) continue;
-                        try {
-                            var p = JSON.parse(line.substring(6));
-                            if (opts.onMessage) opts.onMessage(p);
-                        } catch(e) {}
-                    }
+                    processLines(lines);
                     return processChunk();
                 });
             }
-            processChunk().catch(function() { if (opts.onDone) opts.onDone(); });
-        }).catch(function(e) { if (opts.onError) opts.onError(e); });
+
+            return processChunk();
+        }).then(function() {
+            if (opts.onDone) opts.onDone();
+        }).catch(function(e) {
+            if (opts.onError) opts.onError(e);
+        });
+    };
+
+    BM.describeStreamError = function(err) {
+        if (err && err.message) return err.message;
+        return String(err || 'Connection error');
     };
 
     // Doughnut chart helpers

--- a/webassets/index.go
+++ b/webassets/index.go
@@ -1,0 +1,105 @@
+// Package webassets prepares embedded web assets for serving.
+package webassets
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/url"
+	"path"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// BuildIndexHTML fingerprints every local script and link asset referenced by
+// index.html, then injects the build version displayed in the header.
+func BuildIndexHTML(staticFS fs.FS, buildVersion string) ([]byte, error) {
+	data, err := fs.ReadFile(staticFS, "index.html")
+	if err != nil {
+		return nil, fmt.Errorf("read index.html: %w", err)
+	}
+
+	data, err = fingerprintIndexAssets(staticFS, data)
+	if err != nil {
+		return nil, err
+	}
+
+	data = bytes.Replace(data, []byte("Bandwidth Monitor<span>v1.0</span>"), []byte("Bandwidth Monitor<span>"+buildVersion+"</span>"), 1)
+	return data, nil
+}
+
+func fingerprintIndexAssets(staticFS fs.FS, index []byte) ([]byte, error) {
+	tokenizer := html.NewTokenizer(bytes.NewReader(index))
+	var output bytes.Buffer
+
+	for {
+		tokenType := tokenizer.Next()
+		switch tokenType {
+		case html.ErrorToken:
+			if tokenizer.Err() != io.EOF {
+				return nil, fmt.Errorf("parse index.html: %w", tokenizer.Err())
+			}
+			return output.Bytes(), nil
+		case html.StartTagToken, html.SelfClosingTagToken:
+			token := tokenizer.Token()
+			attribute := ""
+			switch strings.ToLower(token.Data) {
+			case "script":
+				attribute = "src"
+			case "link":
+				attribute = "href"
+			}
+			if attribute == "" {
+				output.Write(tokenizer.Raw())
+				continue
+			}
+
+			changed := false
+			for i := range token.Attr {
+				if !strings.EqualFold(token.Attr[i].Key, attribute) {
+					continue
+				}
+				versioned, local, err := fingerprintAssetURL(staticFS, token.Attr[i].Val)
+				if err != nil {
+					return nil, err
+				}
+				if local {
+					token.Attr[i].Val = versioned
+					changed = true
+				}
+			}
+			if changed {
+				output.WriteString(token.String())
+			} else {
+				output.Write(tokenizer.Raw())
+			}
+		default:
+			output.Write(tokenizer.Raw())
+		}
+	}
+}
+
+func fingerprintAssetURL(staticFS fs.FS, rawURL string) (string, bool, error) {
+	assetURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false, fmt.Errorf("parse asset URL %q: %w", rawURL, err)
+	}
+	if assetURL.Scheme != "" || assetURL.Host != "" || strings.HasPrefix(rawURL, "//") || assetURL.Path == "" {
+		return rawURL, false, nil
+	}
+
+	assetPath := strings.TrimPrefix(path.Clean("/"+assetURL.Path), "/")
+	data, err := fs.ReadFile(staticFS, assetPath)
+	if err != nil {
+		return "", false, fmt.Errorf("read index asset %q: %w", assetPath, err)
+	}
+	hash := sha256.Sum256(data)
+	query := assetURL.Query()
+	query.Set("v", hex.EncodeToString(hash[:4]))
+	assetURL.RawQuery = query.Encode()
+	return assetURL.String(), true, nil
+}

--- a/webassets/index_test.go
+++ b/webassets/index_test.go
@@ -1,0 +1,94 @@
+package webassets
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestBuildIndexHTMLWithProjectAssets(t *testing.T) {
+	if _, err := BuildIndexHTML(os.DirFS("../static"), "test-version"); err != nil {
+		t.Fatalf("BuildIndexHTML() with project assets error = %v", err)
+	}
+}
+
+func TestBuildIndexHTMLFingerprintsAllLocalAssets(t *testing.T) {
+	files := fstest.MapFS{
+		"index.html": {
+			Data: []byte(`<!doctype html><html><head>
+<link rel="stylesheet" href="style.css">
+<link rel="preconnect" href="https://cdn.example.com">
+<script src="//cdn.example.com/library.js"></script>
+<script src="https://cdn.example.com/other.js"></script>
+<script src="js/tabs/example.js"></script>
+</head><body>Bandwidth Monitor<span>v1.0</span></body></html>`),
+		},
+		"style.css":          {Data: []byte("body {}")},
+		"js/tabs/example.js": {Data: []byte("window.example = true;")},
+	}
+
+	got, err := BuildIndexHTML(files, "test-version")
+	if err != nil {
+		t.Fatalf("BuildIndexHTML() error = %v", err)
+	}
+	html := string(got)
+
+	for _, want := range []string{
+		`href="style.css?v=` + shortHash(files["style.css"].Data) + `"`,
+		`src="js/tabs/example.js?v=` + shortHash(files["js/tabs/example.js"].Data) + `"`,
+		`href="https://cdn.example.com"`,
+		`src="//cdn.example.com/library.js"`,
+		`src="https://cdn.example.com/other.js"`,
+		`Bandwidth Monitor<span>test-version</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("rewritten index missing %q:\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, "cdn.example.com?") || strings.Contains(html, "cdn.example.com/library.js?") || strings.Contains(html, "cdn.example.com/other.js?") {
+		t.Errorf("external URLs were fingerprinted:\n%s", html)
+	}
+}
+
+func TestBuildIndexHTMLAssetVersionChangesWithContent(t *testing.T) {
+	index := []byte(`<script src="js/tabs/example.js"></script>`)
+	first := fstest.MapFS{
+		"index.html":         {Data: index},
+		"js/tabs/example.js": {Data: []byte("first")},
+	}
+	second := fstest.MapFS{
+		"index.html":         {Data: index},
+		"js/tabs/example.js": {Data: []byte("second")},
+	}
+
+	firstHTML, err := BuildIndexHTML(first, "test")
+	if err != nil {
+		t.Fatalf("first BuildIndexHTML() error = %v", err)
+	}
+	secondHTML, err := BuildIndexHTML(second, "test")
+	if err != nil {
+		t.Fatalf("second BuildIndexHTML() error = %v", err)
+	}
+	if string(firstHTML) == string(secondHTML) {
+		t.Fatalf("asset content change did not change rewritten index: %s", firstHTML)
+	}
+}
+
+func TestBuildIndexHTMLRejectsMissingLocalAsset(t *testing.T) {
+	files := fstest.MapFS{
+		"index.html": {Data: []byte(`<script src="js/missing.js"></script>`)},
+	}
+
+	_, err := BuildIndexHTML(files, "test")
+	if err == nil || !strings.Contains(err.Error(), `read index asset "js/missing.js"`) {
+		t.Fatalf("BuildIndexHTML() error = %v, want missing asset error", err)
+	}
+}
+
+func shortHash(data []byte) string {
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:4])
+}


### PR DESCRIPTION
## Summary
- release speed test, traceroute, and MTU controls after HTTP failures, stream read failures, or premature EOF
- preserve terminal server error messages and distinguish them from connection failures
- fingerprint every local script and link referenced by `index.html` while preserving external URLs
- add focused tests for index rewriting, content-driven version changes, missing assets, and the project index

## Validation
- `go test ./webassets`
- `GOOS=linux GOARCH=amd64 go build ./...`
- `GOOS=linux GOARCH=amd64 go vet ./...`
- Linux-targeted test compilation for all packages
- Node syntax checks for all first-party JavaScript
- SSE callback harness covering HTTP 409, clean EOF, and read failure