### PR TITLE
Fix release publication repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,7 +435,7 @@ jobs:
       - name: Publish immutable GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "$GITHUB_REF_NAME" --draft=false
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
 
   # ─── Required aggregate release build check ────────────────────────
   release-checks:

--- a/packaging/test-packaging.sh
+++ b/packaging/test-packaging.sh
@@ -183,7 +183,7 @@ assert_contains "$signing_script" '-R=notarized "$binary"'
 assert_not_contains "$signing_script" 'spctl'
 assert_not_contains "$signing_script" 'source=Notarized Developer ID'
 assert_contains "$repo/.github/workflows/release.yml" 'draft: true'
-assert_contains "$repo/.github/workflows/release.yml" 'gh release edit "$GITHUB_REF_NAME" --draft=false'
+assert_contains "$repo/.github/workflows/release.yml" 'gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false'
 assert_contains "$repo/.github/workflows/release.yml" 'release-checks:'
 assert_contains "$repo/.github/workflows/release.yml" "if: always() && !startsWith(github.ref, 'refs/tags/v')"
 assert_contains "$repo/.github/workflows/release.yml" 'DARWIN_TOP_RESULT: ${{ needs.darwin-top.result }}'


### PR DESCRIPTION
## Summary

- pass the workflow repository explicitly when publishing the draft release
- update packaging assertions to prevent repository-context regressions

## Testing

- `./packaging/test-packaging.sh`
- `./packaging/test-homebrew-cask.sh`