### PR TITLE
Fix macOS signing keychain access

### DIFF
--- a/packaging/sign-and-notarize-darwin.sh
+++ b/packaging/sign-and-notarize-darwin.sh
@@ -63,51 +63,197 @@ else
 fi
 keychain="$tmp/release-signing.keychain-db"
 keychain_password=$(openssl rand -hex 32)
-cleanup() {
-	security delete-keychain "$keychain" >/dev/null 2>&1 || true
-	rm -rf "$tmp"
+original_keychains="$tmp/original-keychains"
+original_default_keychain="$tmp/original-default-keychain"
+keychain_created=false
+search_list_changed=false
+default_changed=false
+
+parse_keychain_paths() {
+	input=$1
+	output=$2
+	: > "$output"
+	while IFS= read -r line || [ -n "$line" ]; do
+		[ -n "$line" ] || continue
+		case "$line" in
+			*\"*\")
+				path=${line#*\"}
+				case "$path" in
+					*\") path=${path%\"*} ;;
+					*)
+						echo "could not parse macOS keychain path" >&2
+						return 1
+						;;
+				esac
+				;;
+			*)
+				echo "could not parse macOS keychain path" >&2
+				return 1
+				;;
+		esac
+		printf '%s\n' "$path" >> "$output"
+	done < "$input"
 }
-trap cleanup EXIT HUP INT TERM
+
+set_search_list() {
+	prepend=$1
+	paths=$2
+	set --
+	[ -z "$prepend" ] || set -- "$prepend"
+	while IFS= read -r path || [ -n "$path" ]; do
+		[ -n "$path" ] || continue
+		set -- "$@" "$path"
+	done < "$paths"
+	/usr/bin/security list-keychains -d user -s "$@"
+}
+
+restore_default_keychain() {
+	if [ -s "$original_default_keychain" ]; then
+		IFS= read -r path < "$original_default_keychain"
+		/usr/bin/security default-keychain -d user -s "$path"
+	else
+		/usr/bin/security default-keychain -d user -s
+	fi
+}
+
+cleanup() {
+	status=$?
+	trap - EXIT
+	trap '' HUP INT TERM
+	set +e
+	cleanup_failed=0
+
+	if [ "$default_changed" = true ] &&
+		! restore_default_keychain; then
+		echo "failed to restore the original default keychain" >&2
+		cleanup_failed=1
+	fi
+	if [ "$search_list_changed" = true ] &&
+		! set_search_list "" "$original_keychains"; then
+		echo "failed to restore the original keychain search list" >&2
+		cleanup_failed=1
+	fi
+	if [ "$keychain_created" = true ] &&
+		! /usr/bin/security delete-keychain "$keychain" >/dev/null 2>&1; then
+		echo "failed to delete the ephemeral signing keychain" >&2
+		cleanup_failed=1
+	fi
+	if ! rm -rf "$tmp"; then
+		echo "failed to remove temporary Apple signing files" >&2
+		cleanup_failed=1
+	fi
+
+	if [ "$status" -eq 0 ] && [ "$cleanup_failed" -ne 0 ]; then
+		status=1
+	fi
+	exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+raw_keychains="$tmp/current-keychains"
+/usr/bin/security list-keychains -d user > "$raw_keychains" || {
+	echo "could not read the user keychain search list" >&2
+	exit 1
+}
+parse_keychain_paths "$raw_keychains" "$original_keychains"
+
+raw_default_keychain="$tmp/current-default-keychain"
+/usr/bin/security default-keychain -d user > "$raw_default_keychain" || {
+	echo "could not read the user default keychain" >&2
+	exit 1
+}
+parse_keychain_paths "$raw_default_keychain" "$original_default_keychain"
+[ "$(wc -l < "$original_default_keychain")" -le 1 ] || {
+	echo "macOS returned multiple default keychains" >&2
+	exit 1
+}
 
 printf '%s' "$MACOS_SIGNING_CERTIFICATE" |
 	base64 --decode > "$tmp/signing-certificate.p12"
 printf '%s' "$MACOS_NOTARY_KEY" |
 	base64 --decode > "$tmp/AuthKey_${MACOS_NOTARY_KEY_ID}.p8"
 
-security create-keychain -p "$keychain_password" "$keychain"
-security unlock-keychain -p "$keychain_password" "$keychain"
-security set-keychain-settings -lut 21600 "$keychain"
-security import "$tmp/signing-certificate.p12" \
+keychain_created=true
+/usr/bin/security create-keychain -p "$keychain_password" "$keychain"
+/usr/bin/security unlock-keychain -p "$keychain_password" "$keychain"
+/usr/bin/security set-keychain-settings -lut 21600 "$keychain"
+
+search_list_changed=true
+set_search_list "$keychain" "$original_keychains" || {
+	echo "could not configure the user keychain search list" >&2
+	exit 1
+}
+default_changed=true
+/usr/bin/security default-keychain -d user -s "$keychain" || {
+	echo "could not configure the ephemeral default keychain" >&2
+	exit 1
+}
+
+/usr/bin/security import "$tmp/signing-certificate.p12" \
 	-k "$keychain" \
 	-P "$MACOS_SIGNING_CERTIFICATE_PASSWORD" \
-	-T /usr/bin/codesign
-security set-key-partition-list \
+	-T /usr/bin/codesign \
+	-T /usr/bin/security
+
+identity_output="$tmp/codesigning-identities"
+/usr/bin/security find-identity -v -p codesigning "$keychain" > "$identity_output" || {
+	echo "could not inspect the ephemeral signing keychain" >&2
+	exit 1
+}
+EXPECTED_SIGNING_IDENTITY=$MACOS_SIGNING_IDENTITY awk '
+	/^[[:space:]]*[0-9]+\)/ {
+		identity = $0
+		sub(/^[[:space:]]*[0-9]+\)[[:space:]]+/, "", identity)
+
+		fingerprint = identity
+		sub(/[[:space:]].*$/, "", fingerprint)
+		if (fingerprint == ENVIRON["EXPECTED_SIGNING_IDENTITY"])
+			found = 1
+
+		first_quote = index(identity, "\"")
+		if (first_quote > 0) {
+			name = substr(identity, first_quote + 1)
+			sub(/"[[:space:]]*$/, "", name)
+			if (name == ENVIRON["EXPECTED_SIGNING_IDENTITY"])
+				found = 1
+		}
+	}
+	END { exit(found ? 0 : 1) }
+' "$identity_output" || {
+	echo "configured macOS signing identity was not found in the ephemeral keychain" >&2
+	exit 1
+}
+
+/usr/bin/security set-key-partition-list \
 	-S apple-tool:,apple:,codesign: \
 	-s \
 	-k "$keychain_password" \
 	"$keychain"
 
-codesign \
+/usr/bin/codesign \
 	--force \
 	--options runtime \
 	--sign "$MACOS_SIGNING_IDENTITY" \
 	--timestamp \
 	--keychain "$keychain" \
 	"$binary"
-codesign --verify --strict --verbose=2 "$binary"
+/usr/bin/codesign --verify --strict --verbose=2 "$binary"
 
 ditto -c -k --keepParent "$binary" "$tmp/notarization.zip"
-xcrun notarytool submit "$tmp/notarization.zip" \
+/usr/bin/xcrun notarytool submit "$tmp/notarization.zip" \
 	--issuer "$MACOS_NOTARY_ISSUER_ID" \
 	--key "$tmp/AuthKey_${MACOS_NOTARY_KEY_ID}.p8" \
 	--key-id "$MACOS_NOTARY_KEY_ID" \
 	--wait
 
-spctl --status | grep -Fx "assessments enabled" >/dev/null || {
+/usr/sbin/spctl --status | grep -Fx "assessments enabled" >/dev/null || {
 	echo "Gatekeeper assessments must be enabled to verify notarization" >&2
 	exit 1
 }
-assessment=$(spctl --assess --type execute --verbose=2 "$binary" 2>&1) || {
+assessment=$(/usr/sbin/spctl --assess --type execute --verbose=2 "$binary" 2>&1) || {
 	printf '%s\n' "$assessment" >&2
 	exit 1
 }

--- a/packaging/test-packaging.sh
+++ b/packaging/test-packaging.sh
@@ -20,6 +20,15 @@ assert_not_contains() {
 	fi
 }
 
+assert_before() {
+	first=$(grep -nF -- "$2" "$1" | head -n 1 | cut -d: -f1)
+	second=$(grep -nF -- "$3" "$1" | head -n 1 | cut -d: -f1)
+	[ -n "$first" ] || fail "$1 does not contain $2"
+	[ -n "$second" ] || fail "$1 does not contain $3"
+	[ "$first" -lt "$second" ] ||
+		fail "$1 does not place $2 before $3"
+}
+
 assert_contains "$repo/bandwidth-monitor.openrc" "/opt/bandwidth-monitor/bandwidth-monitor"
 assert_contains "$repo/packaging/bandwidth-monitor.openrc" 'command="/usr/bin/bandwidth-monitor"'
 assert_contains "$repo/packaging/bandwidth-monitor.openrc" ': "${BANDWIDTH_MONITOR_CONFIG:=/etc/bandwidth-monitor/env}"'
@@ -116,6 +125,36 @@ assert_contains "$repo/packaging/sign-and-notarize-darwin.sh" 'openssl rand -hex
 assert_not_contains "$repo/packaging/sign-and-notarize-darwin.sh" '/dev/urandom'
 assert_contains "$repo/packaging/sign-and-notarize-darwin.sh" 'REQUIRE_APPLE_SIGNING'
 assert_contains "$repo/packaging/sign-and-notarize-darwin.sh" 'MACOS_SIGNING_WORK_DIR'
+signing_script="$repo/packaging/sign-and-notarize-darwin.sh"
+assert_contains "$signing_script" '-T /usr/bin/codesign \'
+assert_contains "$signing_script" '-T /usr/bin/security'
+assert_not_contains "$signing_script" '-A'
+assert_contains "$signing_script" '/usr/bin/security find-identity -v -p codesigning "$keychain"'
+assert_contains "$signing_script" '== ENVIRON["EXPECTED_SIGNING_IDENTITY"]'
+assert_before "$signing_script" 'find-identity -v -p codesigning' 'set-key-partition-list \'
+assert_before "$signing_script" 'set-key-partition-list \' '--force \'
+assert_contains "$signing_script" 'set_search_list "$keychain" "$original_keychains"'
+assert_contains "$signing_script" 'default-keychain -d user -s "$keychain"'
+assert_before "$signing_script" 'list-keychains -d user > "$raw_keychains"' \
+	'create-keychain -p "$keychain_password"'
+assert_before "$signing_script" 'default-keychain -d user > "$raw_default_keychain"' \
+	'create-keychain -p "$keychain_password"'
+assert_contains "$signing_script" 'restore_default_keychain; then'
+assert_contains "$signing_script" 'set_search_list "" "$original_keychains"; then'
+assert_before "$signing_script" 'restore_default_keychain; then' \
+	'set_search_list "" "$original_keychains"; then'
+assert_before "$signing_script" 'set_search_list "" "$original_keychains"; then' \
+	'delete-keychain "$keychain"'
+assert_before "$signing_script" 'delete-keychain "$keychain"' 'rm -rf "$tmp"'
+assert_contains "$signing_script" 'trap cleanup EXIT'
+assert_contains "$signing_script" "trap '' HUP INT TERM"
+assert_contains "$signing_script" "trap 'exit 129' HUP"
+assert_contains "$signing_script" "trap 'exit 130' INT"
+assert_contains "$signing_script" "trap 'exit 143' TERM"
+assert_contains "$signing_script" '/usr/bin/codesign \'
+assert_contains "$signing_script" '/usr/bin/codesign --verify'
+assert_contains "$signing_script" '/usr/bin/xcrun notarytool submit'
+assert_contains "$signing_script" '/usr/sbin/spctl --status'
 assert_contains "$repo/.github/workflows/release.yml" 'draft: true'
 assert_contains "$repo/.github/workflows/release.yml" 'gh release edit "$GITHUB_REF_NAME" --draft=false'
 assert_contains "$repo/.github/workflows/release.yml" 'release-checks:'


### PR DESCRIPTION
## Summary

- register and restore the ephemeral user keychain search/default state
- authorize only codesign and security to access the imported private key
- verify the configured Developer ID identity before signing
- retain strict credential, keychain, and temporary-file cleanup
- add packaging assertions for ACL ordering and restoration

## Validation

- diff and shell syntax checks
- packaging assertions
- standalone CLI tests and vet