### PR TITLE
Add port flow view to bandwidth-top

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Common options:
 | `--rows` | `20` | Maximum displayed peers |
 | `--refresh` | `1s` | Refresh interval |
 | `--snapshot` | Off | Print one plain snapshot and exit |
+| `--ports` | Off | Aggregate by remote port/protocol; non-initial fragments use port `-` |
 | `--no-resolve`, `-n` | Off | Disable PTR lookups and show remote IPs |
 | `--server` | Gateway discovery | Explicit Bandwidth Monitor URL |
 | `--no-server-discovery` | Off | Disable the default-gateway probe |

--- a/bandwidthtop/format.go
+++ b/bandwidthtop/format.go
@@ -30,6 +30,8 @@ type Row struct {
 	Stat      Stat
 	Info      Enrichment
 	NoResolve bool
+	Port      string
+	Protocol  string
 }
 
 type Totals struct {
@@ -39,6 +41,22 @@ type Totals struct {
 
 type flowLayout struct {
 	rank, local, arrow, remote int
+	asn, provider, graph, rate int
+	showASN, showProvider      bool
+	showGraph                  bool
+}
+
+// ViewMode selects the row identity rendered by bandwidth-top.
+type ViewMode uint8
+
+const (
+	ViewHosts ViewMode = iota
+	ViewPorts
+)
+
+type portFlowLayout struct {
+	rank, local, arrow, remote int
+	port, protocol             int
 	asn, provider, graph, rate int
 	showASN, showProvider      bool
 	showGraph                  bool
@@ -219,10 +237,25 @@ func RenderLiveWithRowLimit(rows []Row, totals Totals, width, maxRows int) strin
 	return renderFlows(rows, totals, width, maxRows, true)
 }
 
+func RenderSnapshotForMode(rows []Row, totals Totals, width, maxRows int, mode ViewMode) string {
+	if mode == ViewPorts {
+		return renderPortFlows(rows, totals, width, maxRows, false)
+	}
+	return RenderSnapshotWithRowLimit(rows, totals, width, maxRows)
+}
+
+func RenderLiveForMode(rows []Row, totals Totals, width, maxRows int, mode ViewMode) string {
+	if mode == ViewPorts {
+		return renderPortFlows(rows, totals, width, maxRows, true)
+	}
+	return RenderLiveWithRowLimit(rows, totals, width, maxRows)
+}
+
 func renderFlows(rows []Row, totals Totals, width, maxRows int, ansi bool) string {
 	if width <= 0 {
 		width = 120
 	}
+
 	layout, structured := makeFlowLayout(width, rankWidth(maxRows))
 	maxRate := maximumDirectionalRate(rows)
 	var b strings.Builder
@@ -281,6 +314,69 @@ func renderFlows(rows []Row, totals Totals, width, maxRows int, ansi bool) strin
 	return b.String()
 }
 
+func renderPortFlows(rows []Row, totals Totals, width, maxRows int, ansi bool) string {
+	if width <= 0 {
+		width = 120
+	}
+	layout, structured := makePortFlowLayout(width, rankWidth(maxRows))
+	maxRate := maximumDirectionalRate(rows)
+	var b strings.Builder
+	if structured {
+		if layout.showGraph {
+			b.WriteString(color(ansiDim, portFlowLine(layout, "", "", "", "", "", "", "", "", graphRuler(maxRate, layout.graph), "", "", ""), ansi))
+			b.WriteByte('\n')
+		}
+		header := portFlowLine(layout, "#", "LOCAL", "  ", "REMOTE", "PORT", "PROTO", "ASN", "PROVIDER", "GRAPH", "2s", "10s", "40s")
+		b.WriteString(color(ansiBold, header, ansi))
+		b.WriteByte('\n')
+		for i, row := range rows {
+			rank := fmt.Sprintf("%d", i+1)
+			outBar := rateBar(row.Stat.Tx.Two, maxRate, layout.graph)
+			inBar := rateBar(row.Stat.Rx.Two, maxRate, layout.graph)
+			b.WriteString(portFlowLineStyled(layout, rank, row.LocalIP, "=>", remoteHost(row),
+				normalizedPort(row.Port), normalizedProtocol(row.Protocol),
+				formatASN(row.Info.ASN), row.Info.Provider, outBar,
+				formatCompactRate(row.Stat.Tx.Two), formatCompactRate(row.Stat.Tx.Ten),
+				formatCompactRate(row.Stat.Tx.Forty), ansiGreen, ansi))
+			b.WriteByte('\n')
+			b.WriteString(portFlowLineStyled(layout, "", "", "<=", "", "", "", "", "", inBar,
+				formatCompactRate(row.Stat.Rx.Two), formatCompactRate(row.Stat.Rx.Ten),
+				formatCompactRate(row.Stat.Rx.Forty), ansiCyan, ansi))
+			b.WriteByte('\n')
+		}
+	} else {
+		b.WriteString(Truncate("# LOCAL => REMOTE PORT PROTO 2s", width))
+		b.WriteByte('\n')
+		for i, row := range rows {
+			out := fmt.Sprintf("%d %s => %s %s %s %s %s", i+1, row.LocalIP,
+				remoteHost(row), normalizedPort(row.Port), normalizedProtocol(row.Protocol),
+				rateBar(row.Stat.Tx.Two, maxRate, max(1, width/8)),
+				formatCompactRate(row.Stat.Tx.Two))
+			in := fmt.Sprintf("  <= %s %s", rateBar(row.Stat.Rx.Two, maxRate, max(1, width/8)),
+				formatCompactRate(row.Stat.Rx.Two))
+			b.WriteString(color(ansiGreen, Truncate(out, width), ansi))
+			b.WriteByte('\n')
+			b.WriteString(color(ansiCyan, Truncate(in, width), ansi))
+			b.WriteByte('\n')
+		}
+	}
+	b.WriteString(color(ansiDim, strings.Repeat("-", width), ansi))
+	b.WriteByte('\n')
+	b.WriteString(footerLine("TX", totals.Tx, width, ansiGreen, ansi))
+	b.WriteByte('\n')
+	b.WriteString(footerLine("RX", totals.Rx, width, ansiCyan, ansi))
+	b.WriteByte('\n')
+	b.WriteString(footerLine("TOTAL", addRates(totals.Tx, totals.Rx), width, ansiBold, ansi))
+	b.WriteByte('\n')
+	hint := "snapshot complete"
+	if ansi {
+		hint = "Ctrl-C / SIGTERM quit"
+	}
+	b.WriteString(color(ansiDim, Truncate(hint, width), ansi))
+	b.WriteByte('\n')
+	return b.String()
+}
+
 func rankWidth(maxRows int) int {
 	if maxRows < 1 {
 		maxRows = 1
@@ -310,7 +406,54 @@ func makeFlowLayout(width, rank int) (flowLayout, bool) {
 	case width < flowLayoutWidth(layout):
 		return flowLayout{}, false
 	}
+
 	extra := width - flowLayoutWidth(layout)
+	growColumnsEven(&layout.local, &layout.remote, 15, &extra)
+	if layout.showProvider {
+		growColumn(&layout.provider, 16, &extra)
+	}
+	growColumnsEven(&layout.local, &layout.remote, 39, &extra)
+	if layout.showGraph {
+		growColumn(&layout.graph, 24, &extra)
+	}
+	if layout.showProvider {
+		growColumn(&layout.provider, 24, &extra)
+	}
+	if layout.showGraph {
+		growColumn(&layout.graph, 40, &extra)
+	}
+	if layout.showProvider {
+		growColumn(&layout.provider, 40, &extra)
+	}
+	return layout, true
+}
+
+func makePortFlowLayout(width, rank int) (portFlowLayout, bool) {
+	layout := portFlowLayout{
+		rank: rank, local: 7, arrow: 2, remote: 7,
+		port: 5, protocol: 8, graph: 5, rate: 6,
+	}
+	asnOnly := layout
+	asnOnly.showASN, asnOnly.asn = true, 12
+	asnGraph := asnOnly
+	asnGraph.showGraph = true
+	all := asnGraph
+	all.showProvider, all.provider = true, 8
+	graphOnly := layout
+	graphOnly.showGraph = true
+	switch {
+	case width >= portFlowLayoutWidth(all):
+		layout = all
+	case width >= portFlowLayoutWidth(asnGraph):
+		layout = asnGraph
+	case width >= portFlowLayoutWidth(asnOnly):
+		layout = asnOnly
+	case width >= portFlowLayoutWidth(graphOnly):
+		layout = graphOnly
+	case width < portFlowLayoutWidth(layout):
+		return portFlowLayout{}, false
+	}
+	extra := width - portFlowLayoutWidth(layout)
 	growColumnsEven(&layout.local, &layout.remote, 15, &extra)
 	if layout.showProvider {
 		growColumn(&layout.provider, 16, &extra)
@@ -364,6 +507,30 @@ func (layout flowLayout) widths() []int {
 	if layout.showASN {
 		widths = append(widths, layout.asn)
 	}
+
+	if layout.showProvider {
+		widths = append(widths, layout.provider)
+	}
+	if layout.showGraph {
+		widths = append(widths, layout.graph)
+	}
+	return append(widths, layout.rate, layout.rate, layout.rate)
+}
+
+func portFlowLayoutWidth(layout portFlowLayout) int {
+	widths := layout.widths()
+	total := len(widths) - 1
+	for _, width := range widths {
+		total += width
+	}
+	return total
+}
+
+func (layout portFlowLayout) widths() []int {
+	widths := []int{layout.rank, layout.local, layout.arrow, layout.remote, layout.port, layout.protocol}
+	if layout.showASN {
+		widths = append(widths, layout.asn)
+	}
 	if layout.showProvider {
 		widths = append(widths, layout.provider)
 	}
@@ -397,6 +564,7 @@ func flowLineStyled(layout flowLayout, rank, local, arrow, remote, asn, provider
 	if !ansi {
 		return flowLine(layout, rank, local, arrow, remote, asn, provider, graph, rate2, rate10, rate40)
 	}
+
 	values := []string{rank, local, arrow, remote}
 	if layout.showASN {
 		values = append(values, asn)
@@ -419,6 +587,70 @@ func flowLineStyled(layout flowLayout, rank, local, arrow, remote, asn, provider
 		cells[len(cells)-4] = color(style, cells[len(cells)-4], true)
 	}
 	return strings.Join(cells, " ")
+}
+
+func portFlowLine(layout portFlowLayout, rank, local, arrow, remote, port, protocol, asn, provider, graph, rate2, rate10, rate40 string) string {
+	values := []string{rank, local, arrow, remote, port, protocol}
+	if layout.showASN {
+		values = append(values, asn)
+	}
+	if layout.showProvider {
+		values = append(values, provider)
+	}
+	if layout.showGraph {
+		values = append(values, graph)
+	}
+	values = append(values, rate2, rate10, rate40)
+	widths := layout.widths()
+	cells := make([]string, len(values))
+	for i := range values {
+		cells[i] = fitCell(values[i], widths[i], i == 0 || i == 4 || i >= len(values)-3)
+	}
+	return strings.Join(cells, " ")
+}
+
+func portFlowLineStyled(layout portFlowLayout, rank, local, arrow, remote, port, protocol, asn, provider, graph, rate2, rate10, rate40, style string, ansi bool) string {
+	if !ansi {
+		return portFlowLine(layout, rank, local, arrow, remote, port, protocol, asn, provider, graph, rate2, rate10, rate40)
+	}
+	values := []string{rank, local, arrow, remote, port, protocol}
+	if layout.showASN {
+		values = append(values, asn)
+	}
+	if layout.showProvider {
+		values = append(values, provider)
+	}
+	if layout.showGraph {
+		values = append(values, graph)
+	}
+	values = append(values, rate2, rate10, rate40)
+	widths := layout.widths()
+	cells := make([]string, len(values))
+	for i := range values {
+		cells[i] = fitCell(values[i], widths[i], i == 0 || i == 4 || i >= len(values)-3)
+	}
+	cells[0] = color(ansiBold, cells[0], true)
+	cells[2] = color(style, cells[2], true)
+	if layout.showGraph {
+		cells[len(cells)-4] = color(style, cells[len(cells)-4], true)
+	}
+	return strings.Join(cells, " ")
+}
+
+func normalizedPort(port string) string {
+	value, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		return "-"
+	}
+	return strconv.FormatUint(value, 10)
+}
+
+func normalizedProtocol(protocol string) string {
+	protocol = sanitizeTerminal(protocol)
+	if protocol == "" {
+		return "IP-0"
+	}
+	return protocol
 }
 
 func fitCell(value string, width int, right bool) string {

--- a/bandwidthtop/format_test.go
+++ b/bandwidthtop/format_test.go
@@ -484,6 +484,107 @@ func TestRemoteHostnameIsSanitizedBeforeTruncation(t *testing.T) {
 	}
 }
 
+func TestHostModeAPIIsByteCompatible(t *testing.T) {
+	rows := []Row{testFlowRow()}
+	want := RenderSnapshotWithRowLimit(rows, testTotals(), 120, 20)
+	got := RenderSnapshotForMode(rows, testTotals(), 120, 20, ViewHosts)
+	if got != want {
+		t.Fatalf("host mode changed:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestPortModeDedicatedColumnsAtRepresentativeWidths(t *testing.T) {
+	row := testFlowRow()
+	row.Port = "65535"
+	row.Protocol = "TCP"
+	for _, width := range []int{80, 120, 160} {
+		got := RenderSnapshotForMode([]Row{row}, testTotals(), width, 20, ViewPorts)
+		lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+		header := lines[1]
+		primary := lines[2]
+		continuation := lines[3]
+		for _, heading := range []string{"LOCAL", "REMOTE", "PORT", "PROTO", "ASN", "2s", "10s", "40s"} {
+			if !strings.Contains(header, heading) {
+				t.Fatalf("width %d missing %s:\n%s", width, heading, got)
+			}
+		}
+		for _, value := range []string{"65535", "TCP", "AS64500"} {
+			if strings.Count(primary, value) != 1 || strings.Contains(continuation, value) {
+				t.Fatalf("width %d did not isolate %q:\n%s", width, value, got)
+			}
+		}
+		for _, line := range lines {
+			if displayWidth(line) > width {
+				t.Fatalf("width %d produced %d columns: %q", width, displayWidth(line), line)
+			}
+		}
+	}
+}
+
+func TestPortModeDropsOptionalColumnsWholeAndPreservesASN(t *testing.T) {
+	row := testFlowRow()
+	row.Port, row.Protocol = "443", "TCP"
+	row.Info.ASN = 1<<32 - 1
+	row.Info.Provider = "Hostile Provider With Very Wide Text"
+	for _, width := range []int{69, 74, 75, 83, 84} {
+		got := RenderSnapshotForMode([]Row{row}, testTotals(), width, 20, ViewPorts)
+		if !strings.Contains(got, "PORT") || !strings.Contains(got, "PROTO") {
+			t.Fatalf("mandatory columns missing at %d:\n%s", width, got)
+		}
+		if strings.Contains(got, "ASN") && !strings.Contains(got, "AS4294967295") {
+			t.Fatalf("ASN truncated at %d:\n%s", width, got)
+		}
+		if width < 84 && strings.Contains(got, "PROVIDER") {
+			t.Fatalf("provider retained ahead of mandatory/full ASN at %d:\n%s", width, got)
+		}
+	}
+}
+
+func TestPortModeSanitizesAndValidatesFields(t *testing.T) {
+	row := testFlowRow()
+	row.Port = "70000"
+	row.Protocol = "\x1b[31mTCP\n"
+	got := RenderSnapshotForMode([]Row{row}, testTotals(), 120, 20, ViewPorts)
+	if strings.Contains(got, "70000") || strings.Contains(got, "\x1b") || strings.Contains(got, "31m") {
+		t.Fatalf("hostile port/protocol survived:\n%q", got)
+	}
+	if !strings.Contains(got, " - ") || !strings.Contains(got, "TCP") {
+		t.Fatalf("port placeholder or protocol missing:\n%s", got)
+	}
+}
+
+func TestPortModeStableOffsetsAndBoundsAtEveryWidth(t *testing.T) {
+	row := testFlowRow()
+	row.Port, row.Protocol = "443", "TCP"
+	for width := 1; width <= 200; width++ {
+		got := RenderSnapshotForMode([]Row{row}, testTotals(), width, 99, ViewPorts)
+		lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+		for _, line := range lines {
+			if gotWidth := displayWidth(line); gotWidth > width {
+				t.Fatalf("width %d produced %d columns: %q", width, gotWidth, line)
+			}
+		}
+		if _, structured := makePortFlowLayout(width, rankWidth(99)); !structured {
+			continue
+		}
+		headerIndex := indexContaining(lines, "LOCAL")
+		if headerIndex < 0 || !strings.Contains(lines[headerIndex], "PORT") ||
+			!strings.Contains(lines[headerIndex], "PROTO") {
+			t.Fatalf("width %d lost structured port headings:\n%s", width, got)
+		}
+		primary, continuation := lines[headerIndex+1], lines[headerIndex+2]
+		if strings.Index(primary, "=>") != strings.Index(continuation, "<=") {
+			t.Fatalf("width %d moved direction offset:\n%s", width, got)
+		}
+		for _, heading := range []string{"REMOTE", "PORT", "PROTO", "2s"} {
+			if offset := strings.Index(lines[headerIndex], heading); offset < 0 ||
+				len(primary) <= offset || len(continuation) <= offset {
+				t.Fatalf("width %d has unstable %s column:\n%s", width, heading, got)
+			}
+		}
+	}
+}
+
 func testFlowRow() Row {
 	return Row{
 		LocalIP: "192.0.2.10",

--- a/cmd/bandwidth-top/main.go
+++ b/cmd/bandwidth-top/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -34,6 +35,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 	rows := fs.Int("rows", 20, "maximum rows")
 	refresh := fs.Duration("refresh", time.Second, "refresh interval")
 	snapshot := fs.Bool("snapshot", false, "print one plain snapshot and exit")
+	ports := fs.Bool("ports", false, "aggregate by remote port and protocol (view: ports)")
 	asnPath := fs.String("asn-mmdb", discover("GeoLite2-ASN.mmdb"), "ASN MMDB path")
 	cityPath := fs.String("city-mmdb", discoverCity(), "city/country MMDB path")
 	server := fs.String("server", "", "bandwidth-monitor base URL for enrichment")
@@ -89,6 +91,12 @@ func run(args []string, stdout, stderr io.Writer) error {
 		defer dns.Stop()
 	}
 	tracker := talkers.NewDirect(iface.Name, false, localNetworks, nil, dns)
+	viewMode := bandwidthtop.ViewHosts
+	directViewMode := talkers.DirectViewHosts
+	if *ports {
+		viewMode = bandwidthtop.ViewPorts
+		directViewMode = talkers.DirectViewPorts
+	}
 	log.SetOutput(io.Discard)
 	go tracker.Run()
 	defer tracker.Stop()
@@ -115,7 +123,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 
 	return terminal.withScreen(func() error {
 		for {
-			stats, rateTotals := tracker.DirectBandwidthSnapshot(*rows)
+			stats, rateTotals := tracker.DirectBandwidthSnapshotForMode(directViewMode, *rows)
 			viewRows := make([]bandwidthtop.Row, 0, len(stats))
 			for _, stat := range stats {
 				viewRows = append(viewRows, bandwidthtop.Row{
@@ -132,6 +140,13 @@ func run(args []string, stdout, stderr io.Writer) error {
 					},
 					Info: enricher.Lookup(stat.IP),
 				})
+				if viewMode == bandwidthtop.ViewPorts {
+					viewRows[len(viewRows)-1].Protocol = stat.Protocol
+					viewRows[len(viewRows)-1].Port = "-"
+					if stat.HasPort {
+						viewRows[len(viewRows)-1].Port = strconv.FormatUint(uint64(stat.RemotePort), 10)
+					}
+				}
 			}
 			totals := bandwidthtop.Totals{
 				Rx: bandwidthtop.RateWindows{
@@ -148,13 +163,17 @@ func run(args []string, stdout, stderr io.Writer) error {
 				}
 			}
 			size := terminal.dimensions(*width)
-			title := fmt.Sprintf("bandwidth-top  interface=%s  refresh=%s  rates=bit/s",
-				iface.Name, refresh.String())
+			viewName := "hosts"
+			if viewMode == bandwidthtop.ViewPorts {
+				viewName = "ports"
+			}
+			title := fmt.Sprintf("bandwidth-top  interface=%s  refresh=%s  view: %s  rates=bit/s",
+				iface.Name, refresh.String(), viewName)
 			status := enricher.SourceStatusLines(size.width)
 			if lookupStatus := lookupErrorStatus(viewRows); lookupStatus != "" {
 				status = append(status, lookupStatus)
 			}
-			frame := composeFrame(title, status, viewRows, totals, *rows, size, liveTerminal)
+			frame := composeFrameForMode(title, status, viewRows, totals, *rows, size, liveTerminal, viewMode)
 			if err := terminal.draw(frame); err != nil {
 				return err
 			}

--- a/cmd/bandwidth-top/main_linux_test.go
+++ b/cmd/bandwidth-top/main_linux_test.go
@@ -21,6 +21,7 @@ func TestHelpDoesNotStartCapture(t *testing.T) {
 		!strings.Contains(stderr.String(), "CAP_NET_RAW") ||
 		!strings.Contains(stderr.String(), "checked once at startup") ||
 		!strings.Contains(stderr.String(), "local-network") ||
+		!strings.Contains(stderr.String(), "ports") ||
 		!strings.Contains(stderr.String(), "no-resolve") ||
 		!strings.Contains(stderr.String(), "-n") {
 		t.Fatalf("unexpected help:\n%s", stderr.String())

--- a/cmd/bandwidth-top/terminal_linux.go
+++ b/cmd/bandwidth-top/terminal_linux.go
@@ -118,6 +118,10 @@ func (t *terminalSession) dimensions(configuredWidth int) terminalDimensions {
 }
 
 func composeFrame(title string, status []string, rows []bandwidthtop.Row, totals bandwidthtop.Totals, maxRows int, size terminalDimensions, ansi bool) string {
+	return composeFrameForMode(title, status, rows, totals, maxRows, size, ansi, bandwidthtop.ViewHosts)
+}
+
+func composeFrameForMode(title string, status []string, rows []bandwidthtop.Row, totals bandwidthtop.Totals, maxRows int, size terminalDimensions, ansi bool, mode bandwidthtop.ViewMode) string {
 	width := size.width
 	if width <= 0 {
 		width = defaultWidth
@@ -125,7 +129,7 @@ func composeFrame(title string, status []string, rows []bandwidthtop.Row, totals
 	title = bandwidthtop.Truncate(title, width)
 	if !ansi || size.height <= 0 {
 		lines := append([]string{title}, boundedLines(status, width)...)
-		lines = append(lines, splitFrame(bandwidthtop.RenderSnapshotWithRowLimit(rows, totals, width, maxRows))...)
+		lines = append(lines, splitFrame(bandwidthtop.RenderSnapshotForMode(rows, totals, width, maxRows, mode))...)
 		return strings.Join(lines, "\n")
 	}
 
@@ -141,20 +145,24 @@ func composeFrame(title string, status []string, rows []bandwidthtop.Row, totals
 				rows = rows[:pairLimit]
 			}
 			lines := append([]string{title}, status...)
-			lines = append(lines, splitFrame(bandwidthtop.RenderLiveWithRowLimit(rows, totals, width, maxRows))...)
+			lines = append(lines, splitFrame(bandwidthtop.RenderLiveForMode(rows, totals, width, maxRows, mode))...)
 			return strings.Join(lines, "\n")
 		}
 	}
-	return composeShortFrame(title, status, rows, totals, maxRows, width, height)
+	return composeShortFrameForMode(title, status, rows, totals, maxRows, width, height, mode)
 }
 
 // Very short terminals preserve title, column identity, and TOTAL first. The
 // fallback chain, complete pairs, and TX/RX details are added as space permits.
 func composeShortFrame(title string, status []string, rows []bandwidthtop.Row, totals bandwidthtop.Totals, maxRows, width, height int) string {
+	return composeShortFrameForMode(title, status, rows, totals, maxRows, width, height, bandwidthtop.ViewHosts)
+}
+
+func composeShortFrameForMode(title string, status []string, rows []bandwidthtop.Row, totals bandwidthtop.Totals, maxRows, width, height int, mode bandwidthtop.ViewMode) string {
 	if height <= 1 {
 		return bandwidthtop.Truncate(title, width)
 	}
-	rendered := splitFrame(bandwidthtop.RenderLiveWithRowLimit(rows, totals, width, maxRows))
+	rendered := splitFrame(bandwidthtop.RenderLiveForMode(rows, totals, width, maxRows, mode))
 	headerIndex := lineContaining(rendered, "LOCAL")
 	header := ""
 	total := ""

--- a/talkers/direct_flow.go
+++ b/talkers/direct_flow.go
@@ -1,0 +1,186 @@
+package talkers
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	protocolTCP = 6
+	protocolUDP = 17
+)
+
+type directTransport struct {
+	protocol         string
+	srcPort, dstPort uint16
+	hasPorts         bool
+}
+
+// parseDirectTransport parses transport metadata from the raw IP bytes delivered
+// by the direct capture ring. It intentionally returns no port for malformed,
+// truncated, or non-initial fragmented traffic.
+func parseDirectTransport(packet []byte) directTransport {
+	if len(packet) == 0 {
+		return directTransport{protocol: "IP-0"}
+	}
+	switch packet[0] >> 4 {
+	case 4:
+		return parseDirectIPv4Transport(packet)
+	case 6:
+		return parseDirectIPv6Transport(packet)
+	default:
+		return directTransport{protocol: "IP-0"}
+	}
+}
+
+func parseDirectIPv4Transport(packet []byte) directTransport {
+	if len(packet) < 20 {
+		return directTransport{protocol: "IP-0"}
+	}
+	protocol := packet[9]
+	result := directTransport{protocol: protocolLabel(protocol)}
+	headerLen := int(packet[0]&0x0f) * 4
+	totalLen := int(binary.BigEndian.Uint16(packet[2:4]))
+	if headerLen < 20 || headerLen > len(packet) || totalLen < headerLen {
+		return result
+	}
+	end := minPacketEnd(totalLen, len(packet))
+	fragment := binary.BigEndian.Uint16(packet[6:8])
+	if fragment&0x1fff != 0 {
+		return result
+	}
+	return parseDirectPorts(packet, headerLen, end, protocol, result)
+}
+
+func parseDirectIPv6Transport(packet []byte) directTransport {
+	if len(packet) < 40 {
+		return directTransport{protocol: "IP-0"}
+	}
+	next := packet[6]
+	result := directTransport{protocol: protocolLabel(next)}
+	payloadLen := int(binary.BigEndian.Uint16(packet[4:6]))
+	// Jumbograms require validating a Hop-by-Hop Jumbo Payload option. Direct
+	// capture does not need that rare case, so a zero payload length is kept in
+	// the honest unknown-port bucket instead of parsing captured trailing bytes.
+	if payloadLen == 0 {
+		return result
+	}
+	end := len(packet)
+	end = minPacketEnd(40+payloadLen, len(packet))
+	offset := 40
+	for headers := 0; headers < 16; headers++ {
+		result.protocol = protocolLabel(next)
+		switch next {
+		case 0, 43, 60, 135, 139, 140:
+			if offset+2 > end {
+				return result
+			}
+			headerLen := (int(packet[offset+1]) + 1) * 8
+			if headerLen < 8 || offset+headerLen > end {
+				return result
+			}
+			next = packet[offset]
+			offset += headerLen
+		case 44:
+			if offset+8 > end {
+				return result
+			}
+			next = packet[offset]
+			fragment := binary.BigEndian.Uint16(packet[offset+2 : offset+4])
+			offset += 8
+			if fragment&0xfff8 != 0 {
+				return directTransport{protocol: protocolLabel(next)}
+			}
+		case 51:
+			if offset+2 > end {
+				return result
+			}
+			headerLen := (int(packet[offset+1]) + 2) * 4
+			if headerLen < 8 || offset+headerLen > end {
+				return result
+			}
+			next = packet[offset]
+			offset += headerLen
+		default:
+			return parseDirectPorts(packet, offset, end, next, result)
+		}
+	}
+	return result
+}
+
+func parseDirectPorts(packet []byte, offset, end int, protocol uint8, result directTransport) directTransport {
+	required := 0
+	switch protocol {
+	case protocolTCP:
+		required = 20
+	case protocolUDP:
+		required = 8
+	default:
+		return result
+	}
+	if offset < 0 || end < offset || offset+required > end || offset+required > len(packet) {
+		return result
+	}
+	switch protocol {
+	case protocolTCP:
+		headerLen := int(packet[offset+12]>>4) * 4
+		if headerLen < 20 || offset+headerLen > end || offset+headerLen > len(packet) {
+			return result
+		}
+	case protocolUDP:
+		udpLen := int(binary.BigEndian.Uint16(packet[offset+4 : offset+6]))
+		if udpLen < 8 {
+			return result
+		}
+	}
+	result.srcPort = binary.BigEndian.Uint16(packet[offset : offset+2])
+	result.dstPort = binary.BigEndian.Uint16(packet[offset+2 : offset+4])
+	result.hasPorts = true
+	return result
+}
+
+func minPacketEnd(declared, captured int) int {
+	if declared < captured {
+		return declared
+	}
+	return captured
+}
+
+func protocolLabel(protocol uint8) string {
+	switch protocol {
+	case 0:
+		return "HOPOPT"
+	case 1:
+		return "ICMP"
+	case 2:
+		return "IGMP"
+	case 4:
+		return "IPIP"
+	case protocolTCP:
+		return "TCP"
+	case protocolUDP:
+		return "UDP"
+	case 41:
+		return "IPv6"
+	case 43:
+		return "ROUTING"
+	case 44:
+		return "FRAGMENT"
+	case 47:
+		return "GRE"
+	case 50:
+		return "ESP"
+	case 51:
+		return "AH"
+	case 58:
+		return "ICMPv6"
+	case 59:
+		return "NONE"
+	case 60:
+		return "DSTOPTS"
+	case 132:
+		return "SCTP"
+	default:
+		return fmt.Sprintf("IP-%d", protocol)
+	}
+}

--- a/talkers/direct_flow_test.go
+++ b/talkers/direct_flow_test.go
@@ -1,0 +1,134 @@
+package talkers
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseDirectIPv4TransportOptionsFragmentsAndBounds(t *testing.T) {
+	tcp := transportHeader(protocolTCP, 49152, 65535)
+	packet := ipv4Packet(protocolTCP, 24, 0, tcp)
+	got := parseDirectTransport(packet)
+	assertTransport(t, got, "TCP", 49152, 65535, true)
+
+	initial := ipv4Packet(protocolUDP, 20, 0x2000, transportHeader(protocolUDP, 53000, 53))
+	assertTransport(t, parseDirectTransport(initial), "UDP", 53000, 53, true)
+
+	later := ipv4Packet(protocolTCP, 20, 1, []byte{0xff, 0xff, 0xff, 0xff})
+	assertTransport(t, parseDirectTransport(later), "TCP", 0, 0, false)
+
+	for _, malformed := range [][]byte{
+		nil,
+		make([]byte, 19),
+		ipv4Packet(protocolTCP, 16, 0, tcp),
+		ipv4Packet(protocolTCP, 24, 0, []byte{1, 2}),
+	} {
+		_ = parseDirectTransport(malformed)
+	}
+	truncated := ipv4Packet(protocolUDP, 20, 0, []byte{0, 1, 0, 2})
+	assertTransport(t, parseDirectTransport(truncated), "UDP", 0, 0, false)
+	badTCP := transportHeader(protocolTCP, 1, 2)
+	badTCP[12] = 4 << 4
+	assertTransport(t, parseDirectTransport(ipv4Packet(protocolTCP, 20, 0, badTCP)), "TCP", 0, 0, false)
+	badUDP := transportHeader(protocolUDP, 1, 2)
+	binary.BigEndian.PutUint16(badUDP[4:6], 7)
+	assertTransport(t, parseDirectTransport(ipv4Packet(protocolUDP, 20, 0, badUDP)), "UDP", 0, 0, false)
+}
+
+func TestParseDirectIPv6ExtensionChainsFragmentsAndBounds(t *testing.T) {
+	tcp := transportHeader(protocolTCP, 40000, 443)
+	hop := extensionHeader(60, 0)
+	destination := extensionHeader(protocolTCP, 0)
+	packet := ipv6Packet(0, append(append(hop, destination...), tcp...))
+	assertTransport(t, parseDirectTransport(packet), "TCP", 40000, 443, true)
+
+	initialFragment := fragmentHeader(protocolUDP, 0)
+	packet = ipv6Packet(44, append(initialFragment, transportHeader(protocolUDP, 5353, 53)...))
+	assertTransport(t, parseDirectTransport(packet), "UDP", 5353, 53, true)
+
+	laterFragment := fragmentHeader(protocolTCP, 8)
+	packet = ipv6Packet(44, append(laterFragment, []byte{0xff, 0xff, 0xff, 0xff}...))
+	assertTransport(t, parseDirectTransport(packet), "TCP", 0, 0, false)
+
+	malformedExtension := ipv6Packet(0, []byte{protocolTCP, 10, 0, 0, 0, 0, 0, 0})
+	assertTransport(t, parseDirectTransport(malformedExtension), "HOPOPT", 0, 0, false)
+	assertTransport(t, parseDirectTransport(make([]byte, 39)), "IP-0", 0, 0, false)
+	zeroPayload := ipv6Packet(protocolTCP, transportHeader(protocolTCP, 1, 443))
+	binary.BigEndian.PutUint16(zeroPayload[4:6], 0)
+	assertTransport(t, parseDirectTransport(zeroPayload), "TCP", 0, 0, false)
+}
+
+func TestParseDirectTransportLabelsProtocolsWithoutPorts(t *testing.T) {
+	for protocol, want := range map[uint8]string{
+		1: "ICMP", 47: "GRE", 50: "ESP", 58: "ICMPv6", 253: "IP-253",
+	} {
+		packet := ipv4Packet(protocol, 20, 0, make([]byte, 8))
+		if protocol == 58 {
+			packet = ipv6Packet(protocol, make([]byte, 8))
+		}
+		assertTransport(t, parseDirectTransport(packet), want, 0, 0, false)
+	}
+}
+
+func assertTransport(t *testing.T, got directTransport, protocol string, src, dst uint16, hasPorts bool) {
+	t.Helper()
+	if got.protocol != protocol || got.srcPort != src || got.dstPort != dst || got.hasPorts != hasPorts {
+		t.Fatalf("got %+v, want protocol=%s src=%d dst=%d hasPorts=%v", got, protocol, src, dst, hasPorts)
+	}
+}
+
+func ipv4Packet(protocol uint8, headerLen int, fragment uint16, payload []byte) []byte {
+	if headerLen < 20 {
+		packet := make([]byte, 20+len(payload))
+		packet[0] = 0x44
+		packet[9] = protocol
+		binary.BigEndian.PutUint16(packet[2:4], uint16(len(packet)))
+		copy(packet[20:], payload)
+		return packet
+	}
+	packet := make([]byte, headerLen+len(payload))
+	packet[0] = 0x40 | byte(headerLen/4)
+	packet[9] = protocol
+	binary.BigEndian.PutUint16(packet[2:4], uint16(len(packet)))
+	binary.BigEndian.PutUint16(packet[6:8], fragment)
+	copy(packet[headerLen:], payload)
+	return packet
+}
+
+func ipv6Packet(next uint8, payload []byte) []byte {
+	packet := make([]byte, 40+len(payload))
+	packet[0] = 0x60
+	packet[6] = next
+	binary.BigEndian.PutUint16(packet[4:6], uint16(len(payload)))
+	copy(packet[40:], payload)
+	return packet
+}
+
+func transportHeader(protocol uint8, src, dst uint16) []byte {
+	size := 20
+	if protocol == protocolUDP {
+		size = 8
+	}
+	header := make([]byte, size)
+	binary.BigEndian.PutUint16(header[0:2], src)
+	binary.BigEndian.PutUint16(header[2:4], dst)
+	if protocol == protocolTCP {
+		header[12] = 5 << 4
+	} else {
+		binary.BigEndian.PutUint16(header[4:6], uint16(size))
+	}
+	return header
+}
+
+func extensionHeader(next uint8, length uint8) []byte {
+	header := make([]byte, (int(length)+1)*8)
+	header[0], header[1] = next, length
+	return header
+}
+
+func fragmentHeader(next uint8, offset uint16) []byte {
+	header := make([]byte, 8)
+	header[0] = next
+	binary.BigEndian.PutUint16(header[2:4], offset)
+	return header
+}

--- a/talkers/direct_test.go
+++ b/talkers/direct_test.go
@@ -174,6 +174,159 @@ func TestDirectSnapshotWithoutResolverDoesNotResolveHostname(t *testing.T) {
 	}
 }
 
+func TestDirectPortAggregationUsesRemoteServiceAndProtocol(t *testing.T) {
+	now := time.Unix(700, 0)
+	tracker := directAggregationTracker(now.Add(-2 * time.Second))
+	slot := tracker.directRateRing[0]
+	accountDirectTestFlow(tracker, flowPacket("192.168.1.20", "192.0.2.20", true, false, 100, "TCP", 50000, 443, true), slot)
+	accountDirectTestFlow(tracker, flowPacket("192.168.1.20", "192.0.2.20", true, false, 150, "TCP", 50001, 443, true), slot)
+	accountDirectTestFlow(tracker, flowPacket("192.0.2.20", "192.168.1.20", false, true, 200, "TCP", 443, 50000, true), slot)
+	accountDirectTestFlow(tracker, flowPacket("192.168.1.20", "192.0.2.20", true, false, 50, "TCP", 50002, 80, true), slot)
+	accountDirectTestFlow(tracker, flowPacket("192.168.1.20", "192.0.2.20", true, false, 75, "UDP", 50003, 443, true), slot)
+
+	got, totals := tracker.directPortBandwidthSnapshot(10, now)
+	if len(got) != 3 {
+		t.Fatalf("got %d port rows: %+v", len(got), got)
+	}
+	assertDirectFlowStat(t, got[0], "TCP", 443, true, 200, 250, 3)
+	assertDirectFlowStat(t, got[1], "UDP", 443, true, 0, 75, 1)
+	assertDirectFlowStat(t, got[2], "TCP", 80, true, 0, 50, 1)
+	_, hostTotals := tracker.directBandwidthSnapshot(10, now)
+	if totals != hostTotals {
+		t.Fatalf("port totals %+v differ from host totals %+v", totals, hostTotals)
+	}
+}
+
+func TestDirectPortInboundDirectionAndUnknownPortBucket(t *testing.T) {
+	now := time.Unix(800, 0)
+	tracker := directAggregationTracker(now.Add(-2 * time.Second))
+	slot := tracker.directRateRing[0]
+	accountDirectTestFlow(tracker, flowPacket("198.51.100.53", "192.168.1.20", false, true, 100, "UDP", 53, 60000, true), slot)
+	accountDirectTestFlow(tracker, flowPacket("198.51.100.53", "192.168.1.20", false, true, 60, "TCP", 0, 0, false), slot)
+	got, _ := tracker.directPortBandwidthSnapshot(10, now)
+	if len(got) != 2 {
+		t.Fatalf("got %+v", got)
+	}
+	assertDirectFlowStat(t, got[0], "UDP", 53, true, 100, 0, 1)
+	assertDirectFlowStat(t, got[1], "TCP", 0, false, 60, 0, 1)
+}
+
+func TestDirectModeSwitchUsesContinuousRollingData(t *testing.T) {
+	now := time.Unix(900, 0)
+	tracker := directAggregationTracker(now.Add(-2 * time.Second))
+	packet := flowPacket("192.168.1.20", "192.0.2.20", true, false, 200, "TCP", 50000, 443, true)
+	accountDirectTestFlow(tracker, packet, tracker.directRateRing[0])
+
+	hostsBefore, hostTotalsBefore := tracker.DirectBandwidthSnapshotForModeAt(DirectViewHosts, 10, now)
+	ports, portTotals := tracker.DirectBandwidthSnapshotForModeAt(DirectViewPorts, 10, now)
+	hostsAfter, hostTotalsAfter := tracker.DirectBandwidthSnapshotForModeAt(DirectViewHosts, 10, now)
+	if len(hostsBefore) != 1 || len(ports) != 1 || len(hostsAfter) != 1 ||
+		hostsBefore[0].TxRate != ports[0].TxRate || hostsAfter[0].TxRate != hostsBefore[0].TxRate ||
+		hostTotalsBefore != portTotals || hostTotalsAfter != hostTotalsBefore {
+		t.Fatalf("mode switch reset or changed data: hosts=%+v ports=%+v after=%+v totals=%+v/%+v/%+v",
+			hostsBefore, ports, hostsAfter, hostTotalsBefore, portTotals, hostTotalsAfter)
+	}
+}
+
+func (t *Tracker) DirectBandwidthSnapshotForModeAt(mode DirectViewMode, n int, now time.Time) ([]DirectTalkerStat, DirectRateTotals) {
+	if mode == DirectViewPorts {
+		return t.directPortBandwidthSnapshot(n, now)
+	}
+	return t.directBandwidthSnapshot(n, now)
+}
+
+func TestDirectPortCardinalityBoundAndStaleEviction(t *testing.T) {
+	now := time.Unix(1000, 0)
+	tracker := directAggregationTracker(now.Add(-2 * time.Second))
+	slot := tracker.directRateRing[0]
+	for port := 0; port < maxDirectFlowsPerSlot+100; port++ {
+		accountDirectTestFlow(tracker, flowPacket(
+			"192.168.1.20", "192.0.2.20", true, false, 1,
+			"TCP", 50000, uint16(port), true,
+		), slot)
+	}
+	if len(slot.flows) != maxDirectFlowsPerSlot {
+		t.Fatalf("flow cardinality=%d, want %d", len(slot.flows), maxDirectFlowsPerSlot)
+	}
+	old := &directRateSlot{
+		timestamp: now.Add(-41 * time.Second),
+		peers:     map[directPairKey]*hostAccum{},
+		flows: map[directFlowKey]*hostAccum{
+			{directPairKey: directPairKey{local: "192.168.1.30", remote: "203.0.113.1"}, protocol: "TCP", remotePort: 22, hasPort: true}: {bytes: 999, txBytes: 999},
+		},
+	}
+	tracker.directRateRing[1] = old
+	rates, _ := tracker.directFlowRateFromRing(now, 40*time.Second)
+	if len(rates) != maxDirectFlowsPerSlot {
+		t.Fatalf("stale flow survived or current flows lost: %d", len(rates))
+	}
+}
+
+func TestDirectPortRollingWindowsTopNAndDeterministicTies(t *testing.T) {
+	now := time.Unix(1100, 0)
+	tracker := directAggregationTracker(now.Add(-2 * time.Second))
+	flow := directFlowKey{
+		directPairKey: directPairKey{local: "192.168.1.20", remote: "192.0.2.20"},
+		protocol:      "TCP", remotePort: 443, hasPort: true,
+	}
+	tracker.directRateRing[0].peers[flow.directPairKey] = &hostAccum{bytes: 300, rxBytes: 100, txBytes: 200}
+	tracker.directRateRing[0].flows[flow] = &hostAccum{bytes: 300, rxBytes: 100, txBytes: 200}
+	tracker.directRateRing[1] = &directRateSlot{
+		timestamp: now.Add(-10 * time.Second),
+		peers:     map[directPairKey]*hostAccum{flow.directPairKey: {bytes: 700, rxBytes: 300, txBytes: 400}},
+		flows:     map[directFlowKey]*hostAccum{flow: {bytes: 700, rxBytes: 300, txBytes: 400}},
+	}
+	tracker.directRateRing[2] = &directRateSlot{
+		timestamp: now.Add(-40 * time.Second),
+		peers:     map[directPairKey]*hostAccum{flow.directPairKey: {bytes: 3000, rxBytes: 1000, txBytes: 2000}},
+		flows:     map[directFlowKey]*hostAccum{flow: {bytes: 3000, rxBytes: 1000, txBytes: 2000}},
+	}
+	got, totals := tracker.directPortBandwidthSnapshot(1, now)
+	if len(got) != 1 || got[0].RxRate != 50 || got[0].TxRate != 100 ||
+		got[0].RxRate10 != 40 || got[0].TxRate10 != 60 ||
+		got[0].RxRate40 != 35 || got[0].TxRate40 != 65 ||
+		totals.RxRate != got[0].RxRate || totals.TxRate40 != got[0].TxRate40 {
+		t.Fatalf("unexpected port windows or totals: rows=%+v totals=%+v", got, totals)
+	}
+
+	tieTracker := directAggregationTracker(now.Add(-2 * time.Second))
+	slot := tieTracker.directRateRing[0]
+	accountDirectTestFlow(tieTracker, flowPacket("192.168.1.20", "198.51.100.2", true, false, 300, "UDP", 50000, 53, true), slot)
+	accountDirectTestFlow(tieTracker, flowPacket("192.168.1.20", "198.51.100.1", true, false, 300, "TCP", 50001, 53, true), slot)
+	accountDirectTestFlow(tieTracker, flowPacket("192.168.1.20", "203.0.113.3", true, false, 100, "TCP", 50002, 22, true), slot)
+	ranked, allTotals := tieTracker.directPortBandwidthSnapshot(2, now)
+	if len(ranked) != 2 || ranked[0].IP != "198.51.100.1" || ranked[1].IP != "198.51.100.2" {
+		t.Fatalf("nondeterministic port tie order: %+v", ranked)
+	}
+	if allTotals.TxRate <= ranked[0].TxRate+ranked[1].TxRate {
+		t.Fatalf("top-N totals excluded hidden rows: rows=%+v totals=%+v", ranked, allTotals)
+	}
+}
+
+func accountDirectTestFlow(tracker *Tracker, packet *parsedPkt, slot *directRateSlot) {
+	if tracker.accountDirectPeer(packet, slot) {
+		tracker.accountDirectFlow(packet, slot)
+	}
+}
+
+func flowPacket(src, dst string, srcLocal, dstLocal bool, wireLen uint64, protocol string, srcPort, dstPort uint16, hasPorts bool) *parsedPkt {
+	packet := directPacket(src, dst, srcLocal, dstLocal, wireLen)
+	packet.transportProtocol = protocol
+	packet.srcPort = srcPort
+	packet.dstPort = dstPort
+	packet.hasPorts = hasPorts
+	return packet
+}
+
+func assertDirectFlowStat(t *testing.T, got DirectTalkerStat, protocol string, port uint16, hasPort bool, rx, tx, packets uint64) {
+	t.Helper()
+	if got.Protocol != protocol || got.RemotePort != port || got.HasPort != hasPort ||
+		got.RxBytes != rx || got.TxBytes != tx || got.Packets != packets {
+		t.Fatalf("got %+v, want protocol=%s port=%d hasPort=%v rx=%d tx=%d packets=%d",
+			got, protocol, port, hasPort, rx, tx, packets)
+	}
+}
+
 func directAggregationTracker(start time.Time) *Tracker {
 	_, localNet, _ := net.ParseCIDR("192.168.1.0/24")
 	tracker := &Tracker{
@@ -190,6 +343,7 @@ func directAggregationTracker(start time.Time) *Tracker {
 	tracker.directRateRing[0] = &directRateSlot{
 		timestamp: start,
 		peers:     make(map[directPairKey]*hostAccum),
+		flows:     make(map[directFlowKey]*hostAccum),
 	}
 	return tracker
 }

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -37,6 +37,7 @@ const (
 	// iftop-style 2s, 10s, and 40s windows without changing daemon rates.
 	directRateSlotDuration = time.Second
 	directRateSlotCount    = 41
+	maxDirectFlowsPerSlot  = 4096
 )
 
 type TalkerKey struct {
@@ -68,10 +69,13 @@ type TalkerStat struct {
 type DirectTalkerStat struct {
 	LocalIP string
 	TalkerStat
-	RxRate10 float64
-	RxRate40 float64
-	TxRate10 float64
-	TxRate40 float64
+	Protocol   string
+	RemotePort uint16
+	HasPort    bool
+	RxRate10   float64
+	RxRate40   float64
+	TxRate10   float64
+	TxRate40   float64
 }
 
 // DirectRateTotals contains all observed direct peers, including rows below
@@ -89,6 +93,21 @@ type directPairKey struct {
 	local  string
 	remote string
 }
+
+type directFlowKey struct {
+	directPairKey
+	protocol   string
+	remotePort uint16
+	hasPort    bool
+}
+
+// DirectViewMode selects a concurrently maintained direct-capture aggregation.
+type DirectViewMode uint8
+
+const (
+	DirectViewHosts DirectViewMode = iota
+	DirectViewPorts
+)
 
 type bucket struct {
 	timestamp  time.Time
@@ -113,6 +132,7 @@ type rateSlot struct {
 type directRateSlot struct {
 	timestamp time.Time
 	peers     map[directPairKey]*hostAccum
+	flows     map[directFlowKey]*hostAccum
 }
 
 type hostAccum struct {
@@ -131,6 +151,9 @@ type parsedPkt struct {
 	wireLen              uint64
 	proto                string
 	ipVersion            string
+	transportProtocol    string
+	srcPort, dstPort     uint16
+	hasPorts             bool
 }
 
 type Tracker struct {
@@ -266,6 +289,7 @@ func newTracker(devices []string, promiscuous bool, localNets []*net.IPNet, geoD
 		trk.directRateRing[0] = &directRateSlot{
 			timestamp: time.Now(),
 			peers:     make(map[directPairKey]*hostAccum),
+			flows:     make(map[directFlowKey]*hostAccum),
 		}
 	}
 	return trk
@@ -568,6 +592,15 @@ func (t *Tracker) DirectTopByBandwidth(n int) []DirectTalkerStat {
 
 // DirectBandwidthSnapshot returns ranked peers and all-peer rolling totals.
 func (t *Tracker) DirectBandwidthSnapshot(n int) ([]DirectTalkerStat, DirectRateTotals) {
+	return t.DirectBandwidthSnapshotForMode(DirectViewHosts, n)
+}
+
+// DirectBandwidthSnapshotForMode selects host or port aggregation without
+// changing capture state or resetting either rolling index.
+func (t *Tracker) DirectBandwidthSnapshotForMode(mode DirectViewMode, n int) ([]DirectTalkerStat, DirectRateTotals) {
+	if mode == DirectViewPorts {
+		return t.directPortBandwidthSnapshot(n, time.Now())
+	}
 	return t.directBandwidthSnapshot(n, time.Now())
 }
 
@@ -641,6 +674,106 @@ func (t *Tracker) directBandwidthSnapshot(n int, now time.Time) ([]DirectTalkerS
 		t.geoDB.Enrich(list[i].IP, &list[i].TalkerStat)
 	}
 	return list, totals
+}
+
+func (t *Tracker) directPortBandwidthSnapshot(n int, now time.Time) ([]DirectTalkerStat, DirectRateTotals) {
+	if !t.direct || n <= 0 {
+		return nil, DirectRateTotals{}
+	}
+
+	t.mu.RLock()
+	if t.current == nil {
+		t.mu.RUnlock()
+		return nil, DirectRateTotals{}
+	}
+	rates2, elapsed2 := t.directFlowRateFromRing(now, 2*time.Second)
+	rates10, elapsed10 := t.directFlowRateFromRing(now, 10*time.Second)
+	rates40, elapsed40 := t.directFlowRateFromRing(now, 40*time.Second)
+	peerRates2, peerElapsed2 := t.directRateFromRing(now, 2*time.Second)
+	peerRates10, peerElapsed10 := t.directRateFromRing(now, 10*time.Second)
+	peerRates40, peerElapsed40 := t.directRateFromRing(now, 40*time.Second)
+	t.mu.RUnlock()
+
+	list := make([]DirectTalkerStat, 0, len(rates40))
+	for flow, rate40 := range rates40 {
+		rate2 := rates2[flow]
+		rate10 := rates10[flow]
+		if rate2 == nil {
+			rate2 = &hostAccum{}
+		}
+		if rate10 == nil {
+			rate10 = &hostAccum{}
+		}
+		list = append(list, DirectTalkerStat{
+			LocalIP: flow.local,
+			TalkerStat: TalkerStat{
+				IP: flow.remote, TotalBytes: rate40.bytes,
+				RxBytes: rate40.rxBytes, TxBytes: rate40.txBytes,
+				RateBytes: float64(rate2.bytes) / elapsed2,
+				RxRate:    float64(rate2.rxBytes) / elapsed2,
+				TxRate:    float64(rate2.txBytes) / elapsed2,
+				Packets:   rate40.packets,
+			},
+			Protocol: flow.protocol, RemotePort: flow.remotePort, HasPort: flow.hasPort,
+			RxRate10: float64(rate10.rxBytes) / elapsed10,
+			RxRate40: float64(rate40.rxBytes) / elapsed40,
+			TxRate10: float64(rate10.txBytes) / elapsed10,
+			TxRate40: float64(rate40.txBytes) / elapsed40,
+		})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].RateBytes != list[j].RateBytes {
+			return list[i].RateBytes > list[j].RateBytes
+		}
+		if list[i].IP != list[j].IP {
+			return list[i].IP < list[j].IP
+		}
+		if list[i].LocalIP != list[j].LocalIP {
+			return list[i].LocalIP < list[j].LocalIP
+		}
+		if list[i].Protocol != list[j].Protocol {
+			return list[i].Protocol < list[j].Protocol
+		}
+		if list[i].HasPort != list[j].HasPort {
+			return list[i].HasPort
+		}
+		return list[i].RemotePort < list[j].RemotePort
+	})
+	if len(list) > n {
+		list = list[:n]
+	}
+	for i := range list {
+		if t.dns != nil {
+			list[i].Hostname = t.dns.LookupAddrAsync(list[i].IP)
+		}
+		t.geoDB.Enrich(list[i].IP, &list[i].TalkerStat)
+	}
+	totals := directRateTotals(
+		peerRates2, peerElapsed2, peerRates10, peerElapsed10,
+		peerRates40, peerElapsed40,
+	)
+	return list, totals
+}
+
+func directRateTotals(
+	rates2 map[directPairKey]*hostAccum, elapsed2 float64,
+	rates10 map[directPairKey]*hostAccum, elapsed10 float64,
+	rates40 map[directPairKey]*hostAccum, elapsed40 float64,
+) DirectRateTotals {
+	var totals DirectRateTotals
+	for _, rate := range rates2 {
+		totals.RxRate += float64(rate.rxBytes) / elapsed2
+		totals.TxRate += float64(rate.txBytes) / elapsed2
+	}
+	for _, rate := range rates10 {
+		totals.RxRate10 += float64(rate.rxBytes) / elapsed10
+		totals.TxRate10 += float64(rate.txBytes) / elapsed10
+	}
+	for _, rate := range rates40 {
+		totals.RxRate40 += float64(rate.rxBytes) / elapsed40
+		totals.TxRate40 += float64(rate.txBytes) / elapsed40
+	}
+	return totals
 }
 
 // BandwidthForIPs returns current bandwidth stats for the given IP list.
@@ -777,7 +910,7 @@ func (t *Tracker) captureDevice(device string) error {
 		batch = batch[:0]
 		ring.ReadBlock(func(pkt []byte, wireLen uint32) {
 			ipPacket := packets.ParseIPPacket(pkt, true)
-			if ipPacket.Version == 0 || ipPacket.IsTunnel {
+			if ipPacket.Version == 0 || ipPacket.IsTunnel && !t.direct {
 				return
 			}
 			srcIP := ipPacket.SrcIP
@@ -802,19 +935,24 @@ func (t *Tracker) captureDevice(device string) error {
 			default:
 				proto = "Other"
 			}
+			transport := parseDirectTransport(pkt)
 
 			batch = append(batch, parsedPkt{
-				srcStr:    srcStr,
-				dstStr:    dstStr,
-				srcLocal:  t.packetIPIsLocal(srcIP),
-				dstLocal:  t.packetIPIsLocal(dstIP),
-				srcSelf:   srcSelf,
-				dstSelf:   dstSelf,
-				srcLoopLL: srcIP.IsLoopback() || srcIP.IsLinkLocalUnicast(),
-				dstLoopLL: dstIP.IsLoopback() || dstIP.IsLinkLocalUnicast(),
-				wireLen:   uint64(wireLen),
-				proto:     proto,
-				ipVersion: ipVersion,
+				srcStr:            srcStr,
+				dstStr:            dstStr,
+				srcLocal:          t.packetIPIsLocal(srcIP),
+				dstLocal:          t.packetIPIsLocal(dstIP),
+				srcSelf:           srcSelf,
+				dstSelf:           dstSelf,
+				srcLoopLL:         srcIP.IsLoopback() || srcIP.IsLinkLocalUnicast(),
+				dstLoopLL:         dstIP.IsLoopback() || dstIP.IsLinkLocalUnicast(),
+				wireLen:           uint64(wireLen),
+				proto:             proto,
+				ipVersion:         ipVersion,
+				srcPort:           transport.srcPort,
+				dstPort:           transport.dstPort,
+				hasPorts:          transport.hasPorts,
+				transportProtocol: transport.protocol,
 			})
 		}, 100)
 
@@ -840,7 +978,9 @@ func (t *Tracker) captureDevice(device string) error {
 			t.accountPacket(p, t.current, rSlot)
 			t.accountDirection(p, t.current, rSlot)
 			if t.direct {
-				t.accountDirectPeer(p, directSlot)
+				if t.accountDirectPeer(p, directSlot) {
+					t.accountDirectFlow(p, directSlot)
+				}
 			}
 			t.current.protoBytes[p.proto] += p.wireLen
 			t.current.ipVerBytes[p.ipVersion] += p.wireLen
@@ -867,9 +1007,9 @@ func (t *Tracker) packetIPIsLocal(ip net.IP) bool {
 // accountDirectPeer records a packet once under its remote endpoint. Direction
 // is relative to the actual local endpoint, including router-originated flows.
 // Must be called with t.mu held.
-func (t *Tracker) accountDirectPeer(p *parsedPkt, slot *directRateSlot) {
+func (t *Tracker) accountDirectPeer(p *parsedPkt, slot *directRateSlot) bool {
 	if slot == nil || p.srcLocal == p.dstLocal {
-		return
+		return false
 	}
 	var pair directPairKey
 	var rx, tx uint64
@@ -883,10 +1023,54 @@ func (t *Tracker) accountDirectPeer(p *parsedPkt, slot *directRateSlot) {
 	acc, ok := slot.peers[pair]
 	if !ok {
 		if len(slot.peers) >= maxHostsPerBucket {
-			return
+			return false
 		}
 		acc = &hostAccum{}
 		slot.peers[pair] = acc
+	}
+	acc.bytes += p.wireLen
+	acc.rxBytes += rx
+	acc.txBytes += tx
+	acc.packets++
+	return true
+}
+
+// accountDirectFlow keeps remote service aggregation independent of the local
+// ephemeral port. Non-initial fragments and protocols without ports use a
+// protocol-specific unknown-port bucket.
+func (t *Tracker) accountDirectFlow(p *parsedPkt, slot *directRateSlot) {
+	if slot == nil || p.srcLocal == p.dstLocal {
+		return
+	}
+	pair := directPairKey{}
+	remotePort := uint16(0)
+	var rx, tx uint64
+	if p.srcLocal {
+		pair = directPairKey{local: p.srcStr, remote: p.dstStr}
+		remotePort = p.dstPort
+		tx = p.wireLen
+	} else {
+		pair = directPairKey{local: p.dstStr, remote: p.srcStr}
+		remotePort = p.srcPort
+		rx = p.wireLen
+	}
+	key := directFlowKey{
+		directPairKey: pair, protocol: p.transportProtocol,
+		remotePort: remotePort, hasPort: p.hasPorts,
+	}
+	if key.protocol == "" {
+		key.protocol = "IP-0"
+	}
+	if slot.flows == nil {
+		slot.flows = make(map[directFlowKey]*hostAccum)
+	}
+	acc, ok := slot.flows[key]
+	if !ok {
+		if len(slot.flows) >= maxDirectFlowsPerSlot {
+			return
+		}
+		acc = &hostAccum{}
+		slot.flows[key] = acc
 	}
 	acc.bytes += p.wireLen
 	acc.rxBytes += rx
@@ -1124,6 +1308,7 @@ func (t *Tracker) rotateDirectRateRing() {
 			t.directRateRing[t.directRateRingIdx] = &directRateSlot{
 				timestamp: now,
 				peers:     make(map[directPairKey]*hostAccum),
+				flows:     make(map[directFlowKey]*hostAccum),
 			}
 			t.mu.Unlock()
 		case <-t.stopCh:
@@ -1195,6 +1380,41 @@ func (t *Tracker) directRateFromRing(now time.Time, window time.Duration) (map[d
 				total.packets += acc.packets
 			} else {
 				rates[pair] = &hostAccum{
+					bytes: acc.bytes, rxBytes: acc.rxBytes,
+					txBytes: acc.txBytes, packets: acc.packets,
+				}
+			}
+		}
+	}
+	elapsed := now.Sub(oldest).Seconds()
+	if elapsed > window.Seconds() {
+		elapsed = window.Seconds()
+	}
+	if elapsed < 1 {
+		elapsed = 1
+	}
+	return rates, elapsed
+}
+
+func (t *Tracker) directFlowRateFromRing(now time.Time, window time.Duration) (map[directFlowKey]*hostAccum, float64) {
+	rates := make(map[directFlowKey]*hostAccum)
+	var oldest time.Time
+	cutoff := now.Add(-window)
+	for _, slot := range t.directRateRing {
+		if slot == nil || slot.timestamp.Before(cutoff) {
+			continue
+		}
+		if oldest.IsZero() || slot.timestamp.Before(oldest) {
+			oldest = slot.timestamp
+		}
+		for flow, acc := range slot.flows {
+			if total, ok := rates[flow]; ok {
+				total.bytes += acc.bytes
+				total.rxBytes += acc.rxBytes
+				total.txBytes += acc.txBytes
+				total.packets += acc.packets
+			} else {
+				rates[flow] = &hostAccum{
 					bytes: acc.bytes, rxBytes: acc.rxBytes,
 					txBytes: acc.txBytes, packets: acc.packets,
 				}


### PR DESCRIPTION
## Summary
- add optional `--ports` startup mode while preserving host-pair mode by default
- maintain bounded host and port/protocol rolling indexes concurrently so runtime view changes do not reset rates
- parse IPv4/IPv6 TCP and UDP transport headers with strict option, extension-header, fragment, length, and truncation checks
- render dedicated `PORT` and `PROTO` columns with deterministic numeric ports and width-aware metadata/graph dropping

Non-initial TCP/UDP fragments and protocols without ports aggregate into protocol-specific rows with `PORT -`. Port-mode totals come from the same all-peer host accounting, including rows below top-N and flows omitted by the cardinality cap.

## Runtime integration
Use `talkers.Tracker.DirectBandwidthSnapshotForMode(talkers.DirectViewHosts|talkers.DirectViewPorts, rows)` to select the concurrently maintained aggregation. Render with `bandwidthtop.RenderSnapshotForMode` or `bandwidthtop.RenderLiveForMode` using `bandwidthtop.ViewHosts|bandwidthtop.ViewPorts`; the CLI bridge is `composeFrameForMode`.

## Checks
- Linux all-package test, vet, and build
- race tests for talkers, bandwidthtop, and bandwidth-top
- package split assertions
- all OpenWrt release matrix cross-builds
- code and security review