### PR TITLE
Harden frontend output escaping

### DIFF
--- a/static/js/components/host-modal.js
+++ b/static/js/components/host-modal.js
@@ -29,7 +29,8 @@
             })
             .catch(function(e) {
                 if (modal.dataset.ip !== ip) return;
-                body.innerHTML = '<div style="text-align:center;padding:32px;color:var(--danger)">Failed to load: ' + e + '</div>';
+                body.innerHTML = '<div style="text-align:center;padding:32px;color:var(--danger)"></div>';
+                body.firstChild.textContent = 'Failed to load: ' + e;
             });
     };
 
@@ -92,7 +93,7 @@
         h += stat('Rate', BM.formatRate(d.rate_bytes));
         h += stat('RX Rate', BM.formatRate(d.rx_rate), 'rx');
         h += stat('TX Rate', BM.formatRate(d.tx_rate), 'tx');
-        h += stat('Packets', (d.packets || 0).toLocaleString());
+        h += stat('Packets', BM.formatCount(d.packets));
         h += stat('Connections', d.connections ? d.connections.length.toLocaleString() : '0');
         h += '</div>';
 
@@ -126,25 +127,25 @@
                 if (c.orig_src_city && c.orig_src_geo) srcInfo.push(BM.countryFlag(c.orig_src_geo) + ' ' + c.orig_src_city);
                 else if (c.orig_src_geo) srcInfo.push(BM.countryFlag(c.orig_src_geo) + ' ' + c.orig_src_geo);
                 if (c.orig_src_asn) srcInfo.push(c.orig_src_asn);
-                var srcHtml = '<div style="font-family:var(--font-mono,monospace);font-size:11px">' + srcAddr + '</div>';
-                if (srcInfo.length) srcHtml += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px">' + srcInfo.join(' &middot; ') + '</div>';
+                var srcHtml = '<div style="font-family:var(--font-mono,monospace);font-size:11px">' + BM.escHtml(srcAddr) + '</div>';
+                if (srcInfo.length) srcHtml += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px">' + srcInfo.map(BM.escHtml).join(' &middot; ') + '</div>';
                 var dstAddr = c.orig_dst + (c.orig_dport ? ':' + c.orig_dport : '');
                 var dstInfo = [];
                 if (c.orig_dst_host) dstInfo.push(c.orig_dst_host);
                 if (c.orig_dst_city && c.orig_dst_geo) dstInfo.push(BM.countryFlag(c.orig_dst_geo) + ' ' + c.orig_dst_city);
                 else if (c.orig_dst_geo) dstInfo.push(BM.countryFlag(c.orig_dst_geo) + ' ' + c.orig_dst_geo);
                 if (c.orig_dst_asn) dstInfo.push(c.orig_dst_asn);
-                var dstHtml = '<div style="font-family:var(--font-mono,monospace);font-size:11px">' + dstAddr + '</div>';
-                if (dstInfo.length) dstHtml += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px">' + dstInfo.join(' &middot; ') + '</div>';
+                var dstHtml = '<div style="font-family:var(--font-mono,monospace);font-size:11px">' + BM.escHtml(dstAddr) + '</div>';
+                if (dstInfo.length) dstHtml += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px">' + dstInfo.map(BM.escHtml).join(' &middot; ') + '</div>';
                 var familyBadge = c.family === 'ipv6' ? '<span style="font-size:9px;color:var(--text-2);background:var(--bg-2);padding:1px 4px;border-radius:3px;margin-left:4px">v6</span>' : '';
                 h += '<tr' + rowBg + '>';
-                h += '<td style="padding:6px 10px">' + (c.protocol || '').toUpperCase() + familyBadge + '</td>';
-                h += '<td style="padding:6px 10px">' + (c.state || '—') + '</td>';
+                h += '<td style="padding:6px 10px">' + BM.escHtml((c.protocol || '').toUpperCase()) + familyBadge + '</td>';
+                h += '<td style="padding:6px 10px">' + BM.escHtml(c.state || '—') + '</td>';
                 h += '<td style="padding:6px 10px">' + srcHtml + '</td>';
                 h += '<td style="padding:6px 10px">' + dstHtml + '</td>';
-                h += '<td style="padding:6px 10px">' + (c.nat_type || 'none') + '</td>';
+                h += '<td style="padding:6px 10px">' + BM.escHtml(c.nat_type || 'none') + '</td>';
                 h += '<td style="padding:6px 10px;text-align:right;font-variant-numeric:tabular-nums">' + BM.formatBytes(c.bytes || 0) + '</td>';
-                h += '<td style="padding:6px 10px;text-align:right;font-variant-numeric:tabular-nums;color:var(--text-2)">' + (c.packets ? c.packets.toLocaleString() : '—') + '</td>';
+                h += '<td style="padding:6px 10px;text-align:right;font-variant-numeric:tabular-nums;color:var(--text-2)">' + (BM.num(c.packets) > 0 ? BM.formatCount(c.packets) : '—') + '</td>';
                 h += '</tr>';
             }
             h += '</tbody></table></div>';
@@ -189,7 +190,7 @@
                     h += '<tr' + rowBg + '>';
                     h += '<td style="padding:6px 10px;white-space:nowrap;color:var(--text-2)">' + timeStr + '</td>';
                     h += '<td style="padding:6px 10px;font-family:var(--font-mono,monospace);font-size:11px">' + BM.escSvg(q.domain || '') + '</td>';
-                    h += '<td style="padding:6px 10px;color:var(--text-2)">' + (q.type || '—') + '</td>';
+                    h += '<td style="padding:6px 10px;color:var(--text-2)">' + BM.escHtml(q.type || '—') + '</td>';
                     h += '<td style="padding:6px 10px">' + resultHtml + '</td>';
                     h += '</tr>';
                 }

--- a/static/js/tabs/debug.js
+++ b/static/js/tabs/debug.js
@@ -113,8 +113,8 @@
             var lossClass = hop.loss_pct > 0 ? (hop.loss_pct > 10 ? ' style="color:var(--danger);font-weight:600"' : ' style="color:var(--warning)"') : '';
             var rttStr = hop.received > 0 ? hop.avg_rtt_ms.toFixed(2) + ' ms' : '—';
             if (hop.received > 1) rttStr += ' <span style="color:var(--text-2);font-size:11px">(min ' + hop.min_rtt_ms.toFixed(2) + ' / max ' + hop.max_rtt_ms.toFixed(2) + ')</span>';
-            var ipStr = hop.ip || '<span style="color:var(--text-2)">*</span>';
-            var hostStr = hop.hostname || '—';
+            var ipStr = hop.ip ? BM.escHtml(hop.ip) : '<span style="color:var(--text-2)">*</span>';
+            var hostStr = BM.escHtml(hop.hostname || '—');
 
             h += '<tr>';
             h += '<td>' + hop.ttl + '</td>';
@@ -246,7 +246,7 @@
                 h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + p.size + ' bytes' + (p.size === mtu ? ' ←' : '') + '</td>';
                 h += '<td style="color:' + statusColor + ';font-weight:600;font-size:12px">' + statusIcon + '</td>';
                 h += '<td style="font-variant-numeric:tabular-nums;font-size:12px">' + (p.rtt_ms > 0 ? p.rtt_ms.toFixed(2) + ' ms' : '—') + '</td>';
-                h += '<td style="font-size:11px;color:var(--text-2)">' + (p.error || '') + '</td>';
+                h += '<td style="font-size:11px;color:var(--text-2)">' + BM.escHtml(p.error || '') + '</td>';
                 h += '</tr>';
             }
             h += '</tbody></table></div>';
@@ -295,7 +295,7 @@
             if (ri.configured_resolver) {
                 h += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:10px">';
                 h += '<span style="font-size:11px;color:var(--text-2);min-width:110px">Local resolver:</span>';
-                h += '<span style="font-family:JetBrains Mono,monospace;font-size:12px;padding:3px 8px;border-radius:4px;background:var(--bg-3);color:var(--accent)">' + ri.configured_resolver + '</span>';
+                h += '<span style="font-family:JetBrains Mono,monospace;font-size:12px;padding:3px 8px;border-radius:4px;background:var(--bg-3);color:var(--accent)">' + BM.escHtml(ri.configured_resolver) + '</span>';
                 h += '<span style="font-size:11px;color:var(--text-2)">(from /etc/resolv.conf)</span>';
                 h += '</div>';
             }
@@ -305,10 +305,10 @@
             h += '<div style="display:flex;flex-wrap:wrap;gap:4px">';
             if (ri.resolver_ips && ri.resolver_ips.length) {
                 for (var i = 0; i < ri.resolver_ips.length; i++) {
-                    h += '<span style="font-family:JetBrains Mono,monospace;font-size:12px;padding:3px 8px;border-radius:4px;background:var(--bg-3);color:var(--text-0)">' + ri.resolver_ips[i] + '</span>';
+                    h += '<span style="font-family:JetBrains Mono,monospace;font-size:12px;padding:3px 8px;border-radius:4px;background:var(--bg-3);color:var(--text-0)">' + BM.escHtml(ri.resolver_ips[i]) + '</span>';
                 }
             } else {
-                h += '<span style="font-size:12px;color:var(--warning)">' + (ri.error || 'No resolver IPs detected') + '</span>';
+                h += '<span style="font-size:12px;color:var(--warning)">' + BM.escHtml(ri.error || 'No resolver IPs detected') + '</span>';
             }
             h += '</div></div>';
             h += '<div style="font-size:10px;color:var(--text-2);margin-top:4px;margin-bottom:6px;padding-left:118px">IPs seen by authoritative DNS servers (o-o.myaddr.l.google.com, dnscheck.tools)</div>';
@@ -318,7 +318,7 @@
                 h += '<span style="font-size:11px;color:var(--text-2);min-width:110px">ECS:</span>';
                 h += '<div style="display:flex;flex-wrap:wrap;gap:4px">';
                 for (var ei = 0; ei < ri.ecs.length; ei++) {
-                    h += '<span style="font-family:JetBrains Mono,monospace;font-size:11px;padding:2px 6px;border-radius:3px;background:var(--bg-3);color:var(--text-2)">' + ri.ecs[ei] + '</span>';
+                    h += '<span style="font-family:JetBrains Mono,monospace;font-size:11px;padding:2px 6px;border-radius:3px;background:var(--bg-3);color:var(--text-2)">' + BM.escHtml(ri.ecs[ei]) + '</span>';
                 }
                 h += '</div></div>';
             }
@@ -330,7 +330,7 @@
                     var key = dcFields[di][0], label = dcFields[di][1];
                     if (dc[key]) {
                         h += '<span style="color:var(--text-2);font-size:11px">' + label + '</span>';
-                        h += '<span style="font-family:JetBrains Mono,monospace;font-size:11px;color:var(--text-0)">' + dc[key] + '</span>';
+                        h += '<span style="font-family:JetBrains Mono,monospace;font-size:11px;color:var(--text-0)">' + BM.escHtml(dc[key]) + '</span>';
                     }
                 }
                 h += '</div>';
@@ -389,7 +389,7 @@
                 var sColor = servers[ci].rcode === 'NOERROR' ? 'var(--success)' : 'var(--danger)';
                 h += '<th style="text-align:center;padding:4px 4px;font-weight:600;color:var(--text-0);border-bottom:1px solid var(--border);white-space:nowrap;font-size:10px">';
                 h += '<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:' + sColor + ';margin-right:3px;vertical-align:middle"></span>';
-                h += shortNames[ci] + '</th>';
+                h += BM.escHtml(shortNames[ci]) + '</th>';
             }
             h += '</tr></thead><tbody>';
 
@@ -405,7 +405,7 @@
             for (var ci = 0; ci < servers.length; ci++) {
                 var rc = servers[ci].rcode || 'ERROR';
                 var rcc = rc === 'NOERROR' ? 'var(--success)' : (rc === 'NXDOMAIN' ? 'var(--danger)' : 'var(--warning)');
-                h += '<td style="text-align:center;padding:4px;font-size:10px;font-weight:600;color:' + rcc + '">' + rc + '</td>';
+                h += '<td style="text-align:center;padding:4px;font-size:10px;font-weight:600;color:' + rcc + '">' + BM.escHtml(rc) + '</td>';
             }
             h += '</tr>';
 
@@ -421,8 +421,8 @@
                     }
                 }
                 var isPartial = hasCount > 0 && hasCount < servers.length;
-                h += '<tr style="' + bg + '"><td style="padding:4px 8px;font-family:JetBrains Mono,monospace;font-size:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px" title="' + rec.value + '">';
-                h += '<span style="color:var(--text-2);margin-right:4px">' + rec.type + '</span>' + rec.value + '</td>';
+                h += '<tr style="' + bg + '"><td style="padding:4px 8px;font-family:JetBrains Mono,monospace;font-size:10px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:200px" title="' + BM.escAttr(rec.value) + '">';
+                h += '<span style="color:var(--text-2);margin-right:4px">' + BM.escHtml(rec.type) + '</span>' + BM.escHtml(rec.value) + '</td>';
                 for (var ci = 0; ci < servers.length; ci++) {
                     var found = false;
                     if (servers[ci].records) {
@@ -457,18 +457,18 @@
             h += '<div class="dns-check-server-header">';
             h += '<div style="display:flex;align-items:center;gap:8px">';
             h += '<span class="dns-check-server-dot" style="background:' + rcodeColor + '"></span>';
-            h += '<span style="font-size:13px;font-weight:600;color:var(--text-0)">' + srvName + '</span>';
+            h += '<span style="font-size:13px;font-weight:600;color:var(--text-0)">' + BM.escHtml(srvName) + '</span>';
             if (srv.ad) h += '<span class="dns-check-badge dnssec">DNSSEC</span>';
             if (srv.truncated) h += '<span class="dns-check-badge truncated">TRUNCATED</span>';
             h += '</div>';
             h += '<div style="display:flex;align-items:center;gap:16px">';
-            h += '<span class="dns-check-rcode" style="color:' + rcodeColor + '">' + (srv.rcode || 'ERROR') + '</span>';
+            h += '<span class="dns-check-rcode" style="color:' + rcodeColor + '">' + BM.escHtml(srv.rcode || 'ERROR') + '</span>';
             h += '<span class="dns-check-latency" style="color:' + latencyColor + '">' + latencyStr + (isFastest ? ' ⚡' : '') + '</span>';
             h += '</div>';
             h += '</div>';
 
             if (srv.error) {
-                h += '<div class="dns-check-error">' + srv.error + '</div>';
+                h += '<div class="dns-check-error">' + BM.escHtml(srv.error) + '</div>';
             }
 
             if (srv.records && srv.records.length) {
@@ -477,8 +477,8 @@
                     var rec = srv.records[ri];
                     var isUnique = allValues[rec.value] === 1 && Object.keys(allValues).length > 1;
                     h += '<div class="dns-check-record' + (isUnique ? ' unique' : '') + '">';
-                    h += '<span class="dns-check-rec-type">' + rec.type + '</span>';
-                    h += '<span class="dns-check-rec-value">' + rec.value + '</span>';
+                    h += '<span class="dns-check-rec-type">' + BM.escHtml(rec.type) + '</span>';
+                    h += '<span class="dns-check-rec-value">' + BM.escHtml(rec.value) + '</span>';
                     h += '<span class="dns-check-rec-ttl">' + (rec.ttl > 0 ? rec.ttl + 's' : '—') + '</span>';
                     h += '</div>';
                 }

--- a/static/js/tabs/dns.js
+++ b/static/js/tabs/dns.js
@@ -57,10 +57,10 @@
         var providerName = dns.provider_name || 'DNS';
         document.getElementById('dnsCardTitle').textContent = 'DNS \u2014 ' + providerName;
 
-        document.getElementById('dnsTotalQueries').textContent = dns.total_queries.toLocaleString();
-        document.getElementById('dnsBlocked').textContent = dns.blocked_total.toLocaleString();
-        document.getElementById('dnsBlockPct').textContent = dns.blocked_pct.toFixed(1) + '%';
-        document.getElementById('dnsLatency').textContent = dns.avg_latency_ms.toFixed(1) + ' ms';
+        document.getElementById('dnsTotalQueries').textContent = BM.formatCount(dns.total_queries);
+        document.getElementById('dnsBlocked').textContent = BM.formatCount(dns.blocked_total);
+        document.getElementById('dnsBlockPct').textContent = BM.num(dns.blocked_pct).toFixed(1) + '%';
+        document.getElementById('dnsLatency').textContent = BM.num(dns.avg_latency_ms).toFixed(1) + ' ms';
 
         // Queries time-series bar chart
         if (dns.queries_series && dns.queries_series.length) {
@@ -90,7 +90,7 @@
             function(v) { return v.toLocaleString() + ' queries'; }
         );
         fillDetailTable('dnsClientsTable', dns.top_clients || [],
-            function(c) { return c.hostname ? c.hostname + ' <span style="color:var(--text-2);font-size:11px">(' + c.ip + ')</span>' : (c.ip || 'Unknown'); },
+            function(c) { return c.hostname ? c.hostname + ' (' + c.ip + ')' : (c.ip || 'Unknown'); },
             function(c) { return c.count || 0; },
             function(v) { return v.toLocaleString(); }, 'bw'
         );
@@ -136,8 +136,8 @@
                 var latStr = u.avg_ms > 0 ? u.avg_ms.toFixed(1) + ' ms' : '—';
                 var barCls = u.avg_ms <= 20 ? 'bw' : (u.avg_ms <= 100 ? 'vol' : 'vol');
                 uh += '<tr><td class="rank-cell">' + (i + 1) + '</td>';
-                uh += '<td class="host-cell" title="' + u.address + '"><code>' + u.address + '</code></td>';
-                uh += '<td>' + (u.responses || 0).toLocaleString() + '</td>';
+                uh += '<td class="host-cell" title="' + BM.escAttr(u.address) + '"><code>' + BM.escHtml(u.address) + '</code></td>';
+                uh += '<td>' + BM.formatCount(u.responses) + '</td>';
                 uh += '<td>' + latStr + '</td>';
                 uh += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill ' + barCls + '" style="width:' + pct.toFixed(1) + '%"></div></td></tr>';
             }

--- a/static/js/tabs/monitor.js
+++ b/static/js/tabs/monitor.js
@@ -84,7 +84,7 @@
                     d += 'Z';
                     svg += '<path d="' + d + '" fill="' + fill + '" fill-opacity="' + fo + '" stroke="' + stroke + '" stroke-width="' + sw + '"';
                     if (traffic) {
-                        svg += ' filter="url(#glow)" class="map-tip country-clickable" style="cursor:pointer" data-cc="' + cc + '" data-tip="' + BM.countryFlag(cc) + ' ' + (traffic.country_name || cc) + ': ' + BM.formatBytes(traffic.bytes) + ' (' + traffic.connections + ' IPs) \u2014 click to find in Top Talkers"';
+                        svg += ' filter="url(#glow)" class="map-tip country-clickable" style="cursor:pointer" data-cc="' + BM.escAttr(cc) + '" data-tip="' + BM.escAttr(BM.countryFlag(cc) + ' ' + (traffic.country_name || cc) + ': ' + BM.formatBytes(traffic.bytes) + ' (' + traffic.connections + ' IPs) \u2014 click to find in Top Talkers') + '"';
                     }
                     svg += '/>';
                 }
@@ -140,7 +140,7 @@
                     var rxMy = my + perpY * sep;
                     var rxPath = 'M' + dest[0] + ',' + dest[1] + ' Q' + rxMx.toFixed(1) + ',' + rxMy.toFixed(1) + ' ' + center[0] + ',' + center[1];
                     var rxTip = host + asInfo + ' \u2192 \u2193 ' + BM.formatRate(rxRate);
-                    svg += '<path d="' + rxPath + '" fill="none" stroke="transparent" stroke-width="8" style="cursor:pointer" class="map-tip" data-tip="' + rxTip + '"/>';
+                    svg += '<path d="' + rxPath + '" fill="none" stroke="transparent" stroke-width="8" style="cursor:pointer" class="map-tip" data-tip="' + BM.escAttr(rxTip) + '"/>';
                     svg += '<path d="' + rxPath + '" fill="none" stroke="' + rxColor + '" stroke-width="' + rxSw + '" stroke-dasharray="6,4" opacity="' + rxOp + '" stroke-linecap="round" style="pointer-events:none"><animate attributeName="stroke-dashoffset" from="0" to="-20" dur="' + dur + 's" repeatCount="indefinite"/></path>';
                 }
 
@@ -152,7 +152,7 @@
                     var txMy = my - perpY * sep;
                     var txPath = 'M' + center[0] + ',' + center[1] + ' Q' + txMx.toFixed(1) + ',' + txMy.toFixed(1) + ' ' + dest[0] + ',' + dest[1];
                     var txTip = host + asInfo + ' \u2192 \u2191 ' + BM.formatRate(txRate);
-                    svg += '<path d="' + txPath + '" fill="none" stroke="transparent" stroke-width="8" style="cursor:pointer" class="map-tip" data-tip="' + txTip + '"/>';
+                    svg += '<path d="' + txPath + '" fill="none" stroke="transparent" stroke-width="8" style="cursor:pointer" class="map-tip" data-tip="' + BM.escAttr(txTip) + '"/>';
                     svg += '<path d="' + txPath + '" fill="none" stroke="' + txColor + '" stroke-width="' + txSw + '" stroke-dasharray="6,4" opacity="' + txOp + '" stroke-linecap="round" style="pointer-events:none"><animate attributeName="stroke-dashoffset" from="0" to="-20" dur="' + dur + 's" repeatCount="indefinite"/></path>';
                 }
 
@@ -284,8 +284,8 @@
                     var pct = mx > 0 ? (t.total_bytes / mx * 100) : 0;
                     var displayName = BM.deviceDisplayName ? BM.deviceDisplayName(null, [t.ip], t.hostname) : (t.hostname || t.ip);
                     var host = displayName && displayName !== t.ip
-                        ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span> <span class="hostname">' + BM.escSvg(displayName) + '</span>'
-                        : '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span>';
+                        ? '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(t.ip) + '">' + BM.escHtml(t.ip) + '</span> <span class="hostname">' + BM.escHtml(displayName) + '</span>'
+                        : '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(t.ip) + '">' + BM.escHtml(t.ip) + '</span>';
                     var geo = t.as_org ? '<span class="hostname">AS' + (t.asn || '') + ' ' + BM.escSvg(t.as_org) + '</span>' : '';
                     h += '<div style="display:flex;align-items:center;gap:8px;padding:4px 0;border-bottom:1px solid var(--border)">';
                     h += '<span class="' + BM.rankClass(i) + '" style="flex:0 0 auto">' + (i + 1) + '</span>';
@@ -304,7 +304,8 @@
             })
             .catch(function(e) {
                 if (wrap.dataset.cc !== cc) return;
-                list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--danger)">Failed to load: ' + e + '</div>';
+                list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--danger)"></div>';
+                list.firstChild.textContent = 'Failed to load: ' + e;
             });
     };
 
@@ -401,11 +402,11 @@
 
             h += '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">';
             h += '<div>';
-            h += '<div style="font-weight:600;font-size:14px">' + t.name + '</div>';
+            h += '<div style="font-weight:600;font-size:14px">' + BM.escHtml(t.name) + '</div>';
             h += '<div style="font-size:10px;color:var(--text-2);font-family:var(--font-mono, monospace)">';
-            if (hasV4) h += '<span style="background:var(--bg-1);padding:1px 4px;border-radius:3px;margin-right:4px">v4 ' + t.ipv4 + '</span>';
-            if (hasV6) h += '<span style="background:var(--bg-1);padding:1px 4px;border-radius:3px">v6 ' + t.ipv6 + '</span>';
-            if (!hasV4 && !hasV6 && t.ip) h += t.ip;
+            if (hasV4) h += '<span style="background:var(--bg-1);padding:1px 4px;border-radius:3px;margin-right:4px">v4 ' + BM.escHtml(t.ipv4) + '</span>';
+            if (hasV6) h += '<span style="background:var(--bg-1);padding:1px 4px;border-radius:3px">v6 ' + BM.escHtml(t.ipv6) + '</span>';
+            if (!hasV4 && !hasV6 && t.ip) h += BM.escHtml(t.ip);
             h += '</div>';
             h += '</div>';
             h += '<div style="display:flex;align-items:center;gap:6px">';

--- a/static/js/tabs/nat.js
+++ b/static/js/tabs/nat.js
@@ -71,11 +71,11 @@
         document.getElementById('natNoData').style.display = 'none';
         document.getElementById('natHasData').style.display = '';
 
-        document.getElementById('natTotal').textContent = (ct.total || 0).toLocaleString();
-        document.getElementById('natMax').textContent = (ct.max || 0).toLocaleString();
-        document.getElementById('natUsagePct').textContent = (ct.usage_pct || 0).toFixed(1) + '%';
-        document.getElementById('natIPv4').textContent = (ct.ipv4 || 0).toLocaleString();
-        document.getElementById('natIPv6').textContent = (ct.ipv6 || 0).toLocaleString();
+        document.getElementById('natTotal').textContent = BM.formatCount(ct.total);
+        document.getElementById('natMax').textContent = BM.formatCount(ct.max);
+        document.getElementById('natUsagePct').textContent = BM.num(ct.usage_pct).toFixed(1) + '%';
+        document.getElementById('natIPv4').textContent = BM.formatCount(ct.ipv4);
+        document.getElementById('natIPv6').textContent = BM.formatCount(ct.ipv6);
 
         // Protocol doughnut
         var protocols = ct.protocols || {};
@@ -155,15 +155,15 @@
             var host = hosts[i];
             var val = useBytes ? (host.bytes || 0) : host.connections;
             var pct = ((val / mx) * 100).toFixed(1);
-            var display = useBytes ? BM.formatBytes(val) : val.toLocaleString();
+            var display = useBytes ? BM.formatBytes(val) : BM.formatCount(val);
             var flag = host.country ? BM.countryFlag(host.country) + ' ' : '';
             var geo = '';
             var geoName = (host.city && host.country_name) ? host.city + ', ' + host.country_name : (host.country_name || '');
-            if (host.as_org) geo = '<span class="hostname">' + flag + geoName + ' &middot; AS' + (host.asn || '') + ' ' + host.as_org + '</span>';
-            else if (geoName) geo = '<span class="hostname">' + flag + geoName + '</span>';
+            if (host.as_org) geo = '<span class="hostname">' + flag + BM.escHtml(geoName) + ' &middot; AS' + BM.integer(host.asn, 0) + ' ' + BM.escHtml(host.as_org) + '</span>';
+            else if (geoName) geo = '<span class="hostname">' + flag + BM.escHtml(geoName) + '</span>';
             var cell = host.hostname
-                ? '<span class="ip-cell ip-clickable" data-ip="' + host.ip + '">' + host.ip + '</span><span class="hostname">' + host.hostname + '</span>' + geo
-                : '<span class="ip-cell ip-clickable" data-ip="' + host.ip + '">' + host.ip + '</span>' + geo;
+                ? '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(host.ip) + '">' + BM.escHtml(host.ip) + '</span><span class="hostname">' + BM.escHtml(host.hostname) + '</span>' + geo
+                : '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(host.ip) + '">' + BM.escHtml(host.ip) + '</span>' + geo;
             h += '<tr><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
             h += '<td>' + cell + '</td>';
             h += '<td style="font-variant-numeric:tabular-nums">' + display + '</td>';
@@ -221,28 +221,28 @@
             var replDstHL = (e.repl_dst !== e.orig_src) ? ' style="color:var(--rx);font-weight:600"' : '';
 
             function ipCell(addr, host, geo, city, asn, hlStyle) {
-                var s = '<td' + (hlStyle || '') + '><div style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap">' + addr + '</div>';
+                var s = '<td' + (hlStyle || '') + '><div style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap">' + BM.escHtml(addr) + '</div>';
                 var info = [];
                 if (host) info.push(host);
                 if (city && geo) info.push(BM.countryFlag(geo) + ' ' + city + ', ' + geo);
                 else if (geo) info.push(BM.countryFlag(geo) + ' ' + geo);
                 if (asn) info.push(asn);
-                if (info.length) s += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px">' + info.join(' · ') + '</div>';
+                if (info.length) s += '<div style="font-size:9px;color:var(--text-2);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:220px">' + info.map(BM.escHtml).join(' · ') + '</div>';
                 s += '</td>';
                 return s;
             }
 
             h += '<tr>';
-            h += '<td style="font-size:12px;font-weight:500">' + (e.protocol || '').toUpperCase() + '</td>';
-            h += '<td>' + (e.state ? '<span class="nat-state-badge ' + stateClass + '">' + e.state + '</span>' : '<span style="color:var(--text-2)">—</span>') + '</td>';
+            h += '<td style="font-size:12px;font-weight:500">' + BM.escHtml((e.protocol || '').toUpperCase()) + '</td>';
+            h += '<td>' + (e.state ? '<span class="nat-state-badge ' + stateClass + '">' + BM.escHtml(e.state) + '</span>' : '<span style="color:var(--text-2)">—</span>') + '</td>';
             h += ipCell(origSrc, e.orig_src_host, e.orig_src_geo, e.orig_src_city, e.orig_src_asn, '');
             h += ipCell(origDst, e.orig_dst_host, e.orig_dst_geo, e.orig_dst_city, e.orig_dst_asn, '');
-            h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replSrcHL + '>' + replSrc + '</td>';
-            h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replDstHL + '>' + replDst + '</td>';
-            h += '<td><span class="nat-badge ' + e.nat_type + '">' + (e.nat_type || 'none').toUpperCase() + '</span></td>';
+            h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replSrcHL + '>' + BM.escHtml(replSrc) + '</td>';
+            h += '<td style="font-family:JetBrains Mono,monospace;font-size:11px;white-space:nowrap"' + replDstHL + '>' + BM.escHtml(replDst) + '</td>';
+            h += '<td><span class="nat-badge ' + BM.escAttr(e.nat_type || 'none') + '">' + BM.escHtml((e.nat_type || 'none').toUpperCase()) + '</span></td>';
             h += '<td style="font-variant-numeric:tabular-nums;font-size:11px;white-space:nowrap">' + (e.bytes ? BM.formatBytes(e.bytes) : '<span style="color:var(--text-2)">—</span>') + '</td>';
-            h += '<td style="font-variant-numeric:tabular-nums;font-size:11px;white-space:nowrap">' + (e.packets ? e.packets.toLocaleString() : '<span style="color:var(--text-2)">—</span>') + '</td>';
-            h += '<td style="font-variant-numeric:tabular-nums;font-size:12px;color:var(--text-2)">' + e.ttl + 's</td>';
+            h += '<td style="font-variant-numeric:tabular-nums;font-size:11px;white-space:nowrap">' + (BM.num(e.packets) > 0 ? BM.formatCount(e.packets) : '<span style="color:var(--text-2)">—</span>') + '</td>';
+            h += '<td style="font-variant-numeric:tabular-nums;font-size:12px;color:var(--text-2)">' + BM.integer(e.ttl, 0) + 's</td>';
             h += '</tr>';
         }
         tb.innerHTML = h;

--- a/static/js/tabs/network.js
+++ b/static/js/tabs/network.js
@@ -131,15 +131,15 @@
             var displayName = BM.deviceDisplayName(n.mac, n.ips, n.hostname);
             h += '<tr>';
             h += '<td>' + BM.favoriteStarHtml(favKey) + '</td>';
-            h += '<td><span class="net-type-badge net-type-' + n.type + '">' + typeIcon + ' ' + typeLabel + '</span></td>';
-            h += '<td>' + (displayName || '<span style="color:var(--text-2)">—</span>') + '</td>';
+            h += '<td><span class="net-type-badge net-type-' + BM.escAttr(n.type) + '">' + typeIcon + ' ' + BM.escHtml(typeLabel) + '</span></td>';
+            h += '<td>' + (displayName ? BM.escHtml(displayName) : '<span style="color:var(--text-2)">—</span>') + '</td>';
             h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + formatClickableIPs(n.ips) + '</td>';
-            h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + (n.mac || '—') + '</td>';
-            h += '<td>' + (n.iface || '—') + '</td>';
-            h += '<td>' + (n.ssid || '—') + '</td>';
-            h += '<td>' + (sigStr || '—') + '</td>';
-            h += '<td>' + (n.state || '—') + '</td>';
-            h += '<td><span style="font-size:11px">' + (n.source || '—') + '</span></td>';
+            h += '<td style="font-family:JetBrains Mono,monospace;font-size:12px">' + BM.escHtml(n.mac || '—') + '</td>';
+            h += '<td>' + BM.escHtml(n.iface || '—') + '</td>';
+            h += '<td>' + BM.escHtml(n.ssid || '—') + '</td>';
+            h += '<td>' + BM.escHtml(sigStr || '—') + '</td>';
+            h += '<td>' + BM.escHtml(n.state || '—') + '</td>';
+            h += '<td><span style="font-size:11px">' + BM.escHtml(n.source || '—') + '</span></td>';
             h += '</tr>';
         }
         tb.innerHTML = h;
@@ -149,7 +149,7 @@
     function formatClickableIPs(ips) {
         if (!ips || !ips.length) return '—';
         return ips.map(function(ip) {
-            return '<span class="ip-clickable" data-ip="' + ip + '">' + ip + '</span>';
+            return '<span class="ip-clickable" data-ip="' + BM.escAttr(ip) + '">' + BM.escHtml(ip) + '</span>';
         }).join('<br>');
     }
 
@@ -468,7 +468,7 @@
             if (label.length > 20) label = label.substring(0, 18) + '…';
             svgHtml += '<text x="' + pos.x + '" y="' + (pos.y + r + 14) + '" text-anchor="middle" font-size="11" fill="' + textCol + '">' + BM.escSvg(label) + '</text>';
             var typeLabel = node.device_class || node.type;
-            svgHtml += '<text x="' + pos.x + '" y="' + (pos.y + r + 26) + '" text-anchor="middle" font-size="9" fill="' + textCol2 + '">' + typeLabel + '</text>';
+            svgHtml += '<text x="' + pos.x + '" y="' + (pos.y + r + 26) + '" text-anchor="middle" font-size="9" fill="' + textCol2 + '">' + BM.escSvg(typeLabel) + '</text>';
             svgHtml += '</g>';
         }
 

--- a/static/js/tabs/traffic.js
+++ b/static/js/tabs/traffic.js
@@ -442,7 +442,7 @@
         h += stat('TX Rate', BM.formatRate(totalTxRate), 'tx');
         h += stat('Total RX', BM.formatBytes(totalRxBytes), 'rx');
         h += stat('Total TX', BM.formatBytes(totalTxBytes), 'tx');
-        h += stat('IPs (24h)', d && d.unique_ips ? (d.unique_ips).toLocaleString() : '—');
+        h += stat('IPs (24h)', d && BM.num(d.unique_ips) > 0 ? BM.formatCount(d.unique_ips) : '—');
         el.innerHTML = h;
         if (sub && d && d.uptime_secs) {
             sub.textContent = ifaces.length + ' interfaces · up ' + BM.formatUptime(d.uptime_secs);
@@ -482,11 +482,11 @@
         var dotClass = (os === 'up') ? 'up' : (os === 'down' ? 'down' : 'unknown');
         var stateLabel = os === 'up' ? 'Up' : (os === 'down' ? 'Down' : os);
         var speedLabel = (f.speed && f.speed > 0) ? '<span style="font-size:10px;color:var(--text-2);font-weight:400;margin-right:4px">' + (f.speed >= 1000 ? (f.speed / 1000) + ' Gbit' : f.speed + ' Mbit') + '</span>' : '';
-        var badge = groupLabel ? '<span class="iface-group-badge">' + groupLabel + '</span>' : '';
-        var h = '<div class="iface-card"><div class="iface-name"><span>' + f.name + ' ' + badge + '</span><span class="iface-status">' + speedLabel + '<span class="iface-status-dot ' + dotClass + '"></span>' + stateLabel + '</span></div>';
-        h += '<div class="sparkline-wrap"><canvas class="sparkline-canvas" data-iface="' + f.name + '"></canvas></div>';
+        var badge = groupLabel ? '<span class="iface-group-badge">' + BM.escHtml(groupLabel) + '</span>' : '';
+        var h = '<div class="iface-card"><div class="iface-name"><span>' + BM.escHtml(f.name) + ' ' + badge + '</span><span class="iface-status">' + speedLabel + '<span class="iface-status-dot ' + dotClass + '"></span>' + BM.escHtml(stateLabel) + '</span></div>';
+        h += '<div class="sparkline-wrap"><canvas class="sparkline-canvas" data-iface="' + BM.escAttr(f.name) + '"></canvas></div>';
         if (f.vpn_routing) {
-            h += '<div class="vpn-routing active"><span class="iface-status-dot up"></span>Routing' + (f.vpn_routing_since ? ' since ' + f.vpn_routing_since : '') + '</div>';
+            h += '<div class="vpn-routing active"><span class="iface-status-dot up"></span>Routing' + (f.vpn_routing_since ? ' since ' + BM.escHtml(f.vpn_routing_since) : '') + '</div>';
         } else if (f.iface_type === 'vpn' && f.vpn_tracked) {
             h += '<div class="vpn-routing inactive">Not routing</div>';
         }
@@ -506,8 +506,8 @@
                 if (f.addrs[ai].indexOf(':') !== -1) v6.push(f.addrs[ai]); else v4.push(f.addrs[ai]);
             }
             h += '<div class="iface-addrs">';
-            if (v4.length) h += '<div class="iface-addr-row"><span class="iface-addr-tag v4">IPv4</span><span class="iface-addr-list">' + v4.join(', ') + '</span></div>';
-            if (v6.length) h += '<div class="iface-addr-row"><span class="iface-addr-tag v6">IPv6</span><span class="iface-addr-list">' + v6.join(', ') + '</span></div>';
+            if (v4.length) h += '<div class="iface-addr-row"><span class="iface-addr-tag v4">IPv4</span><span class="iface-addr-list">' + v4.map(BM.escHtml).join(', ') + '</span></div>';
+            if (v6.length) h += '<div class="iface-addr-row"><span class="iface-addr-tag v6">IPv6</span><span class="iface-addr-list">' + v6.map(BM.escHtml).join(', ') + '</span></div>';
             h += '</div>';
         }
         h += '</div>';
@@ -565,12 +565,12 @@
             var flag = t.country ? BM.countryFlag(t.country) + ' ' : '';
             var geo = '';
             var geoName = (t.city && t.country_name) ? t.city + ', ' + t.country_name : (t.country_name || '');
-            if (t.as_org) geo = '<span class="hostname">' + flag + BM.escSvg(geoName) + ' &middot; AS' + (t.asn || '') + ' ' + BM.escSvg(t.as_org) + '</span>';
+            if (t.as_org) geo = '<span class="hostname">' + flag + BM.escHtml(geoName) + ' &middot; AS' + BM.integer(t.asn, 0) + ' ' + BM.escHtml(t.as_org) + '</span>';
             else if (geoName) geo = '<span class="hostname">' + flag + BM.escSvg(geoName) + '</span>';
             var displayName = BM.deviceDisplayName(null, [t.ip], t.hostname);
             var host = displayName && displayName !== t.ip
-                ? '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span><span class="hostname">' + BM.escSvg(displayName) + '</span>' + geo
-                : '<span class="ip-cell ip-clickable" data-ip="' + t.ip + '">' + t.ip + '</span>' + geo;
+                ? '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(t.ip) + '">' + BM.escHtml(t.ip) + '</span><span class="hostname">' + BM.escHtml(displayName) + '</span>' + geo
+                : '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(t.ip) + '">' + BM.escHtml(t.ip) + '</span>' + geo;
             h += '<tr' + (t.country ? ' data-country="' + BM.escSvg(t.country) + '"' : '') + '><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
             h += '<td>' + BM.favoriteStarHtml(t.ip) + '</td>';
             h += '<td>' + host + '</td>';
@@ -651,7 +651,7 @@
             var displayVal = formatter ? formatter(values[i]) : values[i].toLocaleString();
             h += '<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">';
             h += '<div style="width:10px;height:10px;border-radius:2px;background:' + colors[i] + ';flex-shrink:0"></div>';
-            h += '<div><div style="font-size:13px;font-weight:600;color:var(--text-0)">' + labels[i] + '</div>';
+            h += '<div><div style="font-size:13px;font-weight:600;color:var(--text-0)">' + BM.escHtml(labels[i]) + '</div>';
             h += '<div style="font-size:11px;color:var(--text-2)">' + displayVal + ' &middot; ' + pct + '%</div></div></div>';
         }
         legendEl.innerHTML = h || '<div style="text-align:center;color:var(--text-2);font-size:12px;padding:8px">No data</div>';
@@ -694,7 +694,7 @@
             var pct = total > 0 ? ((valueFn(items[i]) / total) * 100).toFixed(1) : '0.0';
             lh += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">';
             lh += '<div style="width:8px;height:8px;border-radius:2px;background:' + chartColors[i] + ';flex-shrink:0"></div>';
-            lh += '<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-0);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + labelFn(items[i]) + '</div>';
+            lh += '<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-0);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + BM.escHtml(labelFn(items[i])) + '</div>';
             lh += '<div style="font-size:10px;color:var(--text-2)">' + fmtFn(valueFn(items[i])) + ' &middot; ' + pct + '%</div></div></div>';
         }
         if (rest > 0) {
@@ -717,7 +717,7 @@
         for (var i = 0; i < items.length; i++) {
             var pct = mx > 0 ? ((valueFn(items[i]) / mx) * 100).toFixed(1) : '0';
             h += '<tr><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
-            h += '<td><span class="ip-cell">' + labelFn(items[i]) + '</span></td>';
+            h += '<td><span class="ip-cell">' + BM.escHtml(labelFn(items[i])) + '</span></td>';
             if (countFn) h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + countFn(items[i]) + '</td>';
             h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + fmtFn(valueFn(items[i])) + '</td>';
             h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill ' + cls + '" style="width:' + pct + '%"></div></td></tr>';
@@ -736,7 +736,7 @@
             var it = items[i], total = (it.tx_bytes || 0) + (it.rx_bytes || 0);
             var pct = mx > 0 ? ((total / mx) * 100).toFixed(1) : '0';
             h += '<tr><td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
-            h += '<td><span class="ip-cell">' + labelFn(it) + '</span></td>';
+            h += '<td><span class="ip-cell">' + BM.escHtml(labelFn(it)) + '</span></td>';
             h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + BM.formatBytes(it.rx_bytes || 0) + '</td>';
             h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + BM.formatBytes(it.tx_bytes || 0) + '</td>';
             h += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums;color:var(--rx)">' + BM.formatRate(it.rx_rate || 0) + '</td>';
@@ -762,7 +762,7 @@
             function(v) { return BM.formatBytes(v); }
         );
         fillDetailTable('countryTable', countries,
-            function(c) { return BM.countryFlag(c.country) + ' <span style="font-weight:500">' + (c.country_name || c.country) + '</span> <span class="hostname" style="display:inline">' + c.country + '</span>'; },
+            function(c) { return BM.countryFlag(c.country) + ' ' + (c.country_name || c.country) + ' (' + c.country + ')'; },
             function(c) { return c.bytes; },
             function(v) { return BM.formatBytes(v); }, 'bw',
             function(c) { return c.connections; }
@@ -799,7 +799,7 @@
             function(v) { return BM.formatBytes(v); }
         );
         fillDetailTable('asnTable', asns,
-            function(a) { return '<span style="font-weight:500">' + (a.as_org || 'Unknown') + '</span> <span class="hostname" style="display:inline">AS' + a.asn + '</span>'; },
+            function(a) { return (a.as_org || 'Unknown') + ' (AS' + a.asn + ')'; },
             function(a) { return a.bytes; },
             function(v) { return BM.formatBytes(v); }, 'vol',
             function(a) { return a.connections; }
@@ -848,9 +848,10 @@
                     var pct = mx > 0 ? (m.total_bytes / mx * 100) : 0;
                     var displayName = BM.deviceDisplayName ? BM.deviceDisplayName(null, [m.ip], m.hostname) : (m.hostname || m.ip);
                     var host = displayName && displayName !== m.ip
-                        ? '<span class="ip-cell ip-clickable" data-ip="' + m.ip + '">' + m.ip + '</span> <span class="hostname">' + BM.escSvg(displayName) + '</span>'
-                        : '<span class="ip-cell ip-clickable" data-ip="' + m.ip + '">' + m.ip + '</span>';
-                    var conns = m.connections + ' remote IP' + (m.connections === 1 ? '' : 's');
+                        ? '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(m.ip) + '">' + BM.escHtml(m.ip) + '</span> <span class="hostname">' + BM.escHtml(displayName) + '</span>'
+                        : '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(m.ip) + '">' + BM.escHtml(m.ip) + '</span>';
+                    var connectionCount = BM.integer(m.connections, 0);
+                    var conns = connectionCount + ' remote IP' + (connectionCount === 1 ? '' : 's');
                     var hasRemotes = m.remotes && m.remotes.length > 0;
                     h += '<div class="asn-machine-block" style="border-bottom:1px solid var(--border)">';
                     h += '<div class="asn-machine-row" data-idx="' + i + '" style="display:flex;align-items:center;gap:8px;padding:4px 0' + (hasRemotes ? ';cursor:pointer' : '') + '">';
@@ -866,8 +867,8 @@
                         m.remotes.forEach(function(rm) {
                             var rpct = rmx > 0 ? (rm.total_bytes / rmx * 100) : 0;
                             var rDisplay = rm.hostname && rm.hostname !== rm.ip
-                                ? '<span class="ip-cell ip-clickable" data-ip="' + rm.ip + '">' + rm.ip + '</span> <span class="hostname">' + BM.escSvg(rm.hostname) + '</span>'
-                                : '<span class="ip-cell ip-clickable" data-ip="' + rm.ip + '">' + rm.ip + '</span>';
+                                ? '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(rm.ip) + '">' + BM.escHtml(rm.ip) + '</span> <span class="hostname">' + BM.escHtml(rm.hostname) + '</span>'
+                                : '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(rm.ip) + '">' + BM.escHtml(rm.ip) + '</span>';
                             h += '<div style="display:flex;align-items:center;gap:8px;padding:2px 0;font-size:11px">';
                             h += '<div style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-2)">' + rDisplay + '</div>';
                             h += '<div style="flex:0 0 60px;height:4px;background:var(--bg-2);border-radius:2px;overflow:hidden"><div style="width:' + Math.max(2, rpct).toFixed(1) + '%;height:100%;background:var(--text-3);border-radius:2px;opacity:0.6"></div></div>';
@@ -903,7 +904,8 @@
             })
             .catch(function(e) {
                 if (String(wrap.dataset.asn) !== String(asn.asn)) return;
-                list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--danger)">Failed to load: ' + e + '</div>';
+                list.innerHTML = '<div style="text-align:center;padding:16px;color:var(--danger)"></div>';
+                list.firstChild.textContent = 'Failed to load: ' + e;
             });
     };
 

--- a/static/js/tabs/wifi.js
+++ b/static/js/tabs/wifi.js
@@ -55,20 +55,20 @@
                 var st = ap.status === 'connected' ? 'up' : (ap.status === 'disconnected' ? 'down' : 'unknown');
                 var stLabel = ap.status === 'connected' ? 'Online' : (ap.status === 'disconnected' ? 'Offline' : (ap.status || 'Unknown'));
                 h += '<div class="wifi-ap-card">';
-                h += '<div class="wifi-ap-name"><span>' + (ap.name || ap.mac || 'AP') + ' <span class="wifi-ap-model">' + (ap.model || '') + '</span></span>';
-                h += '<span class="iface-status"><span class="iface-status-dot ' + st + '"></span>' + stLabel + '</span></div>';
+                h += '<div class="wifi-ap-name"><span>' + BM.escHtml(ap.name || ap.mac || 'AP') + ' <span class="wifi-ap-model">' + BM.escHtml(ap.model || '') + '</span></span>';
+                h += '<span class="iface-status"><span class="iface-status-dot ' + st + '"></span>' + BM.escHtml(stLabel) + '</span></div>';
                 h += '<div class="wifi-ap-stats">';
-                h += '<div><div class="wifi-ap-stat-label">Clients</div><div class="wifi-ap-stat-value" style="color:var(--rx)">' + (ap.num_clients || 0) + '</div></div>';
-                h += '<div><div class="wifi-ap-stat-label">Firmware</div><div class="wifi-ap-stat-value" style="font-size:11px">' + (ap.version || '—') + '</div></div>';
+                h += '<div><div class="wifi-ap-stat-label">Clients</div><div class="wifi-ap-stat-value" style="color:var(--rx)">' + BM.integer(ap.num_clients, 0) + '</div></div>';
+                h += '<div><div class="wifi-ap-stat-label">Firmware</div><div class="wifi-ap-stat-value" style="font-size:11px">' + BM.escHtml(ap.version || '—') + '</div></div>';
                 h += '<div><div class="wifi-ap-stat-label label-rx">RX Rate</div><div class="wifi-ap-stat-value" style="font-size:11px;color:var(--rx)">' + BM.formatRate(ap.rx_rate || 0) + '</div></div>';
                 h += '<div><div class="wifi-ap-stat-label label-tx">TX Rate</div><div class="wifi-ap-stat-value" style="font-size:11px;color:var(--tx)">' + BM.formatRate(ap.tx_rate || 0) + '</div></div>';
                 h += '<div><div class="wifi-ap-stat-label">RX Total</div><div class="wifi-ap-stat-value" style="font-size:11px">' + BM.formatBytes(ap.rx_bytes || 0) + '</div></div>';
                 h += '<div><div class="wifi-ap-stat-label">TX Total</div><div class="wifi-ap-stat-value" style="font-size:11px">' + BM.formatBytes(ap.tx_bytes || 0) + '</div></div>';
                 if (ap.ip) {
-                    h += '<div><div class="wifi-ap-stat-label">IP</div><div class="wifi-ap-stat-value" style="font-size:11px;font-family:JetBrains Mono,monospace">' + ap.ip + '</div></div>';
+                    h += '<div><div class="wifi-ap-stat-label">IP</div><div class="wifi-ap-stat-value" style="font-size:11px;font-family:JetBrains Mono,monospace">' + BM.escHtml(ap.ip) + '</div></div>';
                 }
                 if (ap.mac) {
-                    h += '<div><div class="wifi-ap-stat-label">MAC</div><div class="wifi-ap-stat-value" style="font-size:11px;font-family:JetBrains Mono,monospace">' + ap.mac + '</div></div>';
+                    h += '<div><div class="wifi-ap-stat-label">MAC</div><div class="wifi-ap-stat-value" style="font-size:11px;font-family:JetBrains Mono,monospace">' + BM.escHtml(ap.mac) + '</div></div>';
                 }
                 if (ap.uptime) {
                     var days = Math.floor(ap.uptime / 86400);
@@ -178,21 +178,21 @@
                 var ips = cl.ip ? [cl.ip] : [];
                 var name = BM.deviceDisplayName(cl.mac, ips, cl.hostname) || cl.ip || cl.mac || '—';
                 var sub = cl.ip && cl.hostname ? cl.ip : (cl.mac || '');
-                var sig = cl.signal || 0;
+                var sig = BM.num(cl.signal, 0);
                 var sigClass = sig >= -50 ? 'sig-great' : sig >= -65 ? 'sig-good' : sig >= -75 ? 'sig-ok' : 'sig-weak';
                 var favKey = BM.deviceLabelKey(cl.mac, ips);
                 ch += '<tr>';
                 ch += '<td><span class="' + BM.rankClass(i) + '">' + (i + 1) + '</span></td>';
                 ch += '<td>' + BM.favoriteStarHtml(favKey) + '</td>';
                 ch += '<td>';
-                if (cl.ip) ch += '<span class="ip-cell ip-clickable" data-ip="' + cl.ip + '">' + name + '</span>';
-                else ch += '<span class="ip-cell">' + name + '</span>';
-                if (sub && sub !== name) ch += '<div style="font-size:10px;color:var(--text-2);font-family:JetBrains Mono,monospace">' + sub + '</div>';
+                if (cl.ip) ch += '<span class="ip-cell ip-clickable" data-ip="' + BM.escAttr(cl.ip) + '">' + BM.escHtml(name) + '</span>';
+                else ch += '<span class="ip-cell">' + BM.escHtml(name) + '</span>';
+                if (sub && sub !== name) ch += '<div style="font-size:10px;color:var(--text-2);font-family:JetBrains Mono,monospace">' + BM.escHtml(sub) + '</div>';
                 ch += '</td>';
-                ch += '<td style="font-size:12px">' + (cl.ssid || '—') + '</td>';
-                ch += '<td style="font-size:12px">' + (cl.ap_name || '—') + '</td>';
-                ch += '<td style="font-size:11px;color:var(--text-2)">' + (cl.radio || '—') + '</td>';
-                ch += '<td style="font-size:11px;font-variant-numeric:tabular-nums">' + (cl.channel || '—') + '</td>';
+                ch += '<td style="font-size:12px">' + BM.escHtml(cl.ssid || '—') + '</td>';
+                ch += '<td style="font-size:12px">' + BM.escHtml(cl.ap_name || '—') + '</td>';
+                ch += '<td style="font-size:11px;color:var(--text-2)">' + BM.escHtml(cl.radio || '—') + '</td>';
+                ch += '<td style="font-size:11px;font-variant-numeric:tabular-nums">' + (BM.num(cl.channel) > 0 ? BM.integer(cl.channel, 0) : '—') + '</td>';
                 ch += '<td><span class="signal-badge ' + sigClass + '">' + sig + ' dBm</span></td>';
                 ch += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + BM.formatBytes(cl.rx_bytes || 0) + '</td>';
                 ch += '<td style="white-space:nowrap;font-variant-numeric:tabular-nums">' + BM.formatBytes(cl.tx_bytes || 0) + '</td>';

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -4,7 +4,21 @@
     'use strict';
     var BM = window.BM = window.BM || {};
 
+    BM.num = function(value, fallback) {
+        var n = Number(value);
+        return Number.isFinite(n) ? n : (fallback === undefined ? 0 : fallback);
+    };
+
+    BM.integer = function(value, fallback) {
+        return Math.trunc(BM.num(value, fallback));
+    };
+
+    BM.formatCount = function(value) {
+        return BM.integer(value, 0).toLocaleString();
+    };
+
     BM.formatBytes = function(bytes, dec) {
+        bytes = BM.num(bytes, 0);
         if (dec === undefined) dec = 1;
         if (bytes === 0) return '0 B';
         var k = 1024, s = ['B','KB','MB','GB','TB'];
@@ -13,6 +27,7 @@
     };
 
     BM.formatRate = function(bps) {
+        bps = BM.num(bps, 0);
         var mbps = (bps * 8) / 1e6;
         if (mbps < 0.01 && mbps > 0) return mbps.toFixed(4) + ' Mbit/s';
         if (mbps < 1) return mbps.toFixed(2) + ' Mbit/s';
@@ -21,6 +36,7 @@
     };
 
     BM.formatPPS = function(pps) {
+        pps = BM.num(pps, 0);
         if (pps === 0) return '0 pps';
         if (pps < 1000) return pps.toFixed(0) + ' pps';
         if (pps < 1e6) return (pps / 1000).toFixed(1) + ' Kpps';
@@ -28,6 +44,7 @@
     };
 
     BM.formatUptime = function(secs) {
+        secs = BM.num(secs, 0);
         if (!secs || secs <= 0) return '—';
         var d = Math.floor(secs / 86400);
         var h = Math.floor((secs % 86400) / 3600);
@@ -45,9 +62,17 @@
 
     BM.rankClass = function(i) { return i === 0 ? 'rank rank-1' : 'rank'; };
 
-    BM.escSvg = function(s) {
-        return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    BM.escHtml = function(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g,'&amp;')
+            .replace(/</g,'&lt;')
+            .replace(/>/g,'&gt;')
+            .replace(/"/g,'&quot;')
+            .replace(/'/g,'&#39;');
     };
+
+    BM.escAttr = BM.escHtml;
+    BM.escSvg = BM.escHtml;
 
     /* Escapes a string for safe embedding as a single-quoted JS string
      * literal inside an inline onclick="..." HTML attribute, e.g.
@@ -60,6 +85,8 @@
             .replace(/'/g, "\\'")
             .replace(/\n/g, '\\n')
             .replace(/\r/g, '')
+            .replace(/\u2028/g, '\\u2028')
+            .replace(/\u2029/g, '\\u2029')
             .replace(/&/g, '&amp;')
             .replace(/"/g, '&quot;')
             .replace(/</g, '&lt;')
@@ -153,7 +180,7 @@
         for (var i = 0; i < items.length; i++) {
             var pct = ((vals[i] / total) * 100).toFixed(1);
             lh += '<div class="breakdown-legend-item"><span class="breakdown-legend-swatch" style="background:' + BM.doughnutColors[i % BM.doughnutColors.length] + '"></span>';
-            lh += '<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-0);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + labels[i] + '</div>';
+            lh += '<div style="flex:1;min-width:0"><div style="font-size:12px;font-weight:500;color:var(--text-0);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + BM.escHtml(labels[i]) + '</div>';
             lh += '<div style="font-size:11px;color:var(--text-2)">' + fmtFn(vals[i]) + ' · ' + pct + '%</div></div></div>';
         }
         legendEl.innerHTML = lh;
@@ -170,7 +197,7 @@
         for (var i = 0; i < items.length; i++) {
             var v = valueFn(items[i]);
             var pct = maxVal > 0 ? ((v / maxVal) * 100).toFixed(1) : '0';
-            h += '<tr><td>' + BM.rankClass(i) + '</td><td>' + labelFn(items[i]) + '</td>';
+            h += '<tr><td>' + BM.rankClass(i) + '</td><td>' + BM.escHtml(labelFn(items[i])) + '</td>';
             h += '<td>' + fmtFn(v) + '</td>';
             h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill ' + cls + '" style="width:' + pct + '%"></div></td></tr>';
         }
@@ -190,7 +217,7 @@
         for (var i = 0; i < items.length; i++) {
             var it = items[i]; var total = (it.tx_bytes||0) + (it.rx_bytes||0);
             var pct = maxTotal > 0 ? ((total / maxTotal) * 100).toFixed(1) : '0';
-            h += '<tr><td>' + labelFn(it) + '</td><td>' + BM.formatBytes(it.rx_bytes||0) + '</td><td>' + BM.formatBytes(it.tx_bytes||0) + '</td>';
+            h += '<tr><td>' + BM.escHtml(labelFn(it)) + '</td><td>' + BM.formatBytes(it.rx_bytes||0) + '</td><td>' + BM.formatBytes(it.tx_bytes||0) + '</td>';
             h += '<td>' + BM.formatBytes(total) + '</td>';
             h += '<td class="bar-cell"><div class="bar-bg"></div><div class="bar-fill bw" style="width:' + pct + '%"></div></td></tr>';
         }

--- a/static/js/utils.test.js
+++ b/static/js/utils.test.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+'use strict';
+
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var vm = require('vm');
+
+var elements = {};
+var context = {
+    window: {},
+    document: {
+        getElementById: function(id) { return elements[id] || null; }
+    },
+    location: { hash: '' },
+    history: { replaceState: function() {} },
+    URLSearchParams: URLSearchParams,
+    TextDecoder: TextDecoder,
+    fetch: function() { throw new Error('unexpected fetch'); },
+    Chart: function() {}
+};
+context.window.window = context.window;
+context.window.location = context.location;
+context.window.history = context.history;
+
+var source = fs.readFileSync(path.join(__dirname, 'utils.js'), 'utf8');
+vm.runInNewContext(source, context, { filename: 'utils.js' });
+var BM = context.window.BM;
+
+var hostile = '<img src=x onerror="boom()">\'&';
+assert.strictEqual(
+    BM.escHtml(hostile),
+    '&lt;img src=x onerror=&quot;boom()&quot;&gt;&#39;&amp;'
+);
+assert.strictEqual(BM.escAttr(hostile), BM.escHtml(hostile));
+assert.strictEqual(BM.escSvg(hostile), BM.escHtml(hostile));
+assert.strictEqual(BM.escHtml(null), '');
+assert.strictEqual(BM.integer(hostile, 7), 7);
+assert.strictEqual(BM.formatCount(hostile), '0');
+assert.ok(BM.escJs("x');boom();//\u2028").includes("\\'"));
+assert.ok(BM.escJs("x');boom();//\u2028").includes('\\u2028'));
+
+var legend = { innerHTML: '' };
+var chart = {
+    data: { labels: [], datasets: [{ data: [] }] },
+    update: function() {}
+};
+BM.fillDoughnut(chart, legend, [{ label: hostile, value: 1 }],
+    function(item) { return item.label; },
+    function(item) { return item.value; },
+    function(value) { return String(value); }
+);
+assert.ok(legend.innerHTML.includes('&lt;img'));
+assert.ok(!legend.innerHTML.includes('<img'));
+
+elements.hostileTable = { innerHTML: '' };
+BM.fillDetailTable('hostileTable', [{ label: hostile, value: 1 }],
+    function(item) { return item.label; },
+    function(item) { return item.value; },
+    function(value) { return String(value); },
+    'bw'
+);
+assert.ok(elements.hostileTable.innerHTML.includes('&lt;img'));
+assert.ok(!elements.hostileTable.innerHTML.includes('<img'));
+
+console.log('frontend escaping tests passed');


### PR DESCRIPTION
## Summary
- add shared HTML/attribute escaping and numeric validation helpers
- escape backend-derived values across traffic, NAT, DNS, diagnostics, topology, host detail, and wireless rendering
- add hostile-string regression coverage for shared rendering helpers

## Validation
- `node static/js/utils.test.js`
- syntax checks for all frontend JavaScript
- Linux-target `go test`, `go build`, and `go vet` across all packages
- native tests for portable packages