### PR TITLE
Fix Apple signing smoke cask style context

### DIFF
--- a/.github/workflows/test-apple-signing.yml
+++ b/.github/workflows/test-apple-signing.yml
@@ -36,6 +36,7 @@ jobs:
             machine: x86_64
             peer_goarch: arm64
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
 
     steps:
       - name: Check out selected source ref
@@ -187,13 +188,14 @@ jobs:
           ./trusted/packaging/generate-homebrew-cask.sh \
             "v$TEST_CASK_VERSION" "$assets" "$cask"
           ruby -c "$cask"
-          HOMEBREW_NO_AUTO_UPDATE=1 brew style "$cask"
 
           HOMEBREW_NO_AUTO_UPDATE=1 brew tap-new --no-git "$tap_name"
           tapped=true
           tap_path="$(brew --repository "$tap_name")"
           mkdir -p "$tap_path/Casks"
           install -m 0644 "$cask" "$tap_path/Casks/bandwidth-top.rb"
+          HOMEBREW_NO_AUTO_UPDATE=1 brew style \
+            "$tap_path/Casks/bandwidth-top.rb"
           HOMEBREW_NO_AUTO_UPDATE=1 brew audit --cask --arch all \
             "$tap_name/bandwidth-top"
 

--- a/packaging/test-packaging.sh
+++ b/packaging/test-packaging.sh
@@ -107,6 +107,7 @@ assert_contains "$apple_smoke" 'contents: read'
 assert_contains "$apple_smoke" 'group: apple-signing-smoke'
 assert_contains "$apple_smoke" 'runner: macos-15'
 assert_contains "$apple_smoke" 'runner: macos-15-intel'
+assert_contains "$apple_smoke" 'timeout-minutes: 45'
 assert_contains "$apple_smoke" 'persist-credentials: false'
 assert_contains "$apple_smoke" 'ref: ${{ github.sha }}'
 assert_contains "$apple_smoke" 'test "$GITHUB_REF" = "$expected_ref"'
@@ -116,6 +117,14 @@ assert_contains "$apple_smoke" 'REQUIRE_APPLE_SIGNING:'
 assert_contains "$apple_smoke" './trusted/packaging/sign-and-notarize-darwin.sh'
 assert_contains "$apple_smoke" './trusted/packaging/generate-homebrew-cask.sh'
 assert_contains "$apple_smoke" 'cmp "$native_archive" "$RUNNER_TEMP/repeated.tar.gz"'
+assert_contains "$apple_smoke" 'HOMEBREW_NO_AUTO_UPDATE=1 brew style \'
+assert_contains "$apple_smoke" '"$tap_path/Casks/bandwidth-top.rb"'
+assert_not_contains "$apple_smoke" 'brew style "$cask"'
+assert_before "$apple_smoke" \
+	'install -m 0644 "$cask" "$tap_path/Casks/bandwidth-top.rb"' \
+	'HOMEBREW_NO_AUTO_UPDATE=1 brew style \'
+assert_before "$apple_smoke" 'HOMEBREW_NO_AUTO_UPDATE=1 brew style \' \
+	'brew audit --cask --arch all'
 assert_contains "$apple_smoke" 'brew audit --cask --arch all'
 assert_contains "$apple_smoke" 'brew install --cask'
 assert_count "$apple_smoke" 2 \


### PR DESCRIPTION
## Summary
- style the generated cask only after copying it into the temporary tap Casks directory
- keep the audit, architecture-specific install, binary identity, notarization, execution, uninstall, and cleanup checks unchanged
- bound the signing smoke job to 45 minutes and assert the required ordering

## Validation
- workflow YAML parsing
- packaging assertions
- Homebrew cask fixture tests, including local brew audit/install/uninstall
- diff check and focused review