### PR TITLE
Let LISTEN bind several addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,11 @@ examples.
 | `make install` or manual `/opt` install | `/opt/bandwidth-monitor/.env` |
 | NixOS module | `services.bandwidth-monitor` options or an environment file |
 
-The default `LISTEN=:8080` serves the dashboard on all interfaces. A typical
-minimal configuration limits capture to selected interfaces and optionally
-enables one DNS and one WiFi provider:
+The default `LISTEN=:8080` serves the dashboard on all interfaces; a
+comma-separated list binds only the addresses given, e.g.
+`LISTEN=192.0.2.9:8080,[2001:db8::9]:8080`. A typical minimal configuration
+limits capture to selected interfaces and optionally enables one DNS and one
+WiFi provider:
 
 ```bash
 LISTEN=:8080
@@ -253,7 +255,7 @@ Useful common settings:
 
 | Setting | Purpose |
 |---|---|
-| `LISTEN`, `LISTEN_PROTOCOL` | Bind address and HTTP/HTTPS mode |
+| `LISTEN`, `LISTEN_PROTOCOL` | Bind address(es) and HTTP/HTTPS mode |
 | `TLS_CERT_FILE`, `TLS_KEY_FILE` | PEM certificate and key for HTTPS |
 | `INTERFACES` | Interfaces shown and captured |
 | `WAN_INTERFACE` | Override WAN auto-detection |

--- a/apnsgateway/main.go
+++ b/apnsgateway/main.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"bandwidth-monitor/apns"
+	"bandwidth-monitor/httputil"
 )
 
 func env(key, fallback string) string {
@@ -24,7 +26,10 @@ func env(key, fallback string) string {
 }
 
 func main() {
-	listenAddr := env("LISTEN", ":8443")
+	listenAddrs, err := httputil.ParseListenAddrs(env("LISTEN", ":8443"))
+	if err != nil {
+		log.Fatalf("LISTEN: %v", err)
+	}
 	tlsCertFile := env("TLS_CERT_FILE", "")
 	tlsKeyFile := env("TLS_KEY_FILE", "")
 
@@ -69,19 +74,19 @@ func main() {
 	})
 
 	log.Printf("apnsgateway: starting on %s (HTTPS) tls-cert=%s tls-key=%s, apns-key-id=%s team=%s bundle=%s push-interval=%s max-response-bytes=%d",
-		listenAddr, tlsCertFile, tlsKeyFile, keyID, teamID, bundleID, interval, maxResponseBytes)
+		strings.Join(listenAddrs, ", "), tlsCertFile, tlsKeyFile, keyID, teamID, bundleID, interval, maxResponseBytes)
 
-	srv := &http.Server{
-		Addr:              listenAddr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       120 * time.Second,
-	}
+	srv := httputil.NewServers(listenAddrs, func(addr string) *http.Server {
+		return &http.Server{
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+	})
 
 	go awaitShutdown(srv)
 
-	serveErr := srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
-	if serveErr != nil && serveErr != http.ErrServerClosed {
+	if serveErr := srv.ListenAndServe(tlsCertFile, tlsKeyFile); serveErr != nil {
 		log.Fatalf("apnsgateway: server failed: %v", serveErr)
 	}
 	relay.Stop()
@@ -89,7 +94,7 @@ func main() {
 
 // awaitShutdown blocks until SIGINT/SIGTERM, then gracefully shuts srv down (drains active
 // connections, up to 5s).
-func awaitShutdown(srv *http.Server) {
+func awaitShutdown(srv *httputil.Servers) {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	<-sigCh

--- a/docs/apns-gateway.md
+++ b/docs/apns-gateway.md
@@ -31,7 +31,7 @@ All configuration is via environment variables. Every variable except the TLS pa
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `LISTEN` | `:8443` | Listen address. The gateway always serves HTTPS (iOS App Transport Security rejects plain HTTP). |
+| `LISTEN` | `:8443` | Listen address, or a comma-separated list of them (`192.0.2.9:8443,[2001:db8::9]:8443`; bracket IPv6 literals). The gateway always serves HTTPS (iOS App Transport Security rejects plain HTTP). |
 | `TLS_CERT_FILE` | *(required)* | Path to the TLS certificate (PEM). |
 | `TLS_KEY_FILE` | *(required)* | Path to the TLS private key (PEM). |
 | `APNS_KEY_FILE` | *(required)* | Path to the APNs auth key (`.p8`) from [developer.apple.com](https://developer.apple.com) (Keys → Apple Push Notification service). Keep it `chmod 0600`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,11 @@ INTERFACES=eth0,ppp0,wg0
 WAN_INTERFACE=ppp0
 ```
 
-- `LISTEN` controls the web bind address.
+- `LISTEN` controls the web bind address. It accepts a comma-separated list to
+  serve specific addresses rather than every interface; IPv6 literals must be
+  bracketed, as in `LISTEN=192.0.2.9:8080,[2001:db8::9]:8080`. Every address is
+  bound before the dashboard starts serving, so a wrong or busy address fails
+  at startup instead of leaving part of the list unserved.
 - `INTERFACES` limits both displayed interfaces and packet capture. Without it,
   all non-loopback interfaces are used.
 - `WAN_INTERFACE` overrides automatic WAN detection.

--- a/env.example
+++ b/env.example
@@ -6,6 +6,9 @@
 ## Core
 
 # Web server binding (host:port). Use :8080 to bind all interfaces.
+# Comma-separate to bind specific addresses instead of the wildcard; IPv6
+# literals must be bracketed:
+# LISTEN=192.0.2.9:8080,[2001:db8::9]:8080
 LISTEN=:8080
 
 # Choose web server protocol: http or https.

--- a/httputil/listen.go
+++ b/httputil/listen.go
@@ -1,0 +1,161 @@
+package httputil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// ParseListenAddrs splits a comma-separated LISTEN value ("host:port") into
+// individual bind addresses, so a daemon can serve on a specific v4 and v6
+// address instead of having to fall back to the "*" wildcard:
+//
+//	LISTEN=192.0.2.9:443,[2001:db8::9]:443
+//
+// IPv6 literals must be bracketed, exactly as elsewhere in Go's net package —
+// an unbracketed address is itself ambiguous with a host:port pair, so it is
+// rejected with a hint rather than guessed at. Duplicates are collapsed and
+// empty entries ignored; the returned slice always has at least one address.
+func ParseListenAddrs(raw string) ([]string, error) {
+	var addrs []string
+	seen := make(map[string]bool)
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, _, err := net.SplitHostPort(part); err != nil {
+			return nil, fmt.Errorf("invalid bind address %q: %w%s", part, err, bracketHint(part))
+		}
+		if seen[part] {
+			continue
+		}
+		seen[part] = true
+		addrs = append(addrs, part)
+	}
+	if len(addrs) == 0 {
+		return nil, errors.New("no bind address given")
+	}
+	return addrs, nil
+}
+
+// bracketHint returns " (did you mean [addr]:port?)" when addr looks like an
+// unbracketed IPv6 address with a port appended — by far the most likely way
+// to get an address wrong here.
+func bracketHint(addr string) string {
+	i := strings.LastIndex(addr, ":")
+	if i < 0 || strings.Contains(addr, "[") {
+		return ""
+	}
+	host, port := addr[:i], addr[i+1:]
+	if net.ParseIP(host) == nil {
+		return ""
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return ""
+	}
+	return fmt.Sprintf(" (did you mean [%s]:%s?)", host, port)
+}
+
+// Servers is a group of HTTP servers, one per bind address, sharing a handler
+// and started and stopped as a unit. Each address gets its own *http.Server
+// rather than one server serving several listeners: a server mutates its
+// TLSConfig when it configures HTTP/2, which is not safe to do while sibling
+// listeners are already handshaking against that same config.
+type Servers struct {
+	servers []*http.Server
+}
+
+// NewServers builds one server per address in addrs. build is called once per
+// address and must return a fresh *http.Server; its Addr field is set from
+// addr, so build can ignore it and only set Handler and timeouts.
+func NewServers(addrs []string, build func(addr string) *http.Server) *Servers {
+	s := &Servers{servers: make([]*http.Server, 0, len(addrs))}
+	for _, addr := range addrs {
+		srv := build(addr)
+		srv.Addr = addr
+		s.servers = append(s.servers, srv)
+	}
+	return s
+}
+
+// Addrs returns the bind addresses in configuration order.
+func (s *Servers) Addrs() []string {
+	addrs := make([]string, 0, len(s.servers))
+	for _, srv := range s.servers {
+		addrs = append(addrs, srv.Addr)
+	}
+	return addrs
+}
+
+// ListenAndServe binds every address and serves until all servers stop,
+// returning the first error that is not http.ErrServerClosed. When certFile
+// is non-empty the servers speak HTTPS using certFile and keyFile.
+//
+// Every address is bound before any of them starts serving, so a busy port or
+// an address that does not exist on this host fails at startup rather than
+// leaving the daemon half-listening.
+func (s *Servers) ListenAndServe(certFile, keyFile string) error {
+	listeners := make([]net.Listener, 0, len(s.servers))
+	for _, srv := range s.servers {
+		ln, err := net.Listen("tcp", srv.Addr)
+		if err != nil {
+			for _, opened := range listeners {
+				opened.Close()
+			}
+			return fmt.Errorf("listen on %s: %w", srv.Addr, err)
+		}
+		listeners = append(listeners, ln)
+	}
+
+	errCh := make(chan error, len(s.servers))
+	for i, srv := range s.servers {
+		go func(srv *http.Server, ln net.Listener) {
+			if certFile != "" {
+				errCh <- srv.ServeTLS(ln, certFile, keyFile)
+				return
+			}
+			errCh <- srv.Serve(ln)
+		}(srv, listeners[i])
+	}
+
+	var firstErr error
+	for range s.servers {
+		err := <-errCh
+		if err == nil || errors.Is(err, http.ErrServerClosed) || firstErr != nil {
+			continue
+		}
+		firstErr = err
+		// One bind died on its own; stop the rest so the caller reports a
+		// single clear failure instead of continuing to serve on a subset of
+		// the configured addresses.
+		s.Close()
+	}
+	return firstErr
+}
+
+// Shutdown gracefully shuts every server down, returning the first error.
+func (s *Servers) Shutdown(ctx context.Context) error {
+	var firstErr error
+	for _, srv := range s.servers {
+		if err := srv.Shutdown(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// Close immediately closes every server and its active connections.
+func (s *Servers) Close() error {
+	var firstErr error
+	for _, srv := range s.servers {
+		if err := srv.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/httputil/listen_test.go
+++ b/httputil/listen_test.go
@@ -1,0 +1,265 @@
+package httputil
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseListenAddrs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"wildcard port only", ":8080", []string{":8080"}},
+		{"single host port", "192.0.2.9:443", []string{"192.0.2.9:443"}},
+		{"v4 and v6 pair", "192.0.2.9:443,[2001:db8::9]:443", []string{"192.0.2.9:443", "[2001:db8::9]:443"}},
+		{"surrounding spaces", " 192.0.2.9:443 , [2001:db8::9]:443 ", []string{"192.0.2.9:443", "[2001:db8::9]:443"}},
+		{"empty entries ignored", ":8080,,", []string{":8080"}},
+		{"duplicates collapsed", ":8080,:8080", []string{":8080"}},
+		{"hostname", "localhost:8080", []string{"localhost:8080"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseListenAddrs(tt.raw)
+			if err != nil {
+				t.Fatalf("ParseListenAddrs(%q) returned error: %v", tt.raw, err)
+			}
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("ParseListenAddrs(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseListenAddrsErrors(t *testing.T) {
+	for _, raw := range []string{"", "   ", ",", ":8080,nonsense", "192.0.2.9"} {
+		if got, err := ParseListenAddrs(raw); err == nil {
+			t.Errorf("ParseListenAddrs(%q) = %v, want error", raw, got)
+		}
+	}
+}
+
+// An unbracketed IPv6 address with a port is the most likely mistake, so the
+// error must name the bracketed form the user actually needs.
+func TestParseListenAddrsUnbracketedIPv6Hint(t *testing.T) {
+	_, err := ParseListenAddrs("[2001:db8::9]:443,2001:db8:1::9:443")
+	if err == nil {
+		t.Fatal("expected an error for an unbracketed IPv6 address")
+	}
+	if !strings.Contains(err.Error(), "[2001:db8:1::9]:443") {
+		t.Errorf("error %q does not suggest the bracketed form", err)
+	}
+}
+
+// freePort returns a port that was free on host a moment ago.
+func freePort(t *testing.T, host string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on %s: %v", host, err)
+	}
+	defer ln.Close()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", ln.Addr(), err)
+	}
+	return port
+}
+
+func TestServersServeEveryAddress(t *testing.T) {
+	addrs := []string{
+		net.JoinHostPort("127.0.0.1", freePort(t, "127.0.0.1")),
+		net.JoinHostPort("::1", freePort(t, "::1")),
+	}
+
+	srv := NewServers(addrs, okServer)
+	if got := strings.Join(srv.Addrs(), "|"); got != strings.Join(addrs, "|") {
+		t.Errorf("Addrs() = %v, want %v", srv.Addrs(), addrs)
+	}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe("", "") }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx)
+		if err := <-errCh; err != nil {
+			t.Errorf("ListenAndServe returned %v, want nil after Shutdown", err)
+		}
+	})
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	for _, addr := range addrs {
+		if err := waitForServer(client, addr); err != nil {
+			t.Fatalf("GET http://%s: %v", addr, err)
+		}
+	}
+}
+
+func okServer(addr string) *http.Server {
+	return &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok")
+	})}
+}
+
+func waitForServer(client *http.Client, addr string) error {
+	return waitForServerScheme(client, "http", addr)
+}
+
+// waitForServerScheme polls addr until it answers with the expected body,
+// since ListenAndServe starts accepting a moment after it is called.
+func waitForServerScheme(client *http.Client, scheme, addr string) error {
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(scheme + "://" + addr + "/")
+		if err != nil {
+			lastErr = err
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if string(body) != "ok" {
+			return fmt.Errorf("body = %q, want %q", body, "ok")
+		}
+		return nil
+	}
+	return lastErr
+}
+
+// A bad address must fail at startup and leave nothing listening, rather than
+// serving on the addresses that did bind.
+func TestServersListenFailureReleasesGoodAddress(t *testing.T) {
+	good := net.JoinHostPort("127.0.0.1", freePort(t, "127.0.0.1"))
+	addrs := []string{good, "192.0.2.111:9"} // TEST-NET-1: not a local address
+
+	srv := NewServers(addrs, okServer)
+	err := srv.ListenAndServe("", "")
+	if err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx)
+		t.Fatal("ListenAndServe succeeded, want a bind error")
+	}
+	if !strings.Contains(err.Error(), "192.0.2.111:9") {
+		t.Errorf("error %q does not name the failing address", err)
+	}
+
+	ln, err := net.Listen("tcp", good)
+	if err != nil {
+		t.Fatalf("%s still bound after a failed startup: %v", good, err)
+	}
+	ln.Close()
+}
+
+func TestServersShutdownIsIdempotent(t *testing.T) {
+	srv := NewServers([]string{net.JoinHostPort("127.0.0.1", freePort(t, "127.0.0.1"))}, okServer)
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe("", "") }()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	if err := waitForServer(client, srv.Addrs()[0]); err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Errorf("first Shutdown: %v", err)
+	}
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Errorf("second Shutdown: %v", err)
+	}
+	if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+		t.Errorf("ListenAndServe returned %v", err)
+	}
+}
+
+// Each address gets its own http.Server so that concurrent TLS setup on the
+// listeners cannot race on a shared TLSConfig; run under -race to check that.
+func TestServersServeTLSOnEveryAddress(t *testing.T) {
+	certFile, keyFile := writeSelfSignedCert(t)
+	addrs := []string{
+		net.JoinHostPort("127.0.0.1", freePort(t, "127.0.0.1")),
+		net.JoinHostPort("::1", freePort(t, "::1")),
+	}
+
+	srv := NewServers(addrs, okServer)
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe(certFile, keyFile) }()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		srv.Shutdown(ctx)
+		if err := <-errCh; err != nil {
+			t.Errorf("ListenAndServe returned %v, want nil after Shutdown", err)
+		}
+	})
+
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	for _, addr := range addrs {
+		if err := waitForServerScheme(client, "https", addr); err != nil {
+			t.Fatalf("GET https://%s: %v", addr, err)
+		}
+	}
+}
+
+func writeSelfSignedCert(t *testing.T) (certFile, keyFile string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	writePEM(t, certFile, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+	writePEM(t, keyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certFile, keyFile
+}
+
+func writePEM(t *testing.T, path string, block *pem.Block) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, block); err != nil {
+		t.Fatalf("encode %s: %v", path, err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"bandwidth-monitor/dns"
 	"bandwidth-monitor/geoip"
 	"bandwidth-monitor/handler"
+	"bandwidth-monitor/httputil"
 	"bandwidth-monitor/latency"
 	"bandwidth-monitor/liveactivity"
 	"bandwidth-monitor/nextdns"
@@ -62,7 +63,10 @@ func collectorInterval() (time.Duration, error) {
 }
 
 func main() {
-	listenAddr := env("LISTEN", ":8080")
+	listenAddrs, err := httputil.ParseListenAddrs(env("LISTEN", ":8080"))
+	if err != nil {
+		log.Fatalf("LISTEN: %v", err)
+	}
 	listenProto := strings.ToLower(strings.TrimSpace(env("LISTEN_PROTOCOL", "http")))
 	tlsCertFile := env("TLS_CERT_FILE", "")
 	tlsKeyFile := env("TLS_KEY_FILE", "")
@@ -400,11 +404,13 @@ func main() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
-	log.Printf("server: bandwidth-monitor %s starting on %s (%s)", version.String(), listenAddr, strings.ToUpper(listenProto))
-	if strings.HasPrefix(listenAddr, ":") {
-		log.Printf("server: open %s://localhost%s in your browser", listenProto, listenAddr)
-	} else {
-		log.Printf("server: open %s://%s in your browser", listenProto, listenAddr)
+	log.Printf("server: bandwidth-monitor %s starting on %s (%s)", version.String(), strings.Join(listenAddrs, ", "), strings.ToUpper(listenProto))
+	for _, addr := range listenAddrs {
+		if strings.HasPrefix(addr, ":") {
+			log.Printf("server: open %s://localhost%s in your browser", listenProto, addr)
+		} else {
+			log.Printf("server: open %s://%s in your browser", listenProto, addr)
+		}
 	}
 	if listenProto == "https" {
 		log.Printf("server: TLS enabled cert=%s key=%s", tlsCertFile, tlsKeyFile)
@@ -416,30 +422,31 @@ func main() {
 	}
 	handler = withSignature(handler)
 
-	srv := &http.Server{
-		Addr:              listenAddr,
-		Handler:           handler,
-		ReadHeaderTimeout: 10 * time.Second,
-		IdleTimeout:       120 * time.Second,
-	}
+	// One server per LISTEN address, so a specific v4 and v6 address can be
+	// served without falling back to the wildcard bind.
+	srv := httputil.NewServers(listenAddrs, func(addr string) *http.Server {
+		return &http.Server{
+			Handler:           handler,
+			ReadHeaderTimeout: 10 * time.Second,
+			IdleTimeout:       120 * time.Second,
+		}
+	})
 
 	go func() {
 		<-sigCh
 		fmt.Println("\nShutting down...")
 
-		// Gracefully shut down the HTTP server (drains active connections).
+		// Gracefully shut down the HTTP servers (drains active connections).
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		srv.Shutdown(ctx)
 	}()
 
-	serveErr := error(nil)
+	certFile, keyFile := "", ""
 	if listenProto == "https" {
-		serveErr = srv.ListenAndServeTLS(tlsCertFile, tlsKeyFile)
-	} else {
-		serveErr = srv.ListenAndServe()
+		certFile, keyFile = tlsCertFile, tlsKeyFile
 	}
-	if serveErr != nil && serveErr != http.ErrServerClosed {
+	if serveErr := srv.ListenAndServe(certFile, keyFile); serveErr != nil {
 		log.Fatalf("Server failed: %v", serveErr)
 	}
 


### PR DESCRIPTION
## Problem

`LISTEN` accepted exactly one address — it was passed straight to `http.Server.Addr` — so serving a specific IPv4 **and** IPv6 address was impossible without falling back to the `*` wildcard bind.

Two things had to change:

1. **`LISTEN` now takes a comma-separated list.**
2. **IPv6 literals must be bracketed** (`[2001:db8::9]:443`). Unbracketed, such a string is itself a valid IPv6 address, so it is genuinely ambiguous with `host:port` and is rejected rather than guessed at — but the error names the fix:

   ```
   LISTEN: invalid bind address "2001:db8:1::9:443": address 2001:db8:1::9:443:
   too many colons in address (did you mean [2001:db8:1::9]:443?)
   ```

## Change

New `httputil/listen.go`:

- `ParseListenAddrs` splits and validates the list, collapsing duplicates and ignoring empty entries.
- `httputil.Servers` runs one `http.Server` per address, sharing the handler and starting/stopping as a unit. **Every address is bound before any of them starts serving**, so a busy port or an address that does not exist on the host fails at startup instead of leaving the daemon serving on part of the list. If one listener later dies on its own, the rest are closed so the failure surfaces once rather than silently degrading.

One server per address, rather than one server over several listeners, is deliberate: `http.Server` mutates its own `TLSConfig` when it configures HTTP/2, which is not safe to do while sibling listeners are already handshaking against that same config.

`apnsgateway` had the identical limitation and gets the same treatment.

Config example:

```bash
LISTEN=192.0.2.9:443,[2001:db8::9]:443
```

The single-address and default `:8080` forms are unchanged, so this is backwards compatible.

## Testing

- `go test -race ./httputil` — new tests cover parsing (7 subtests), the bracket hint, plaintext and TLS serving across `127.0.0.1` + `::1` simultaneously, that a failed bind releases the address that did bind, and idempotent shutdown.
- `GOOS=linux go build ./...` and `GOOS=linux go vet ./...` clean.
- Run live on a router with a dual-stack `LISTEN`, confirming two specific binds and no wildcard:

  ```
  LISTEN 0      4096                         195.114.13.9:443       0.0.0.0:*
  LISTEN 0      4096                  [2001:678:ac8:1::9]:443          [::]:*
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)