### PR TITLE
Show resolved names in bandwidth-top

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,13 @@ sudo setcap cap_net_raw+ep /usr/bin/bandwidth-top
 Rates are displayed in bit/s (capture accounting uses bytes/s). Each ranked flow
 uses two linked lines: `=>` for outbound traffic and `<=` for inbound traffic,
 with an iftop-style bandwidth ruler, proportional graph-lane bars, and rolling
-2s, 10s, and 40s rates. Remote IP, ASN, and provider have independent headed
-columns on the primary line; the inbound continuation leaves those cells blank
-and aligned. A shown ASN always has room for the full `AS4294967295`; narrower
-layouts truncate and then drop provider before dropping ASN, and drop optional
+2s, 10s, and 40s rates. REMOTE prefers names from the local reverse-DNS resolver,
+then enrichment hostnames, and otherwise shows the IP; `--no-resolve`/`-n`
+disables PTR lookups and always shows IPs. Remote host, ASN, and provider have
+independent headed columns on the primary line; the inbound continuation leaves
+those cells blank and aligned. A shown ASN always has room for the full
+`AS4294967295`; narrower layouts truncate and then drop provider before dropping
+ASN, and drop optional
 columns whole rather than merging metadata into the remote host. The footer
 summarizes TX, RX, and total rates across all observed peers, including peers
 below the row limit.
@@ -236,6 +239,7 @@ interface-derived prefixes, which is useful for routed or bridged captures.
 | `--rows` | `20` | Maximum displayed peers |
 | `--refresh` | `1s` | Refresh interval |
 | `--snapshot` | off | Print one plain snapshot and exit |
+| `--no-resolve`, `-n` | off | Disable PTR lookups and show remote IPs |
 | `--width` | terminal width | Output width; long values are truncated |
 | `--asn-mmdb` | auto | GeoLite2 ASN MMDB |
 | `--city-mmdb` | auto | GeoLite2 City/Country MMDB |

--- a/README.md
+++ b/README.md
@@ -208,13 +208,10 @@ sudo setcap cap_net_raw+ep /usr/bin/bandwidth-top
 Rates are displayed in bit/s (capture accounting uses bytes/s). Each ranked flow
 uses two linked lines: `=>` for outbound traffic and `<=` for inbound traffic,
 with an iftop-style bandwidth ruler, proportional graph-lane bars, and rolling
-2s, 10s, and 40s rates. REMOTE prefers names from the local reverse-DNS resolver,
-then enrichment hostnames, and otherwise shows the IP; `--no-resolve`/`-n`
-disables PTR lookups and always shows IPs. Remote host, ASN, and provider have
-independent headed columns on the primary line; the inbound continuation leaves
-those cells blank and aligned. A shown ASN always has room for the full
-`AS4294967295`; narrower layouts truncate and then drop provider before dropping
-ASN, and drop optional
+2s, 10s, and 40s rates. Remote IP, ASN, and provider have independent headed
+columns on the primary line; the inbound continuation leaves those cells blank
+and aligned. A shown ASN always has room for the full `AS4294967295`; narrower
+layouts truncate and then drop provider before dropping ASN, and drop optional
 columns whole rather than merging metadata into the remote host. The footer
 summarizes TX, RX, and total rates across all observed peers, including peers
 below the row limit.

--- a/bandwidthtop/format.go
+++ b/bandwidthtop/format.go
@@ -26,9 +26,10 @@ type Stat struct {
 }
 
 type Row struct {
-	LocalIP string
-	Stat    Stat
-	Info    Enrichment
+	LocalIP   string
+	Stat      Stat
+	Info      Enrichment
+	NoResolve bool
 }
 
 type Totals struct {
@@ -479,7 +480,17 @@ func maximumDirectionalRate(rows []Row) float64 {
 }
 
 func remoteHost(row Row) string {
-	return sanitizeTerminal(row.Stat.IP)
+	ip := sanitizeTerminal(row.Stat.IP)
+	if row.NoResolve {
+		return ip
+	}
+	if hostname := sanitizeTerminal(row.Stat.Hostname); hostname != "" && hostname != ip {
+		return hostname
+	}
+	if hostname := sanitizeTerminal(row.Info.Hostname); hostname != "" && hostname != ip {
+		return hostname
+	}
+	return ip
 }
 
 func formatASN(asn uint) string {

--- a/bandwidthtop/format_test.go
+++ b/bandwidthtop/format_test.go
@@ -27,6 +27,92 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
+func TestRemoteHostResolutionPreference(t *testing.T) {
+	tests := []struct {
+		name string
+		row  Row
+		want string
+	}{
+		{
+			name: "PTR preferred",
+			row: Row{
+				Stat: Stat{IP: "198.51.100.20", Hostname: "ptr.example"},
+				Info: Enrichment{Hostname: "enrichment.example"},
+			},
+			want: "ptr.example",
+		},
+		{
+			name: "enrichment fallback",
+			row: Row{
+				Stat: Stat{IP: "198.51.100.20"},
+				Info: Enrichment{Hostname: "enrichment.example"},
+			},
+			want: "enrichment.example",
+		},
+		{
+			name: "raw IP fallback",
+			row:  Row{Stat: Stat{IP: "198.51.100.20"}},
+			want: "198.51.100.20",
+		},
+		{
+			name: "sanitized PTR fallback",
+			row: Row{
+				Stat: Stat{IP: "198.51.100.20", Hostname: "\x1b[31m"},
+				Info: Enrichment{Hostname: "enrichment.example"},
+			},
+			want: "enrichment.example",
+		},
+		{
+			name: "sanitized hostname IP fallback",
+			row: Row{
+				Stat: Stat{IP: "198.51.100.20", Hostname: "\x1b[31m"},
+				Info: Enrichment{Hostname: "\u202e"},
+			},
+			want: "198.51.100.20",
+		},
+		{
+			name: "no resolve forces IP",
+			row: Row{
+				Stat:      Stat{IP: "198.51.100.20", Hostname: "ptr.example"},
+				Info:      Enrichment{Hostname: "enrichment.example"},
+				NoResolve: true,
+			},
+			want: "198.51.100.20",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := remoteHost(test.row); got != test.want {
+				t.Fatalf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRemoteHostnameArrivalPreservesLayout(t *testing.T) {
+	const width = 80
+	row := testFlowRow()
+	before := RenderSnapshot([]Row{row}, testTotals(), width)
+	row.Stat.Hostname = "peer-with-a-long-local-ptr-name.example"
+	after := RenderSnapshot([]Row{row}, testTotals(), width)
+
+	beforeLines := strings.Split(strings.TrimSuffix(before, "\n"), "\n")
+	afterLines := strings.Split(strings.TrimSuffix(after, "\n"), "\n")
+	if beforeLines[1] != afterLines[1] {
+		t.Fatalf("async hostname changed columns:\n%s\n%s", before, after)
+	}
+	if strings.Index(beforeLines[2], "=>") != strings.Index(afterLines[2], "=>") {
+		t.Fatalf("async hostname moved direction column:\n%s\n%s", before, after)
+	}
+	if displayWidth(beforeLines[2]) != width || displayWidth(afterLines[2]) != width {
+		t.Fatalf("async hostname changed line width: before=%d after=%d",
+			displayWidth(beforeLines[2]), displayWidth(afterLines[2]))
+	}
+	if !strings.Contains(afterLines[2], "peer-with-a-lon~") {
+		t.Fatalf("hostname was not truncated in the REMOTE cell:\n%s", after)
+	}
+}
+
 func TestRenderShowsClassicLinkedDirectionsAndDedicatedMetadata(t *testing.T) {
 	got := RenderSnapshot([]Row{testFlowRow()}, testTotals(), 160)
 	for _, want := range []string{
@@ -381,18 +467,35 @@ func TestRenderStripsTerminalAndUnicodeControls(t *testing.T) {
 	}
 }
 
+func TestRemoteHostnameIsSanitizedBeforeTruncation(t *testing.T) {
+	row := testFlowRow()
+	row.Stat.Hostname = "\x1b[31mhostname-with-a-very-long-label.example\x1b[0m"
+	got := RenderSnapshot([]Row{row}, testTotals(), 80)
+	if strings.Contains(got, "\x1b") || strings.Contains(got, "31m") {
+		t.Fatalf("terminal control sequence survived: %q", got)
+	}
+	if !strings.Contains(got, "hostname-with-a~") {
+		t.Fatalf("sanitized hostname was not truncated to the REMOTE cell:\n%s", got)
+	}
+	for _, line := range strings.Split(strings.TrimSuffix(got, "\n"), "\n") {
+		if displayWidth(line) > 80 {
+			t.Fatalf("line exceeded requested width: %q", line)
+		}
+	}
+}
+
 func testFlowRow() Row {
 	return Row{
 		LocalIP: "192.0.2.10",
 		Stat: Stat{
-			IP: "198.51.100.20", Hostname: "peer.example",
+			IP:      "198.51.100.20",
 			Tx:      RateWindows{Two: 125000, Ten: 62500, Forty: 31250},
 			Rx:      RateWindows{Two: 250000, Ten: 125000, Forty: 62500},
 			Packets: 42,
 		},
 		Info: Enrichment{
-			Hostname: "peer.example", Provider: "Example Networks",
-			Country: "Exampleland", ASN: 64500, Source: "local+monitor",
+			Provider: "Example Networks",
+			Country:  "Exampleland", ASN: 64500, Source: "local+monitor",
 		},
 	}
 }

--- a/cmd/bandwidth-top/main.go
+++ b/cmd/bandwidth-top/main.go
@@ -40,6 +40,9 @@ func run(args []string, stdout, stderr io.Writer) error {
 	noServerDiscovery := fs.Bool("no-server-discovery", false, "disable one-time default-gateway monitor discovery")
 	publicURL := fs.String("public-url", bandwidthtop.DefaultPublicURL, "public enrichment API base URL")
 	noPublic := fs.Bool("no-public", false, "disable public enrichment fallback")
+	noResolve := false
+	fs.BoolVar(&noResolve, "no-resolve", false, "disable reverse DNS and show remote IPs")
+	fs.BoolVar(&noResolve, "n", false, "disable reverse DNS and show remote IPs (shorthand)")
 	width := fs.Int("width", 0, "output width in columns (default: terminal width)")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage: bandwidth-top [options]")
@@ -81,8 +84,10 @@ func run(args []string, stdout, stderr io.Writer) error {
 	terminal := newTerminalSession(stdout, liveTerminal, func() terminalDimensions {
 		return terminalSize(stdout)
 	})
-	dns := resolver.New()
-	defer dns.Stop()
+	dns := resolverUnlessDisabled(noResolve, resolver.New)
+	if dns != nil {
+		defer dns.Stop()
+	}
 	tracker := talkers.NewDirect(iface.Name, false, localNetworks, nil, dns)
 	log.SetOutput(io.Discard)
 	go tracker.Run()
@@ -114,7 +119,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 			viewRows := make([]bandwidthtop.Row, 0, len(stats))
 			for _, stat := range stats {
 				viewRows = append(viewRows, bandwidthtop.Row{
-					LocalIP: stat.LocalIP,
+					LocalIP:   stat.LocalIP,
+					NoResolve: noResolve,
 					Stat: bandwidthtop.Stat{
 						IP: stat.IP, Hostname: stat.Hostname, Packets: stat.Packets,
 						Rx: bandwidthtop.RateWindows{
@@ -172,6 +178,13 @@ func run(args []string, stdout, stderr io.Writer) error {
 			}
 		}
 	})
+}
+
+func resolverUnlessDisabled(disabled bool, create func() *resolver.Resolver) *resolver.Resolver {
+	if disabled {
+		return nil
+	}
+	return create()
 }
 
 func lookupErrorStatus(rows []bandwidthtop.Row) string {

--- a/cmd/bandwidth-top/main_linux_test.go
+++ b/cmd/bandwidth-top/main_linux_test.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"strings"
 	"testing"
+
+	"bandwidth-monitor/resolver"
 )
 
 func TestHelpDoesNotStartCapture(t *testing.T) {
@@ -18,8 +20,21 @@ func TestHelpDoesNotStartCapture(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Usage: bandwidth-top") ||
 		!strings.Contains(stderr.String(), "CAP_NET_RAW") ||
 		!strings.Contains(stderr.String(), "checked once at startup") ||
-		!strings.Contains(stderr.String(), "local-network") {
+		!strings.Contains(stderr.String(), "local-network") ||
+		!strings.Contains(stderr.String(), "no-resolve") ||
+		!strings.Contains(stderr.String(), "-n") {
 		t.Fatalf("unexpected help:\n%s", stderr.String())
+	}
+}
+
+func TestNoResolveDoesNotCreateResolver(t *testing.T) {
+	created := 0
+	got := resolverUnlessDisabled(true, func() *resolver.Resolver {
+		created++
+		return nil
+	})
+	if got != nil || created != 0 {
+		t.Fatalf("resolver=%v created=%d, want nil resolver without factory use", got, created)
 	}
 }
 

--- a/talkers/direct_test.go
+++ b/talkers/direct_test.go
@@ -161,6 +161,19 @@ func TestDirectPeerSortTieIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestDirectSnapshotWithoutResolverDoesNotResolveHostname(t *testing.T) {
+	now := time.Unix(600, 0)
+	tracker := directAggregationTracker(now.Add(-2 * time.Second))
+	tracker.accountDirectPeer(
+		directPacket("192.168.1.20", "192.0.2.20", true, false, 100),
+		tracker.directRateRing[0],
+	)
+	got, _ := tracker.directBandwidthSnapshot(1, now)
+	if len(got) != 1 || got[0].Hostname != "" {
+		t.Fatalf("snapshot unexpectedly resolved hostname without resolver: %+v", got)
+	}
+}
+
 func directAggregationTracker(start time.Time) *Tracker {
 	_, localNet, _ := net.ParseCIDR("192.168.1.0/24")
 	tracker := &Tracker{


### PR DESCRIPTION
## Summary
- prefer local PTR names, then enrichment hostnames, in the REMOTE column
- add `--no-resolve` / `-n` to skip resolver creation and force IP display
- preserve fixed-width layouts while covering hostname precedence, sanitization, truncation, and resolver-disable behavior

## Checks
- `go test -race ./bandwidthtop ./cmd/bandwidth-top ./talkers` (Linux)
- `go vet ./...` (Linux)
- `CGO_ENABLED=0 go test ./...` (Linux)
- `CGO_ENABLED=0 go build ./cmd/bandwidth-top` (Linux)
- `./packaging/test-packaging.sh`