### PR TITLE
Add signed Arch package repository

### DIFF
--- a/.github/workflows/publish-package-repositories.yml
+++ b/.github/workflows/publish-package-repositories.yml
@@ -1,0 +1,113 @@
+name: Publish package repositories
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing immutable release tag to publish
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: package-repositories
+  cancel-in-progress: false
+
+jobs:
+  build-arch-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository packaging
+        uses: actions/checkout@v4
+
+      - name: Validate immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          case "$RELEASE_TAG" in
+            v[0-9]*) ;;
+            *) echo "release tag must start with v followed by a digit" >&2; exit 1 ;;
+          esac
+          test "$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" --jq .immutable)" = "true"
+
+      - name: Check out released source
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.release_tag }}
+          path: release-source
+          persist-credentials: false
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.7'
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Build Arch Linux packages
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          COMMIT="$(git -C release-source rev-parse --short=7 HEAD)"
+          mkdir -p arch-packages
+
+          for GOARCH in amd64 arm64; do
+            export GOARCH
+            export GOOS=linux
+            export CGO_ENABLED=0
+            LDFLAGS="-s -w -X bandwidth-monitor/version.Commit=${COMMIT} -X bandwidth-monitor/version.Version=${VERSION}"
+            go -C release-source build -ldflags="$LDFLAGS" -o "$GITHUB_WORKSPACE/bandwidth-monitor" .
+            go -C release-source build -ldflags="$LDFLAGS" -o "$GITHUB_WORKSPACE/bandwidth-top" ./cmd/bandwidth-top
+            VERSION="$VERSION" nfpm package -p archlinux -f nfpm-arch.yaml -t arch-packages/
+            VERSION="$VERSION" nfpm package -p archlinux -f nfpm-top-arch.yaml -t arch-packages/
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: arch-packages
+          path: arch-packages/*.pkg.tar.zst
+
+  publish:
+    needs: build-arch-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository packaging
+        uses: actions/checkout@v4
+
+      - name: Check out current Pages repository
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: repo
+
+      - name: Download Arch Linux packages
+        uses: actions/download-artifact@v4
+        with:
+          name: arch-packages
+          path: artifacts
+
+      - name: Import repository signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format long 2>/dev/null | awk '/^sec/{print $2}' | cut -d/ -f2 | head -1)
+          echo "GPG_KEY_ID=$GPG_KEY_ID" >> "$GITHUB_ENV"
+
+      - name: Build pacman repository
+        run: |
+          rm -rf repo/.git repo/arch
+          ./packaging/create-pacman-repository.sh artifacts repo/arch "$GPG_KEY_ID"
+          install -m 0755 packaging/install-arch-repo.sh repo/install-arch-repo.sh
+          install -m 0644 packaging/package-repository-index.html repo/index.html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./repo
+          force_orphan: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,15 @@ jobs:
           nfpm package -p rpm -f nfpm.yaml
           nfpm package -p rpm -f nfpm-top.yaml
 
+      - name: Build Arch Linux packages
+        env:
+          VERSION: ${{ env.PACKAGE_VERSION }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          export VERSION="${VERSION#v}"
+          nfpm package -p archlinux -f nfpm-arch.yaml
+          nfpm package -p archlinux -f nfpm-top-arch.yaml
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -148,6 +157,7 @@ jobs:
           path: |
             *.deb
             *.rpm
+            *.pkg.tar.zst
 
   # ─── OpenWrt (multiple targets) ────────────────────────────────────
   openwrt:
@@ -427,6 +437,7 @@ jobs:
           files: |
             artifacts/**/*.deb
             artifacts/**/*.rpm
+            artifacts/**/*.pkg.tar.zst
             artifacts/**/*.ipk
             artifacts/**/*.apk
             artifacts/**/*.tar.gz
@@ -453,13 +464,15 @@ jobs:
           test "$LINUX_PACKAGES_RESULT" = "success"
           test "$OPENWRT_RESULT" = "success"
 
-  # ─── APT Repository (GitHub Pages) ─────────────────────────────────
-  # Builds a Debian/Ubuntu apt repository from the .deb artifacts and
-  # deploys to gh-pages so users can: apt install bandwidth-monitor
+  # ─── Package Repositories (GitHub Pages) ────────────────────────────
+  # Builds APT and pacman repositories and deploys them together.
   apt-repo:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [release]
     runs-on: ubuntu-latest
+    concurrency:
+      group: package-repositories
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
@@ -518,23 +531,11 @@ jobs:
           # Export public key for users
           gpg --armor --export "$GPG_KEY_ID" > bandwidth-monitor.gpg.key
 
-          # Create an index page
-          cat > index.html << 'HTML'
-          <!DOCTYPE html>
-          <html><head><title>bandwidth-monitor APT Repository</title></head>
-          <body>
-          <h1>bandwidth-monitor APT Repository</h1>
-          <h2>Quick Install (Debian/Ubuntu)</h2>
-          <pre>
-          curl -fsSL https://awlx.github.io/bandwidth-monitor/bandwidth-monitor.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/bandwidth-monitor.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/bandwidth-monitor.gpg] https://awlx.github.io/bandwidth-monitor stable main" | sudo tee /etc/apt/sources.list.d/bandwidth-monitor.list
-          sudo apt update
-          sudo apt install bandwidth-monitor
-          sudo apt install bandwidth-top
-          sudo apt install bandwidth-monitor bandwidth-top
-          </pre>
-          </body></html>
-          HTML
+      - name: Build pacman repository
+        run: |
+          ./packaging/create-pacman-repository.sh artifacts repo/arch "$GPG_KEY_ID"
+          install -m 0755 packaging/install-arch-repo.sh repo/install-arch-repo.sh
+          install -m 0644 packaging/package-repository-index.html repo/index.html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,12 +6,14 @@ independently; neither package requires the other.
 
 ## Release packages
 
-[GitHub Releases](https://github.com/awlx/bandwidth-monitor/releases) provide:
+[GitHub Releases](https://github.com/awlx/bandwidth-monitor/releases) and the
+project package repositories provide:
 
 | Format | Platforms |
 |---|---|
 | `.deb` | Debian, Ubuntu, and Raspbian on amd64 or arm64 |
 | `.rpm` | Fedora, RHEL, and compatible distributions on amd64 or arm64 |
+| `.pkg.tar.zst` | Arch Linux and Arch Linux ARM on x86_64 or aarch64 |
 | `.ipk` | OpenWrt 23.05 targets |
 | `.apk` | OpenWrt snapshot targets |
 | `.tar.gz` | Standalone macOS `bandwidth-top` on amd64 or arm64 |
@@ -54,6 +56,30 @@ For the CLI only:
 
 ```bash
 sudo dpkg -i bandwidth-top_*.deb
+```
+
+## Arch Linux
+
+Add the signed repository and refresh package databases:
+
+```bash
+curl -fsSL https://awlx.github.io/bandwidth-monitor/install-arch-repo.sh | sudo sh
+```
+
+The setup command does not install or upgrade any packages. Install the daemon,
+the terminal viewer, or both explicitly:
+
+```bash
+sudo pacman -Syu bandwidth-monitor
+sudo pacman -Syu bandwidth-top
+sudo pacman -Syu bandwidth-monitor bandwidth-top
+```
+
+Enable the daemon after configuring it:
+
+```bash
+sudoedit /etc/bandwidth-monitor/env
+sudo systemctl enable --now bandwidth-monitor
 ```
 
 ## Fedora and RHEL

--- a/nfpm-arch.yaml
+++ b/nfpm-arch.yaml
@@ -1,0 +1,27 @@
+name: bandwidth-monitor
+arch: "${GOARCH}"
+platform: linux
+version: "${VERSION}"
+release: "1"
+maintainer: "Annika Wickert <awlx@users.noreply.github.com>"
+description: "Real-time network monitoring dashboard with embedded web UI"
+vendor: "awlx"
+homepage: "https://github.com/awlx/bandwidth-monitor"
+license: "AGPL-3.0-only"
+
+contents:
+  - src: ./bandwidth-monitor
+    dst: /usr/bin/bandwidth-monitor
+    file_info:
+      mode: 0755
+
+  - src: ./env.example
+    dst: /etc/bandwidth-monitor/env
+    type: config|noreplace
+    file_info:
+      mode: 0600
+
+  - src: ./packaging/bandwidth-monitor.service
+    dst: /usr/lib/systemd/system/bandwidth-monitor.service
+    file_info:
+      mode: 0644

--- a/nfpm-top-arch.yaml
+++ b/nfpm-top-arch.yaml
@@ -1,0 +1,16 @@
+name: bandwidth-top
+arch: "${GOARCH}"
+platform: linux
+version: "${VERSION}"
+release: "1"
+maintainer: "Annika Wickert <awlx@users.noreply.github.com>"
+description: "Ad-hoc live terminal network traffic viewer"
+vendor: "awlx"
+homepage: "https://github.com/awlx/bandwidth-monitor"
+license: "AGPL-3.0-only"
+
+contents:
+  - src: ./bandwidth-top
+    dst: /usr/bin/bandwidth-top
+    file_info:
+      mode: 0755

--- a/packaging/create-pacman-repository.sh
+++ b/packaging/create-pacman-repository.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 3 ]; then
+	echo "usage: $0 <artifact-directory> <repository-directory> <gpg-key-id>" >&2
+	exit 2
+fi
+
+artifact_dir=$(CDPATH= cd -- "$1" && pwd)
+mkdir -p "$2"
+repository_dir=$(CDPATH= cd -- "$2" && pwd)
+gpg_key_id=$3
+
+for arch in x86_64 aarch64; do
+	arch_dir=$repository_dir/$arch
+	rm -rf "$arch_dir"
+	mkdir -p "$arch_dir"
+
+	for package_name in bandwidth-monitor bandwidth-top; do
+		matches=$(find "$artifact_dir" -type f \
+			-name "${package_name}-*-1-${arch}.pkg.tar.zst" -print)
+		count=$(printf '%s\n' "$matches" | awk 'NF { count++ } END { print count + 0 }')
+		if [ "$count" -ne 1 ]; then
+			echo "expected one ${package_name} package for ${arch}, found ${count}" >&2
+			exit 1
+		fi
+		cp "$matches" "$arch_dir/"
+	done
+
+	for package in "$arch_dir"/*.pkg.tar.zst; do
+		gpg --batch --yes --local-user "$gpg_key_id" --detach-sign \
+			--output "$package.sig" "$package"
+	done
+done
+
+docker run --rm \
+	--platform linux/amd64 \
+	-v "$repository_dir:/repo" \
+	archlinux:base-devel \
+	/bin/sh -eu -c '
+		for arch in x86_64 aarch64; do
+			set -- /repo/$arch/*.pkg.tar.zst
+			repo-add /repo/$arch/bandwidth-monitor.db.tar.gz "$@"
+		done
+	'
+
+for arch in x86_64 aarch64; do
+	arch_dir=$repository_dir/$arch
+
+	rm -f "$arch_dir/bandwidth-monitor.db" "$arch_dir/bandwidth-monitor.files"
+	cp "$arch_dir/bandwidth-monitor.db.tar.gz" "$arch_dir/bandwidth-monitor.db"
+	cp "$arch_dir/bandwidth-monitor.files.tar.gz" "$arch_dir/bandwidth-monitor.files"
+
+	gpg --batch --yes --local-user "$gpg_key_id" --detach-sign \
+		--output "$arch_dir/bandwidth-monitor.db.sig" \
+		"$arch_dir/bandwidth-monitor.db"
+done

--- a/packaging/install-arch-repo.sh
+++ b/packaging/install-arch-repo.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+repository_name=bandwidth-monitor
+repository_url=https://awlx.github.io/bandwidth-monitor/arch/\$arch
+key_url=https://awlx.github.io/bandwidth-monitor/bandwidth-monitor.gpg.key
+expected_fingerprint=2F9C7923C454355A9CF1232C4B621C9FAAEE0D71
+
+if [ "$(id -u)" -ne 0 ]; then
+	echo "run this repository setup as root" >&2
+	exit 1
+fi
+
+for command in awk curl gpg grep mktemp pacman pacman-key; do
+	if ! command -v "$command" >/dev/null 2>&1; then
+		echo "required command not found: $command" >&2
+		exit 1
+	fi
+done
+
+key_file=$(mktemp)
+trap 'rm -f "$key_file"' EXIT HUP INT TERM
+curl -fsSL "$key_url" -o "$key_file"
+
+fingerprint=$(gpg --batch --show-keys --with-colons "$key_file" |
+	awk -F: '$1 == "fpr" { print $10; exit }')
+if [ "$fingerprint" != "$expected_fingerprint" ]; then
+	echo "repository signing key fingerprint does not match" >&2
+	exit 1
+fi
+
+pacman-key --add "$key_file"
+pacman-key --lsign-key "$expected_fingerprint"
+
+if grep -Eq '^[[:space:]]*\[bandwidth-monitor\][[:space:]]*$' /etc/pacman.conf; then
+	echo "the bandwidth-monitor repository is already configured"
+else
+	cat >>/etc/pacman.conf <<EOF
+
+[$repository_name]
+SigLevel = Required DatabaseOptional
+Server = $repository_url
+EOF
+	echo "added the bandwidth-monitor repository to /etc/pacman.conf"
+fi
+
+pacman -Sy
+
+cat <<'EOF'
+
+Repository metadata refreshed. No packages were installed.
+Install either or both packages explicitly:
+
+  sudo pacman -Syu bandwidth-monitor
+  sudo pacman -Syu bandwidth-top
+  sudo pacman -Syu bandwidth-monitor bandwidth-top
+EOF

--- a/packaging/package-repository-index.html
+++ b/packaging/package-repository-index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html><head><title>bandwidth-monitor Package Repositories</title></head>
+<body>
+<h1>bandwidth-monitor Package Repositories</h1>
+<h2>Debian and Ubuntu</h2>
+<pre>
+curl -fsSL https://awlx.github.io/bandwidth-monitor/bandwidth-monitor.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/bandwidth-monitor.gpg
+echo "deb [signed-by=/etc/apt/keyrings/bandwidth-monitor.gpg] https://awlx.github.io/bandwidth-monitor stable main" | sudo tee /etc/apt/sources.list.d/bandwidth-monitor.list
+sudo apt update
+sudo apt install bandwidth-monitor
+sudo apt install bandwidth-top
+</pre>
+<h2>Arch Linux</h2>
+<pre>
+curl -fsSL https://awlx.github.io/bandwidth-monitor/install-arch-repo.sh | sudo sh
+sudo pacman -Syu bandwidth-monitor
+sudo pacman -Syu bandwidth-top
+</pre>
+</body></html>

--- a/packaging/test-packaging.sh
+++ b/packaging/test-packaging.sh
@@ -68,6 +68,26 @@ assert_not_contains "$repo/nfpm-top.yaml" "/etc/"
 assert_not_contains "$repo/nfpm-top.yaml" "/var/"
 assert_not_contains "$repo/nfpm-top.yaml" "scripts:"
 assert_not_contains "$repo/nfpm-top.yaml" "depends:"
+assert_contains "$repo/nfpm-arch.yaml" "name: bandwidth-monitor"
+assert_contains "$repo/nfpm-arch.yaml" "dst: /etc/bandwidth-monitor/env"
+assert_contains "$repo/nfpm-arch.yaml" "type: config|noreplace"
+assert_contains "$repo/nfpm-arch.yaml" "dst: /usr/lib/systemd/system/bandwidth-monitor.service"
+assert_not_contains "$repo/nfpm-arch.yaml" "scripts:"
+assert_contains "$repo/nfpm-top-arch.yaml" "name: bandwidth-top"
+assert_contains "$repo/nfpm-top-arch.yaml" "dst: /usr/bin/bandwidth-top"
+assert_not_contains "$repo/nfpm-top-arch.yaml" "/etc/"
+assert_not_contains "$repo/nfpm-top-arch.yaml" "scripts:"
+assert_contains "$repo/packaging/install-arch-repo.sh" "pacman -Sy"
+assert_not_contains "$repo/packaging/install-arch-repo.sh" "pacman -S "
+assert_contains "$repo/packaging/install-arch-repo.sh" "No packages were installed."
+assert_contains "$repo/packaging/create-pacman-repository.sh" "bandwidth-monitor bandwidth-top"
+assert_contains "$repo/.github/workflows/release.yml" "nfpm package -p archlinux -f nfpm-arch.yaml"
+assert_contains "$repo/.github/workflows/release.yml" "nfpm package -p archlinux -f nfpm-top-arch.yaml"
+assert_contains "$repo/.github/workflows/release.yml" "./packaging/create-pacman-repository.sh artifacts repo/arch"
+assert_contains "$repo/.github/workflows/publish-package-repositories.yml" "workflow_dispatch:"
+assert_contains "$repo/.github/workflows/publish-package-repositories.yml" "ref: gh-pages"
+assert_contains "$repo/.github/workflows/publish-package-repositories.yml" "ref: refs/tags/\${{ inputs.release_tag }}"
+assert_not_contains "$repo/.github/workflows/publish-package-repositories.yml" "gh release create"
 assert_contains "$repo/.github/workflows/release.yml" 'cp "$TOP_BINARY" "$TOP_PKG_DIR/usr/bin/bandwidth-top"'
 assert_contains "$repo/.github/workflows/release.yml" 'bandwidth-top_${VERSION}_${ARCH}.ipk'
 assert_contains "$repo/.github/workflows/release.yml" 'bandwidth-top-${VERSION}-r1_${ARCH}.apk'
@@ -257,7 +277,9 @@ retry_openwrt_number=${retry_openwrt##*_git}
 
 if command -v nfpm >/dev/null 2>&1; then
 	mkdir -p "$tmp/build/packaging"
-	cp "$repo/nfpm.yaml" "$repo/nfpm-top.yaml" "$repo/env.example" "$tmp/build/"
+	cp "$repo/nfpm.yaml" "$repo/nfpm-top.yaml" \
+		"$repo/nfpm-arch.yaml" "$repo/nfpm-top-arch.yaml" \
+		"$repo/env.example" "$tmp/build/"
 	cp "$repo/packaging/bandwidth-monitor.service" \
 		"$repo/packaging/bandwidth-monitor.openrc" \
 		"$repo/packaging/preinstall.sh" \
@@ -275,11 +297,25 @@ if command -v nfpm >/dev/null 2>&1; then
 		VERSION=$newer_nfpm GOARCH=amd64 nfpm package -p rpm -f nfpm.yaml -t "$tmp/package.rpm" >/dev/null
 		VERSION=$newer_nfpm GOARCH=amd64 nfpm package -p deb -f nfpm-top.yaml -t "$tmp/top-package.deb" >/dev/null
 		VERSION=$newer_nfpm GOARCH=amd64 nfpm package -p rpm -f nfpm-top.yaml -t "$tmp/top-package.rpm" >/dev/null
+		VERSION=$newer_nfpm GOARCH=amd64 nfpm package -p archlinux -f nfpm-arch.yaml -t "$tmp/package.pkg.tar.zst" >/dev/null
+		VERSION=$newer_nfpm GOARCH=amd64 nfpm package -p archlinux -f nfpm-top-arch.yaml -t "$tmp/top-package.pkg.tar.zst" >/dev/null
 	)
 	[ -s "$tmp/package.deb" ] || fail "nfpm did not build a Debian package"
 	[ -s "$tmp/package.rpm" ] || fail "nfpm did not build an RPM package"
 	[ -s "$tmp/top-package.deb" ] || fail "nfpm did not build a bandwidth-top Debian package"
 	[ -s "$tmp/top-package.rpm" ] || fail "nfpm did not build a bandwidth-top RPM package"
+	[ -s "$tmp/package.pkg.tar.zst" ] || fail "nfpm did not build an Arch Linux package"
+	[ -s "$tmp/top-package.pkg.tar.zst" ] || fail "nfpm did not build a bandwidth-top Arch Linux package"
+
+	tar -tf "$tmp/package.pkg.tar.zst" | sort > "$tmp/monitor-arch-files"
+	tar -tf "$tmp/top-package.pkg.tar.zst" | sort > "$tmp/top-arch-files"
+	assert_contains "$tmp/monitor-arch-files" "usr/bin/bandwidth-monitor"
+	assert_contains "$tmp/monitor-arch-files" "etc/bandwidth-monitor/env"
+	assert_contains "$tmp/monitor-arch-files" "usr/lib/systemd/system/bandwidth-monitor.service"
+	assert_contains "$tmp/top-arch-files" "usr/bin/bandwidth-top"
+	assert_not_contains "$tmp/top-arch-files" "usr/bin/bandwidth-monitor"
+	assert_not_contains "$tmp/top-arch-files" "etc/"
+	assert_not_contains "$tmp/top-arch-files" "usr/lib/systemd/"
 
 	if command -v dpkg-deb >/dev/null 2>&1; then
 		dpkg-deb --info "$tmp/package.deb" > "$tmp/deb-info"


### PR DESCRIPTION
## Summary
- build independent `bandwidth-monitor` and `bandwidth-top` Arch packages for x86_64 and aarch64
- publish signed pacman databases alongside the unchanged APT repository on GitHub Pages
- add an idempotent repo-only bootstrap command that refreshes databases but installs nothing
- add a manual workflow to backfill an existing immutable release without creating a new release

## Validation
- packaging assertions
- Linux test suite in Go 1.25.7 container
- signed pacman repository generation and signature verification
- `v0.0.34` cross-build for both architectures