### PR TITLE
Bound Homebrew cask CI waits

### DIFF
--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -17,6 +17,8 @@ on:
       - 'packaging/generate-homebrew-cask.sh'
       - 'packaging/sign-and-notarize-darwin.sh'
       - 'packaging/test-homebrew-cask.sh'
+      - 'packaging/run-with-timeout.sh'
+      - 'packaging/test-run-with-timeout.sh'
       - 'packaging/update-homebrew-cask.sh'
       - 'packaging/verify-homebrew-release.sh'
 
@@ -26,6 +28,7 @@ permissions:
 jobs:
   homebrew-cask:
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -34,24 +37,60 @@ jobs:
           go-version: '1.25.7'
 
       - name: Test cask generation and local install
-        run: ./packaging/test-homebrew-cask.sh --brew
+        run: |
+          ./packaging/test-run-with-timeout.sh
+          ./packaging/test-homebrew-cask.sh --brew
 
       - name: Audit published cask
         if: hashFiles('Casks/bandwidth-top.rb') != ''
         run: |
           set -eu
           tap_name=cask-test/bandwidth-monitor
-          trap '
-            brew uninstall --cask "$tap_name/bandwidth-top" >/dev/null 2>&1 || true
-            brew untap --force "$tap_name" >/dev/null 2>&1 || true
-          ' EXIT
-          brew style Casks/bandwidth-top.rb
-          brew tap-new --no-git "$tap_name"
-          tap_path="$(brew --repository "$tap_name")"
+          timeout_helper=./packaging/run-with-timeout.sh
+          installed=false
+          tapped=false
+          run_brew() {
+            timeout=$1
+            command_name=$2
+            shift 2
+            HOMEBREW_NO_AUTO_UPDATE=1 "$timeout_helper" --homebrew \
+              "$timeout" "$command_name" brew "$@"
+          }
+          cleanup() {
+            status=$?
+            trap - EXIT
+            if [ "$installed" = true ]; then
+              run_brew 120 "cleanup published cask uninstall" \
+                uninstall --cask "$tap_name/bandwidth-top" || true
+            fi
+            if [ "$tapped" = true ]; then
+              run_brew 120 "cleanup published cask tap" \
+                untap --force "$tap_name" || true
+            fi
+            exit "$status"
+          }
+          trap cleanup EXIT
+          trap 'exit 129' HUP
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+
+          run_brew 60 "brew style published cask" style Casks/bandwidth-top.rb
+          tapped=true
+          run_brew 60 "brew create published cask tap" \
+            tap-new --no-git "$tap_name"
+          tap_path="$(run_brew 60 "brew locate published cask tap" \
+            --repository "$tap_name")"
           mkdir -p "$tap_path/Casks"
           install -m 0644 Casks/bandwidth-top.rb "$tap_path/Casks/bandwidth-top.rb"
-          brew audit --cask --arch all "$tap_name/bandwidth-top"
-          brew install --cask "$tap_name/bandwidth-top"
+          run_brew 600 "brew audit published cask" \
+            audit --cask --arch all "$tap_name/bandwidth-top"
+          installed=true
+          run_brew 600 "brew install published cask" \
+            install --cask "$tap_name/bandwidth-top"
           bandwidth-top --version
-          brew uninstall --cask "$tap_name/bandwidth-top"
-          brew untap --force "$tap_name"
+          run_brew 120 "brew uninstall published cask" \
+            uninstall --cask "$tap_name/bandwidth-top"
+          installed=false
+          run_brew 120 "brew remove published cask tap" \
+            untap --force "$tap_name"
+          tapped=false

--- a/packaging/run-with-timeout.sh
+++ b/packaging/run-with-timeout.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+set -u
+
+usage() {
+	echo "usage: $0 [--homebrew] SECONDS COMMAND_NAME COMMAND [ARG ...]" >&2
+	exit 2
+}
+
+homebrew=false
+if [ "${1:-}" = "--homebrew" ]; then
+	homebrew=true
+	shift
+fi
+
+[ "$#" -ge 3 ] || usage
+seconds=$1
+command_name=$2
+shift 2
+
+case "$seconds" in
+	'' | *[!0-9]*) usage ;;
+esac
+[ "$seconds" -gt 0 ] || usage
+[ -n "$command_name" ] || usage
+
+if [ "$homebrew" = true ]; then
+	HOMEBREW_NO_AUTO_UPDATE=1
+	export HOMEBREW_NO_AUTO_UPDATE
+fi
+
+ruby -e '
+require "open3"
+
+def group_alive?(pid)
+  Process.kill(0, -pid)
+  true
+rescue Errno::ESRCH
+  false
+rescue Errno::EPERM
+  true
+end
+
+def signal_group(signal, pid)
+  Process.kill(signal, -pid)
+rescue Errno::ESRCH
+  nil
+end
+
+def terminate_group(pid)
+  signal_group("TERM", pid)
+  deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 2
+  while group_alive?(pid) &&
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
+    begin
+      Process.waitpid(pid, Process::WNOHANG)
+    rescue Errno::ECHILD
+      nil
+    end
+    sleep 0.05
+  end
+  signal_group("KILL", pid) if group_alive?(pid)
+  begin
+    Process.waitpid(pid)
+  rescue Errno::ECHILD
+    nil
+  end
+end
+
+def report_process_group(pid)
+  output, status = Open3.capture2e(
+    "/bin/ps", "-axo", "pid=,ppid=,pgid=,state=,etime=,comm="
+  )
+  return unless status.success?
+
+  rows = output.lines.filter_map do |line|
+    fields = line.split(nil, 6)
+    next unless fields.length == 6 && fields[2].to_i == pid
+
+    fields[0, 5] + [File.basename(fields[5].strip)]
+  end
+  return if rows.empty?
+
+  warn "Process group state (pid ppid pgid state elapsed command):"
+  rows.each { |row| warn row.join(" ") }
+end
+
+timeout = Integer(ARGV.shift, 10)
+command_name = ARGV.shift
+command = ARGV
+started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+deadline = started + timeout
+forwarded_signal = nil
+
+%w[HUP INT TERM].each do |signal|
+  Signal.trap(signal) { forwarded_signal = signal }
+end
+
+begin
+  pid = Process.spawn(*command, pgroup: true)
+rescue SystemCallError => error
+  warn "Unable to start #{command_name}: #{error.message}"
+  exit 127
+end
+
+loop do
+  waited = Process.waitpid2(pid, Process::WNOHANG)
+  if waited
+    status = waited[1]
+    exit(status.exitstatus || 128 + status.termsig)
+  end
+
+  if forwarded_signal
+    warn "Interrupted while running #{command_name}; terminating its process group"
+    terminate_group(pid)
+    exit 128 + Signal.list.fetch(forwarded_signal)
+  end
+
+  now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  if now >= deadline
+    warn "Timed out after #{timeout}s: #{command_name}"
+    report_process_group(pid)
+    terminate_group(pid)
+    exit 124
+  end
+
+  sleep [0.1, deadline - now].min
+end
+' "$seconds" "$command_name" "$@"
+status=$?
+
+if [ "$status" -eq 124 ] && [ "$homebrew" = true ]; then
+	helper=$(CDPATH= cd -- "$(dirname "$0")" && pwd)/$(basename "$0")
+	"$helper" 10 "Homebrew version and config diagnostics" sh -c '
+		HOMEBREW_NO_AUTO_UPDATE=1 brew --version 2>&1 | sed -n "1,3p"
+		HOMEBREW_NO_AUTO_UPDATE=1 brew config 2>&1 |
+			awk "/^(HOMEBREW_VERSION|ORIGIN|HEAD|Last commit|Branch|Core tap JSON|Core cask tap JSON|CPU|Clang|Git|Curl|macOS|CLT|Xcode|Rosetta):/"
+	' || true
+	"$helper" 10 "Homebrew lock and cache diagnostics" sh -c '
+		prefix=$(HOMEBREW_NO_AUTO_UPDATE=1 brew --prefix) || exit
+		cache=$(HOMEBREW_NO_AUTO_UPDATE=1 brew --cache) || exit
+		locks=$prefix/var/homebrew/locks
+
+		if [ -d "$locks" ]; then
+			set -- "$locks"/*
+			if [ "$#" -eq 1 ] && [ ! -e "$1" ] && [ ! -L "$1" ]; then
+				echo "Homebrew lock entries: 0"
+			else
+				echo "Homebrew lock entries: $#"
+				printf "%s\n" "$@" | sed "s|.*/||" | sed -n "1,20p"
+			fi
+		else
+			echo "Homebrew lock entries: 0"
+		fi
+
+		if [ -d "$cache" ]; then
+			set -- "$cache"/*
+			if [ "$#" -eq 1 ] && [ ! -e "$1" ] && [ ! -L "$1" ]; then
+				echo "Homebrew cache entries: 0"
+			else
+				echo "Homebrew cache entries: $#"
+			fi
+		else
+			echo "Homebrew cache entries: 0"
+		fi
+	' || true
+fi
+
+exit "$status"

--- a/packaging/test-homebrew-cask.sh
+++ b/packaging/test-homebrew-cask.sh
@@ -5,16 +5,38 @@ repo=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
 tmp=$(mktemp -d)
 installed=false
 tapped=false
-tap_name=awlx-test/bandwidth-monitor
-trap '
+tap_name=${HOMEBREW_TEST_TAP_NAME:-awlx-test/bandwidth-monitor}
+timeout_helper="$repo/packaging/run-with-timeout.sh"
+brew_query_timeout=${HOMEBREW_TEST_QUERY_TIMEOUT:-60}
+brew_operation_timeout=${HOMEBREW_TEST_OPERATION_TIMEOUT:-600}
+brew_cleanup_timeout=${HOMEBREW_TEST_CLEANUP_TIMEOUT:-120}
+
+run_brew() {
+	timeout=$1
+	command_name=$2
+	shift 2
+	HOMEBREW_NO_AUTO_UPDATE=1 "$timeout_helper" --homebrew \
+		"$timeout" "$command_name" brew "$@"
+}
+
+cleanup() {
+	status=$?
+	trap - EXIT
 	if [ "$installed" = true ]; then
-		HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask "$tap_name/bandwidth-top" >/dev/null 2>&1 || true
+		run_brew "$brew_cleanup_timeout" "cleanup brew uninstall" \
+			uninstall --cask "$tap_name/bandwidth-top" || true
 	fi
 	if [ "$tapped" = true ]; then
-		HOMEBREW_NO_AUTO_UPDATE=1 brew untap --force "$tap_name" >/dev/null 2>&1 || true
+		run_brew "$brew_cleanup_timeout" "cleanup brew untap" \
+			untap --force "$tap_name" || true
 	fi
 	rm -rf "$tmp"
-' EXIT HUP INT TERM
+	exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 fail() {
 	echo "Homebrew cask assertion failed: $*" >&2
@@ -108,9 +130,12 @@ fi
 
 if [ "${1:-}" = "--brew" ]; then
 	command -v brew >/dev/null 2>&1 || fail "brew is required for --brew"
-	HOMEBREW_NO_AUTO_UPDATE=1 brew style "$cask"
+	run_brew "$brew_query_timeout" "brew style generated cask" style "$cask"
 
-	if HOMEBREW_NO_AUTO_UPDATE=1 brew list --cask bandwidth-top >/dev/null 2>&1; then
+	installed_casks=$(run_brew "$brew_query_timeout" \
+		"brew list installed casks" list --cask)
+	if printf '%s\n' "$installed_casks" |
+			grep -Fx bandwidth-top >/dev/null; then
 		fail "bandwidth-top is already installed; refusing to replace it"
 	fi
 
@@ -126,30 +151,39 @@ if [ "${1:-}" = "--brew" ]; then
 		-e "s|https://github.com/awlx/bandwidth-monitor/releases/download/v#{version}/bandwidth-top_#{version}_darwin_amd64.tar.gz|file://$escaped_archive|" \
 		"$cask" > "$tmp/bandwidth-top.rb"
 
-	if HOMEBREW_NO_AUTO_UPDATE=1 brew tap | grep -Fx "$tap_name" >/dev/null; then
+	taps=$(run_brew "$brew_query_timeout" "brew list taps" tap)
+	if printf '%s\n' "$taps" | grep -Fx "$tap_name" >/dev/null; then
 		fail "$tap_name is already tapped; refusing to replace it"
 	fi
-	HOMEBREW_NO_AUTO_UPDATE=1 brew tap-new --no-git "$tap_name"
 	tapped=true
-	tap_path=$(brew --repository "$tap_name")
+	run_brew "$brew_query_timeout" "brew create test tap" \
+		tap-new --no-git "$tap_name"
+	tap_path=$(run_brew "$brew_query_timeout" "brew locate test tap" \
+		--repository "$tap_name")
 	mkdir -p "$tap_path/Casks"
 	install -m 0644 "$cask" "$tap_path/Casks/bandwidth-top.rb"
-	HOMEBREW_NO_AUTO_UPDATE=1 brew audit --cask --arch all \
-		"$tap_name/bandwidth-top"
+	run_brew "$brew_operation_timeout" "brew audit generated cask" \
+		audit --cask --arch all "$tap_name/bandwidth-top"
 	install -m 0644 "$tmp/bandwidth-top.rb" "$tap_path/Casks/bandwidth-top.rb"
-	rm -f "$(brew --cache --cask "$tap_name/bandwidth-top")"
+	cache_path=$(run_brew "$brew_query_timeout" "brew locate cask cache" \
+		--cache --cask "$tap_name/bandwidth-top")
+	rm -f "$cache_path"
 
-	HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask "$tap_name/bandwidth-top"
 	installed=true
-	[ -x "$(brew --prefix)/bin/bandwidth-top" ] ||
+	run_brew "$brew_operation_timeout" "brew install local cask" \
+		install --cask "$tap_name/bandwidth-top"
+	brew_prefix=$(run_brew "$brew_query_timeout" "brew locate prefix" --prefix)
+	[ -x "$brew_prefix/bin/bandwidth-top" ] ||
 		fail "Homebrew did not link bandwidth-top"
-	cmp "$tmp/bandwidth-top-$goarch" "$(brew --prefix)/bin/bandwidth-top" >/dev/null ||
+	cmp "$tmp/bandwidth-top-$goarch" "$brew_prefix/bin/bandwidth-top" >/dev/null ||
 		fail "installed cask binary does not match the selected archive"
-	HOMEBREW_NO_AUTO_UPDATE=1 brew uninstall --cask "$tap_name/bandwidth-top"
+	run_brew "$brew_cleanup_timeout" "brew uninstall local cask" \
+		uninstall --cask "$tap_name/bandwidth-top"
 	installed=false
-	[ ! -e "$(brew --prefix)/bin/bandwidth-top" ] ||
+	[ ! -e "$brew_prefix/bin/bandwidth-top" ] ||
 		fail "Homebrew did not unlink bandwidth-top"
-	HOMEBREW_NO_AUTO_UPDATE=1 brew untap --force "$tap_name"
+	run_brew "$brew_cleanup_timeout" "brew remove test tap" \
+		untap --force "$tap_name"
 	tapped=false
 fi
 

--- a/packaging/test-packaging.sh
+++ b/packaging/test-packaging.sh
@@ -124,6 +124,33 @@ assert_contains "$repo/.github/workflows/release.yml" 'DARWIN_TOP_RESULT: ${{ ne
 assert_contains "$repo/.github/workflows/release.yml" 'LINUX_PACKAGES_RESULT: ${{ needs.linux-packages.result }}'
 assert_contains "$repo/.github/workflows/release.yml" 'OPENWRT_RESULT: ${{ needs.openwrt.result }}'
 assert_contains "$repo/.github/workflows/homebrew-cask.yml" 'homebrew-cask:'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" 'timeout-minutes: 30'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" './packaging/test-run-with-timeout.sh'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" \
+	'./packaging/run-with-timeout.sh'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" \
+	'HOMEBREW_NO_AUTO_UPDATE=1 "$timeout_helper" --homebrew'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" \
+	'"brew audit published cask"'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" \
+	'"brew install published cask"'
+assert_contains "$repo/.github/workflows/homebrew-cask.yml" \
+	'"cleanup published cask uninstall"'
+assert_contains "$repo/packaging/test-homebrew-cask.sh" \
+	'HOMEBREW_NO_AUTO_UPDATE=1 "$timeout_helper" --homebrew'
+assert_contains "$repo/packaging/test-homebrew-cask.sh" \
+	'"brew audit generated cask"'
+assert_contains "$repo/packaging/test-homebrew-cask.sh" \
+	'"brew install local cask"'
+assert_contains "$repo/packaging/test-homebrew-cask.sh" \
+	'"cleanup brew uninstall"'
+assert_contains "$repo/packaging/run-with-timeout.sh" \
+	'Process.spawn(*command, pgroup: true)'
+assert_contains "$repo/packaging/run-with-timeout.sh" \
+	'Process.kill(signal, -pid)'
+assert_contains "$repo/packaging/run-with-timeout.sh" \
+	'Homebrew lock and cache diagnostics'
+assert_not_contains "$repo/packaging/run-with-timeout.sh" 'env |'
 assert_contains "$repo/packaging/generate-homebrew-cask.sh" 'on_arm do'
 assert_contains "$repo/packaging/generate-homebrew-cask.sh" 'on_intel do'
 assert_contains "$repo/packaging/generate-homebrew-cask.sh" 'binary "bandwidth-top"'
@@ -249,5 +276,7 @@ if command -v nfpm >/dev/null 2>&1; then
 		[ ! -s "$tmp/rpm-overlap" ] || fail "RPM package payloads overlap"
 	fi
 fi
+
+"$repo/packaging/test-run-with-timeout.sh"
 
 echo "packaging assertions passed"

--- a/packaging/test-run-with-timeout.sh
+++ b/packaging/test-run-with-timeout.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -eu
+
+repo=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+helper="$repo/packaging/run-with-timeout.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+	echo "timeout helper assertion failed: $*" >&2
+	exit 1
+}
+
+output=$("$helper" 5 "successful fixture" sh -c 'printf success')
+[ "$output" = success ] || fail "successful command output changed"
+output=$("$helper" --homebrew 5 "Homebrew environment fixture" \
+	sh -c 'printf %s "$HOMEBREW_NO_AUTO_UPDATE"')
+[ "$output" = 1 ] || fail "Homebrew auto-update suppression was not preserved"
+
+set +e
+"$helper" 5 "failing fixture" sh -c 'exit 23'
+status=$?
+set -e
+[ "$status" -eq 23 ] || fail "nonzero exit status was not preserved"
+
+started=$(date +%s)
+set +e
+output=$(
+	"$helper" 1 "timeout fixture" sh -c '
+		sleep 30 &
+		echo "$!" > "$1"
+		wait
+	' fixture "$tmp/child-pid" 2>&1
+)
+status=$?
+set -e
+elapsed=$(($(date +%s) - started))
+
+[ "$status" -eq 124 ] || fail "timeout did not return status 124"
+[ "$elapsed" -le 5 ] || fail "timeout took ${elapsed}s"
+printf '%s\n' "$output" | grep -F 'Timed out after 1s: timeout fixture' >/dev/null ||
+	fail "timeout diagnostic omitted the command name and duration"
+printf '%s\n' "$output" | grep -F 'Process group state' >/dev/null ||
+	fail "timeout diagnostic omitted process state"
+
+child_pid=$(cat "$tmp/child-pid")
+child_state=$(ps -o state= -p "$child_pid" 2>/dev/null | tr -d '[:space:]' || true)
+case "$child_state" in
+	'' | Z*) ;;
+	*) fail "timeout left child process $child_pid running in state $child_state" ;;
+esac
+
+echo "timeout helper assertions passed"


### PR DESCRIPTION
## Summary
- add a macOS-compatible process-group timeout helper for Homebrew commands
- bound cask style, audit, install, query, uninstall, and untap operations plus the Homebrew job
- emit sanitized process, Homebrew config, lock, and cache diagnostics on timeout
- add focused timeout behavior and static workflow regressions

## Investigation
The cancelled cask run stopped producing output immediately after cask generation and remained in the local install step until cancellation. Cleanup found Homebrew shell descendants, consistent with a Homebrew launcher waiting on a lock or network operation; the retained logs do not identify the exact Homebrew subcommand.

## Validation
- shell syntax checks
- workflow YAML parse
- packaging regression suite
- timeout helper normal, nonzero, process-group timeout, and Homebrew diagnostics tests
- full local Homebrew style, audit, install, execution, uninstall, and untap test