### PR TITLE
Make service shutdown idempotent and waitable

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -1,19 +1,51 @@
 package poller
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // Runner manages a periodic poll loop with graceful shutdown.
 type Runner struct {
-	stopCh chan struct{}
+	mu      sync.Mutex
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+	started bool
+	stopped bool
 }
 
 // Init allocates the stop channel. Call in your constructor.
 func (r *Runner) Init() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stopCh != nil {
+		panic("poller: Runner.Init called more than once")
+	}
 	r.stopCh = make(chan struct{})
+	r.doneCh = make(chan struct{})
 }
 
 // Run calls fn immediately, then every interval until Stop. Blocks.
 func (r *Runner) Run(interval time.Duration, fn func()) {
+	r.mu.Lock()
+	if r.stopCh == nil {
+		r.mu.Unlock()
+		panic("poller: Runner.Init must be called before Run")
+	}
+	if r.started {
+		r.mu.Unlock()
+		panic("poller: Runner.Run called more than once")
+	}
+	if r.stopped {
+		r.mu.Unlock()
+		return
+	}
+	r.started = true
+	stopCh := r.stopCh
+	doneCh := r.doneCh
+	r.mu.Unlock()
+
+	defer close(doneCh)
 	fn()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -21,18 +53,32 @@ func (r *Runner) Run(interval time.Duration, fn func()) {
 		select {
 		case <-ticker.C:
 			fn()
-		case <-r.stopCh:
+		case <-stopCh:
 			return
 		}
 	}
 }
 
-// Stop signals the loop to exit. Safe to call multiple times.
+// Stop signals the loop to exit and waits for any active poll to finish.
+// It is safe to call multiple times or concurrently.
 func (r *Runner) Stop() {
-	select {
-	case <-r.stopCh:
-	default:
+	r.mu.Lock()
+	if r.stopCh == nil {
+		r.mu.Unlock()
+		panic("poller: Runner.Init must be called before Stop")
+	}
+	if !r.stopped {
 		close(r.stopCh)
+	}
+	r.stopped = true
+	var doneCh <-chan struct{}
+	if r.started {
+		doneCh = r.doneCh
+	}
+	r.mu.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
 	}
 }
 

--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -1,0 +1,71 @@
+package poller
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStopIsSafeBeforeRun(t *testing.T) {
+	var runner Runner
+	runner.Init()
+
+	const callers = 16
+	var stops sync.WaitGroup
+	stops.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer stops.Done()
+			runner.Stop()
+		}()
+	}
+	stops.Wait()
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		runner.Run(time.Hour, func() {
+			t.Error("poll ran after Runner was stopped")
+		})
+	}()
+	<-runDone
+}
+
+func TestStopWaitsForActivePoll(t *testing.T) {
+	var runner Runner
+	runner.Init()
+
+	pollStarted := make(chan struct{})
+	releasePoll := make(chan struct{})
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		runner.Run(time.Hour, func() {
+			close(pollStarted)
+			<-releasePoll
+		})
+	}()
+	<-pollStarted
+
+	const callers = 16
+	stopDone := make(chan struct{}, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			runner.Stop()
+			stopDone <- struct{}{}
+		}()
+	}
+
+	<-runner.stopCh
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while a poll was still active")
+	default:
+	}
+
+	close(releasePoll)
+	for i := 0; i < callers; i++ {
+		<-stopDone
+	}
+	<-runDone
+}

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -106,8 +106,14 @@ type Tracker struct {
 	buckets     []*bucket
 	current     *bucket
 	stopCh      chan struct{}
+	doneCh      chan struct{}
 	dns         *resolver.Resolver
 	geoDB       *geoip.DB
+	lifecycleMu sync.Mutex
+	workers     sync.WaitGroup
+	started     bool
+	stopped     bool
+	captureFn   func(string)
 
 	// Rate ring: short circular buffer (5s slots) for responsive rate calc.
 	// Protected by the same mu as buckets/current.
@@ -191,9 +197,11 @@ func New(devices []string, promiscuous bool, localNets []*net.IPNet, geoDB *geoi
 		lanDevices:  lanDevices,
 		buckets:     make([]*bucket, 0, 1440),
 		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
 		dns:         dns,
 		geoDB:       geoDB,
 	}
+	trk.captureFn = trk.captureDevice
 	// Initialize first rate ring slot
 	trk.rateRing[0] = &rateSlot{
 		timestamp: time.Now(),
@@ -203,6 +211,19 @@ func New(devices []string, promiscuous bool, localNets []*net.IPNet, geoDB *geoi
 }
 
 func (t *Tracker) Run() {
+	t.lifecycleMu.Lock()
+	if t.started {
+		t.lifecycleMu.Unlock()
+		panic("talkers: Tracker.Run called more than once")
+	}
+	if t.stopped {
+		t.lifecycleMu.Unlock()
+		return
+	}
+	t.started = true
+	t.lifecycleMu.Unlock()
+	defer close(t.doneCh)
+
 	devices, err := t.getDevices()
 	if err != nil {
 		log.Printf("talkers: cannot list devices: %v", err)
@@ -214,6 +235,7 @@ func (t *Tracker) Run() {
 		return
 	}
 
+	t.mu.Lock()
 	t.current = &bucket{
 		timestamp:  time.Now().Truncate(bucketSize),
 		hosts:      make(map[string]*hostAccum),
@@ -221,23 +243,56 @@ func (t *Tracker) Run() {
 		ipVerBytes: make(map[string]uint64),
 		pairs:      make(map[string]map[string]*hostAccum),
 	}
+	t.mu.Unlock()
 
-	go t.rotateBuckets()
-	go t.rotateRateRing()
-
+	t.lifecycleMu.Lock()
+	if t.stopped {
+		t.lifecycleMu.Unlock()
+		return
+	}
+	t.startWorker(t.rotateBuckets)
+	t.startWorker(t.rotateRateRing)
 	for _, dev := range devices {
 		if !t.lanDevices[dev] {
 			log.Printf("talkers: skipping capture on %s (not LAN)", dev)
 			continue
 		}
-		go t.captureDevice(dev)
+		device := dev
+		t.startWorker(func() {
+			t.captureFn(device)
+		})
 	}
+	t.lifecycleMu.Unlock()
 
 	<-t.stopCh
+	t.workers.Wait()
 }
 
+// Stop signals all tracker goroutines and waits for them to release their resources.
+// It is safe to call multiple times or concurrently.
 func (t *Tracker) Stop() {
-	close(t.stopCh)
+	t.lifecycleMu.Lock()
+	if !t.stopped {
+		close(t.stopCh)
+	}
+	t.stopped = true
+	var doneCh <-chan struct{}
+	if t.started {
+		doneCh = t.doneCh
+	}
+	t.lifecycleMu.Unlock()
+
+	if doneCh != nil {
+		<-doneCh
+	}
+}
+
+func (t *Tracker) startWorker(fn func()) {
+	t.workers.Add(1)
+	go func() {
+		defer t.workers.Done()
+		fn()
+	}()
 }
 
 func (t *Tracker) TopByVolume(n int) []TalkerStat {

--- a/talkers/talkers_lifecycle_test.go
+++ b/talkers/talkers_lifecycle_test.go
@@ -1,0 +1,86 @@
+package talkers
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestStopIsSafeBeforeRun(t *testing.T) {
+	tracker := lifecycleTestTracker(nil)
+
+	const callers = 16
+	var stops sync.WaitGroup
+	stops.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer stops.Done()
+			tracker.Stop()
+		}()
+	}
+	stops.Wait()
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		tracker.Run()
+	}()
+	<-runDone
+}
+
+func TestStopWaitsForCaptureWorker(t *testing.T) {
+	captureStarted := make(chan struct{})
+	stopObserved := make(chan struct{})
+	releaseCapture := make(chan struct{})
+	var tracker *Tracker
+	tracker = lifecycleTestTracker(func(string) {
+		close(captureStarted)
+		<-tracker.stopCh
+		close(stopObserved)
+		<-releaseCapture
+	})
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		tracker.Run()
+	}()
+	<-captureStarted
+
+	const callers = 16
+	stopDone := make(chan struct{}, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			tracker.Stop()
+			stopDone <- struct{}{}
+		}()
+	}
+
+	<-stopObserved
+	select {
+	case <-stopDone:
+		t.Fatal("Stop returned while a capture worker was still active")
+	default:
+	}
+
+	close(releaseCapture)
+	for i := 0; i < callers; i++ {
+		<-stopDone
+	}
+	<-runDone
+}
+
+func lifecycleTestTracker(captureFn func(string)) *Tracker {
+	if captureFn == nil {
+		captureFn = func(string) {
+			panic("capture worker started unexpectedly")
+		}
+	}
+	return &Tracker{
+		devices:    []string{"capture-test"},
+		lanDevices: map[string]bool{"capture-test": true},
+		buckets:    make([]*bucket, 0, 1),
+		stopCh:     make(chan struct{}),
+		doneCh:     make(chan struct{}),
+		captureFn:  captureFn,
+	}
+}


### PR DESCRIPTION
## Summary
- serialize poller shutdown so concurrent and repeated `Stop` calls are safe
- wait for an active poll callback before dependent resources are released
- join talker capture and rotation workers before tracker shutdown completes
- add deterministic lifecycle tests for stop-before-run, concurrent stop, and active-work waiting

## Validation
- `go test -race ./poller`
- Linux-targeted compilation of all package tests
- Linux-targeted `go vet ./...`
- Linux-targeted `go build ./...`