### PR TITLE
Fix raw CLI notarization verification

### DIFF
--- a/.github/workflows/test-apple-signing.yml
+++ b/.github/workflows/test-apple-signing.yml
@@ -117,10 +117,9 @@ jobs:
           set -eu
           binary="$RUNNER_TEMP/bandwidth-top-${{ matrix.goarch }}"
           test ! -e "$RUNNER_TEMP/apple-signing"
-          codesign --verify --strict --verbose=2 "$binary"
-          assessment="$(spctl --assess --type execute --verbose=2 "$binary" 2>&1)"
-          printf '%s\n' "$assessment" |
-            grep -F "source=Notarized Developer ID"
+          /usr/bin/codesign --verify --strict --verbose=2 "$binary"
+          /usr/bin/codesign --verify --strict --verbose=2 --check-notarization \
+            -R=notarized "$binary"
           test "$("$binary" --version)" = \
             "bandwidth-top signing-smoke-$SHORT_SHA"
 
@@ -211,11 +210,9 @@ jobs:
           installed=true
           installed_binary="$(brew --prefix)/bin/bandwidth-top"
           cmp "$RUNNER_TEMP/bandwidth-top-${{ matrix.goarch }}" "$installed_binary"
-          codesign --verify --strict --verbose=2 "$installed_binary"
-          assessment="$(spctl --assess --type execute --verbose=2 \
-            "$installed_binary" 2>&1)"
-          printf '%s\n' "$assessment" |
-            grep -F "source=Notarized Developer ID"
+          /usr/bin/codesign --verify --strict --verbose=2 "$installed_binary"
+          /usr/bin/codesign --verify --strict --verbose=2 --check-notarization \
+            -R=notarized "$installed_binary"
           test "$("$installed_binary" --version)" = \
             "bandwidth-top signing-smoke-$SHORT_SHA"
 

--- a/.github/workflows/update-homebrew-cask.yml
+++ b/.github/workflows/update-homebrew-cask.yml
@@ -205,9 +205,10 @@ jobs:
 
             The update workflow authenticated with GitHub, verified both release
             checksum sidecars, recomputed both SHA-256 checksums, inspected the
-            exact archive payloads, Mach-O architectures, and notarization, and
-            completed Homebrew style, audit, install, execution, and uninstall
-            checks. Required repository checks will merge this PR automatically.
+            exact archive payloads and Mach-O architectures, verified both
+            notarization tickets online, and completed Homebrew style, audit,
+            install, execution, and uninstall checks. Required repository checks
+            will merge this PR automatically.
           branch: automation/update-bandwidth-top-cask
           commit-message: Update bandwidth-top cask for ${{ env.RELEASE_TAG }}
           delete-branch: true

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -213,7 +213,7 @@ Every successful tagged **Build & Release** run automatically starts the
 confirms that the upstream run completed the release job and that the tag still
 resolves to the released commit. It then downloads the four expected Darwin
 assets, verifies both checksum sidecars, archive payloads, architectures, and
-Gatekeeper acceptance, runs Homebrew checks, and creates or updates
+online notarization tickets, runs Homebrew checks, and creates or updates
 `automation/update-bandwidth-top-cask`. Required checks merge that pull request
 automatically. No per-release command, approval, or merge is required.
 
@@ -278,13 +278,14 @@ unmerged pull request code is rejected before credentials are exposed.
 
 The manual smoke runs natively on Apple silicon and Intel macOS runners. It
 builds an explicitly test-only version, signs and notarizes it, verifies
-Gatekeeper reports `Notarized Developer ID`, creates deterministic local
-release-like archives and checksums, and performs cask generation, audit,
-install, and uninstall checks. It creates no tag, release, artifact, branch, or
-pull request and pushes nothing. Credential files and the ephemeral keychain
-are deleted even when a job fails. This is a one-time credential validation,
-not a recurring release task; successful tagged releases continue to update
-the cask automatically.
+the signature and forces an online lookup of its notarization ticket, creates
+deterministic local release-like archives and checksums, and performs cask
+generation, audit, install, and uninstall checks. It repeats signature and
+online ticket verification for the installed native binary. It creates no tag,
+release, artifact, branch, or pull request and pushes nothing. Credential files
+and the ephemeral keychain are deleted even when a job fails. This is a
+one-time credential validation, not a recurring release task; successful tagged
+releases continue to update the cask automatically.
 
 The tag build imports the certificate into an ephemeral keychain, signs each
 native binary with the hardened runtime and a secure timestamp, submits it to
@@ -299,10 +300,13 @@ point. If immutability is not enabled, the release remains available but the
 automatic cask update fails safely without opening or merging a pull request.
 
 Standalone executables and tar archives cannot carry a stapled notarization
-ticket, so the first launch requires network access for Gatekeeper to confirm
-Apple's ticket. The automatic cask updater requires Gatekeeper to be enabled
-and verifies the `Notarized Developer ID` assessment before opening its pull
-request.
+ticket. The signing workflow waits for the notary service to return `Accepted`,
+then `codesign --check-notarization` forces an independent online lookup of the
+ticket while `-R=notarized` requires that ticket to exist and the raw
+executable's signature is verified. The automatic cask updater performs the
+same online signature and ticket verification for both architecture binaries
+before opening its pull request. It does not use `spctl`'s app-bundle
+assessment for these standalone CLI executables.
 
 Never create the cask before both immutable architecture archives exist: the
 generator requires exact SHA-256 checksums and rejects missing, unexpected, or

--- a/packaging/generate-homebrew-cask.sh
+++ b/packaging/generate-homebrew-cask.sh
@@ -32,13 +32,6 @@ esac
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT HUP INT TERM
 
-if [ "${REQUIRE_NOTARIZATION:-0}" = "1" ]; then
-	spctl --status | grep -Fx "assessments enabled" >/dev/null || {
-		echo "Gatekeeper assessments must be enabled to verify release assets" >&2
-		exit 1
-	}
-fi
-
 validate_asset() {
 	goarch=$1
 	machine=$2
@@ -106,18 +99,9 @@ validate_asset() {
 		exit 1
 	}
 	if [ "${REQUIRE_NOTARIZATION:-0}" = "1" ]; then
-		assessment=$(
-			spctl --assess --type execute --verbose=2 \
-				"$extract_dir/bandwidth-top" 2>&1
-		) || {
-			printf '%s\n' "$assessment" >&2
-			echo "Gatekeeper rejected bandwidth-top in $archive_name" >&2
-			exit 1
-		}
-		printf '%s\n' "$assessment" |
-			grep -F "source=Notarized Developer ID" >/dev/null || {
-			printf '%s\n' "$assessment" >&2
-			echo "notarization was not verified for $archive_name" >&2
+		/usr/bin/codesign --verify --strict --verbose=2 --check-notarization \
+			-R=notarized "$extract_dir/bandwidth-top" || {
+			echo "online notarization ticket was not verified for $archive_name" >&2
 			exit 1
 		}
 	fi

--- a/packaging/sign-and-notarize-darwin.sh
+++ b/packaging/sign-and-notarize-darwin.sh
@@ -243,23 +243,24 @@ EXPECTED_SIGNING_IDENTITY=$MACOS_SIGNING_IDENTITY awk '
 /usr/bin/codesign --verify --strict --verbose=2 "$binary"
 
 ditto -c -k --keepParent "$binary" "$tmp/notarization.zip"
+notary_result="$tmp/notary-result.plist"
 /usr/bin/xcrun notarytool submit "$tmp/notarization.zip" \
 	--issuer "$MACOS_NOTARY_ISSUER_ID" \
 	--key "$tmp/AuthKey_${MACOS_NOTARY_KEY_ID}.p8" \
 	--key-id "$MACOS_NOTARY_KEY_ID" \
-	--wait
+	--wait \
+	--output-format plist > "$notary_result"
+notary_status=$(
+	/usr/bin/plutil -extract status raw -o - "$notary_result"
+) || {
+	echo "could not read the Apple notarization status" >&2
+	exit 1
+}
+[ "$notary_status" = "Accepted" ] || {
+	/usr/bin/plutil -p "$notary_result" >&2
+	echo "Apple notarization was not accepted" >&2
+	exit 1
+}
 
-/usr/sbin/spctl --status | grep -Fx "assessments enabled" >/dev/null || {
-	echo "Gatekeeper assessments must be enabled to verify notarization" >&2
-	exit 1
-}
-assessment=$(/usr/sbin/spctl --assess --type execute --verbose=2 "$binary" 2>&1) || {
-	printf '%s\n' "$assessment" >&2
-	exit 1
-}
-printf '%s\n' "$assessment" |
-	grep -F "source=Notarized Developer ID" >/dev/null || {
-	printf '%s\n' "$assessment" >&2
-	echo "Apple notarization was not verified" >&2
-	exit 1
-}
+/usr/bin/codesign --verify --strict --verbose=2 --check-notarization \
+	-R=notarized "$binary"

--- a/packaging/test-packaging.sh
+++ b/packaging/test-packaging.sh
@@ -20,6 +20,12 @@ assert_not_contains() {
 	fi
 }
 
+assert_count() {
+	actual=$(grep -F -c -- "$3" "$1" || true)
+	[ "$actual" -eq "$2" ] ||
+		fail "$1 contains $actual instances of $3 instead of $2"
+}
+
 assert_before() {
 	first=$(grep -nF -- "$2" "$1" | head -n 1 | cut -d: -f1)
 	second=$(grep -nF -- "$3" "$1" | head -n 1 | cut -d: -f1)
@@ -112,7 +118,12 @@ assert_contains "$apple_smoke" './trusted/packaging/generate-homebrew-cask.sh'
 assert_contains "$apple_smoke" 'cmp "$native_archive" "$RUNNER_TEMP/repeated.tar.gz"'
 assert_contains "$apple_smoke" 'brew audit --cask --arch all'
 assert_contains "$apple_smoke" 'brew install --cask'
-assert_contains "$apple_smoke" 'source=Notarized Developer ID'
+assert_count "$apple_smoke" 2 \
+	'/usr/bin/codesign --verify --strict --verbose=2 --check-notarization \'
+assert_contains "$apple_smoke" '-R=notarized "$binary"'
+assert_contains "$apple_smoke" '-R=notarized "$installed_binary"'
+assert_not_contains "$apple_smoke" 'spctl'
+assert_not_contains "$apple_smoke" 'source=Notarized Developer ID'
 assert_contains "$apple_smoke" 'if: always()'
 assert_not_contains "$apple_smoke" 'pull_request_target:'
 assert_not_contains "$apple_smoke" 'actions/upload-artifact'
@@ -154,7 +165,14 @@ assert_contains "$signing_script" "trap 'exit 143' TERM"
 assert_contains "$signing_script" '/usr/bin/codesign \'
 assert_contains "$signing_script" '/usr/bin/codesign --verify'
 assert_contains "$signing_script" '/usr/bin/xcrun notarytool submit'
-assert_contains "$signing_script" '/usr/sbin/spctl --status'
+assert_contains "$signing_script" '--wait \'
+assert_contains "$signing_script" '--output-format plist > "$notary_result"'
+assert_contains "$signing_script" '[ "$notary_status" = "Accepted" ]'
+assert_count "$signing_script" 1 \
+	'/usr/bin/codesign --verify --strict --verbose=2 --check-notarization \'
+assert_contains "$signing_script" '-R=notarized "$binary"'
+assert_not_contains "$signing_script" 'spctl'
+assert_not_contains "$signing_script" 'source=Notarized Developer ID'
 assert_contains "$repo/.github/workflows/release.yml" 'draft: true'
 assert_contains "$repo/.github/workflows/release.yml" 'gh release edit "$GITHUB_REF_NAME" --draft=false'
 assert_contains "$repo/.github/workflows/release.yml" 'release-checks:'
@@ -168,6 +186,13 @@ assert_contains "$repo/packaging/generate-homebrew-cask.sh" 'on_intel do'
 assert_contains "$repo/packaging/generate-homebrew-cask.sh" 'binary "bandwidth-top"'
 assert_not_contains "$repo/packaging/generate-homebrew-cask.sh" 'sha256 :no_check'
 assert_not_contains "$repo/packaging/generate-homebrew-cask.sh" 'version :latest'
+assert_count "$repo/packaging/generate-homebrew-cask.sh" 1 \
+	'/usr/bin/codesign --verify --strict --verbose=2 --check-notarization \'
+assert_contains "$repo/packaging/generate-homebrew-cask.sh" \
+	'-R=notarized "$extract_dir/bandwidth-top"'
+assert_not_contains "$repo/packaging/generate-homebrew-cask.sh" 'spctl'
+assert_not_contains "$repo/packaging/generate-homebrew-cask.sh" \
+	'source=Notarized Developer ID'
 assert_contains "$repo/packaging/update-homebrew-cask.sh" 'REQUIRE_NOTARIZATION=1'
 assert_contains "$repo/packaging/update-homebrew-cask.sh" '--jq .immutable'
 assert_contains "$repo/packaging/verify-homebrew-release.sh" 'release_jobs='


### PR DESCRIPTION
## Summary
- replace Gatekeeper app-bundle assessment of standalone Mach-O CLIs with strict `codesign` verification and an online notarization-ticket check
- require the `notarized` code-signing requirement and explicitly gate waited notary submissions on `Accepted`
- apply the same verification to signing smoke checks, both Homebrew release architectures, and the installed native binary
- add regression assertions and document the raw executable verification model

## Testing
- shell syntax checks for all tracked shell scripts
- packaging assertion suite
- Homebrew cask fixture generation, style, audit, install, and uninstall
- workflow YAML parsing
- targeted bandwidth-top Go tests and vet
- negative codesign test rejecting a non-notarized signed executable
- security and correctness review
