### PR TITLE
Classify LAN interfaces using LOCAL_NETS, not just private addresses

### DIFF
--- a/talkers/lan_devices_test.go
+++ b/talkers/lan_devices_test.go
@@ -1,0 +1,50 @@
+package talkers
+
+import (
+	"net"
+	"testing"
+)
+
+func mustCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", cidr, err)
+	}
+	return n
+}
+
+func TestIsLANAddress(t *testing.T) {
+	publicLAN := []*net.IPNet{
+		mustCIDR(t, "195.114.13.0/24"),
+		mustCIDR(t, "2001:678:ac8::/48"),
+	}
+
+	tests := []struct {
+		name      string
+		ip        string
+		localNets []*net.IPNet
+		want      bool
+	}{
+		{"public v4 inside LOCAL_NETS", "195.114.13.5", publicLAN, true},
+		{"public v6 inside LOCAL_NETS", "2001:678:ac8:1::10", publicLAN, true},
+		{"public v4 outside LOCAL_NETS", "8.8.8.8", publicLAN, false},
+		{"private v4 outside LOCAL_NETS", "192.168.1.1", publicLAN, false},
+		{"private v4 without LOCAL_NETS", "192.168.1.1", nil, true},
+		{"ULA v6 without LOCAL_NETS", "fd00::1", nil, true},
+		{"public v4 without LOCAL_NETS", "195.114.13.5", nil, false},
+		{"CGNAT without LOCAL_NETS", "100.64.0.1", nil, false},
+		{"link-local v6 never LAN", "fe80::1", nil, false},
+		{"link-local v6 never LAN even in LOCAL_NETS", "fe80::1", []*net.IPNet{mustCIDR(t, "fe80::/10")}, false},
+		{"nil IP", "", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if got := isLANAddress(ip, tt.localNets); got != tt.want {
+				t.Errorf("isLANAddress(%q, localNets=%v) = %v, want %v", tt.ip, tt.localNets, got, tt.want)
+			}
+		})
+	}
+}

--- a/talkers/talkers.go
+++ b/talkers/talkers.go
@@ -201,6 +201,16 @@ func NewDirect(device string, promiscuous bool, localNets []*net.IPNet, geoDB *g
 	return newTracker([]string{device}, promiscuous, localNets, geoDB, dns, true)
 }
 
+// isLANAddress reports whether ip marks its interface as LAN-facing:
+// inside a configured local network, or private when none are configured.
+// Link-local addresses never count — every interface has one.
+func isLANAddress(ip net.IP, localNets []*net.IPNet) bool {
+	if ip == nil || ip.IsLinkLocalUnicast() {
+		return false
+	}
+	return netutil.IsLocal(ip, localNets)
+}
+
 func newTracker(devices []string, promiscuous bool, localNets []*net.IPNet, geoDB *geoip.DB, dns *resolver.Resolver, direct bool) *Tracker {
 	// Build a set of the router's own interface IPs so we can resolve
 	// direction when both endpoints fall within localNets (e.g. the
@@ -226,10 +236,12 @@ func newTracker(devices []string, promiscuous bool, localNets []*net.IPNet, geoD
 	}
 
 	// Identify LAN-facing interfaces: L2 (Ethernet) interfaces that have
-	// at least one private (RFC 1918 / ULA) address. Only LAN interfaces
-	// count per-host traffic to avoid double-counting packets that traverse
-	// multiple interfaces (e.g. WAN → kernel routing → LAN, or tunnel →
-	// kernel → LAN).
+	// at least one address inside localNets (LOCAL_NETS), or — when no
+	// local networks are configured — a private (RFC 1918 / ULA) address.
+	// Publicly-addressed LANs (PI space) are only recognised via
+	// LOCAL_NETS. Only LAN interfaces count per-host traffic to avoid
+	// double-counting packets that traverse multiple interfaces (e.g.
+	// WAN → kernel routing → LAN, or tunnel → kernel → LAN).
 	//
 	// L3 interfaces (WireGuard, PPP, tun) are excluded even if they have
 	// private tunnel IPs (e.g. 10.x.x.x) — they are tunnel/WAN endpoints,
@@ -254,7 +266,7 @@ func newTracker(devices []string, promiscuous bool, localNets []*net.IPNet, geoD
 				if !ok {
 					continue
 				}
-				if ipnet.IP.IsPrivate() && !ipnet.IP.IsLinkLocalUnicast() {
+				if isLANAddress(ipnet.IP, localNets) {
 					lanDevices[iface.Name] = true
 					break
 				}


### PR DESCRIPTION
_tl;dr weird things happen when you run public IPs on your LAN....._

## Problem

LAN interface detection in `talkers` only recognised interfaces holding an RFC 1918 / ULA address. On a publicly-addressed LAN (e.g. provider-independent space like `195.114.13.0/24` / `2001:678:ac8::/48`), no interface matched, so every capture device was skipped with `talkers: skipping capture on ... (not LAN)`. The talkers list stayed empty and the web UI misreported the condition as "No data — requires root / CAP_NET_RAW", even when running as root. `INTERFACES` couldn't work around it — it only filters collector display and never overrides LAN classification.

## Fix

An interface now counts as LAN-facing when any of its addresses falls inside a configured `LOCAL_NETS` prefix, using the existing `netutil.IsLocal` helper. With no `LOCAL_NETS` configured, the private-address heuristic applies exactly as before (link-local still never qualifies, since every interface has one). The check is extracted into `isLANAddress()` with unit tests covering both modes.

## Testing

- `go test ./talkers/` passes, including new `TestIsLANAddress` covering public-LAN prefixes, the no-LOCAL_NETS fallback, CGNAT, and link-local exclusion
- `GOOS=linux go build ./...` compiles
- Verified live on a publicly-addressed LAN: previously all capture devices were skipped; with this fix the LAN interface is detected and per-host traffic populates (yeled#13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)